### PR TITLE
fix: Continuation crash

### DIFF
--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 				Utils/MacOSPermissionHandlerTests.swift,
 				XPC/JSON/AnyValidJobResponse.json,
 				XPC/JSON/ParsingError.json,
+				XPC/XPCContinuationTests.swift,
 				XPC/XPCQueryFetcherTest.swift,
 			);
 			target = 7A4DFBB02EA91F9D00B138B8 /* kDriveTests */;

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/NSXPCConnection+Extension.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/NSXPCConnection+Extension.swift
@@ -36,7 +36,8 @@ extension NSXPCConnection {
     }
 }
 
-actor XPCContinuation<Value: Sendable> {
+final class XPCContinuation<Value>: @unchecked Sendable {
+    private let lock = NSLock()
     private var continuation: CheckedContinuation<Value, Error>?
 
     init(_ continuation: CheckedContinuation<Value, Error>) {
@@ -44,12 +45,19 @@ actor XPCContinuation<Value: Sendable> {
     }
 
     func resume(returning value: Value) {
-        continuation?.resume(returning: value)
-        continuation = nil
+        takeContinuation()?.resume(returning: value)
     }
 
     func resume(throwing error: Error) {
-        continuation?.resume(throwing: error)
-        continuation = nil
+        takeContinuation()?.resume(throwing: error)
+    }
+
+    private func takeContinuation() -> CheckedContinuation<Value, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let continuation = continuation
+        self.continuation = nil
+        return continuation
     }
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/NSXPCConnection+Extension.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/NSXPCConnection+Extension.swift
@@ -22,12 +22,9 @@ enum NSXPCConnectionError: Error {
     case failedToCastProxy(_: String)
 }
 
-public extension NSXPCConnection {
-    func proxy<Interface>(
-        from connection: NSXPCConnection,
-        type: Interface.Type
-    ) throws -> Interface where Interface: AnyObject {
-        let proxy = connection.remoteObjectProxy
+extension NSXPCConnection {
+    func proxy<Interface: AnyObject>(type: Interface.Type) throws -> Interface {
+        let proxy = remoteObjectProxy
         guard let typedProxy = proxy as? Interface else {
             throw NSXPCConnectionError.failedToCastProxy(String(describing: Interface.self))
         }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/NSXPCConnection+Extension.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/NSXPCConnection+Extension.swift
@@ -23,12 +23,33 @@ enum NSXPCConnectionError: Error {
 }
 
 extension NSXPCConnection {
-    func proxy<Interface: AnyObject>(type: Interface.Type) throws -> Interface {
-        let proxy = remoteObjectProxy
+    func proxy<Interface: AnyObject>(
+        errorHandler: @escaping (Error) -> Void,
+        type: Interface.Type
+    ) throws -> Interface {
+        let proxy = remoteObjectProxyWithErrorHandler(errorHandler)
         guard let typedProxy = proxy as? Interface else {
             throw NSXPCConnectionError.failedToCastProxy(String(describing: Interface.self))
         }
 
         return typedProxy
+    }
+}
+
+actor XPCContinuation<Value: Sendable> {
+    private var continuation: CheckedContinuation<Value, Error>?
+
+    init(_ continuation: CheckedContinuation<Value, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(returning value: Value) {
+        continuation?.resume(returning: value)
+        continuation = nil
+    }
+
+    func resume(throwing error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
     }
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/XPCGuiProtocol+SwiftConcurrency.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/XPCGuiProtocol+SwiftConcurrency.swift
@@ -20,7 +20,7 @@ import Foundation
 
 extension XPCGuiProtocol {
     /// Async/Await wrapping of sendQuery(data:)
-    func sendQueryAsync(_ requestData: Data) async -> Data? {
+    func sendQueryAsync(_ requestData: Data) async -> Data {
         await withCheckedContinuation { continuation in
             self.processQuery(requestData) { data in
                 // IKLogger.xpc.log("[KD] recv raw callback string: \(String(data: data, encoding: .utf8))")

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/MockServer/XPCServerMock.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/MockServer/XPCServerMock.swift
@@ -54,8 +54,8 @@ public actor XPCServerMock: XPCGuiProtocol, @preconcurrency XPCConnectionProvide
         case unsupported
     }
 
-    public var guiConnection: XPCGuiProtocol {
-        self
+    public func sendQuery(_ requestData: Data) async throws -> Data {
+        await sendQueryAsync(requestData)
     }
 
     public func reconnectToLoginAgent() async {}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
@@ -234,22 +234,30 @@ import InfomaniakDI
     }
 
     func getServerEndpoint() async throws -> NSXPCListenerEndpoint {
-        guard let loginItemAgentConnection,
-              let loginItemProxy = loginItemAgentConnection.remoteObjectProxy as? XPCLoginItemProtocol else {
+        guard let loginItemAgentConnection else {
             throw XPCError.noLoginItemAgentConnection
         }
 
         IKLogger.xpc.log("[KD] Get server gui endpoint from login item agent")
 
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<NSXPCListenerEndpoint, Error>) in
-            loginItemProxy.serverGuiEndpoint { endpoint in
-                IKLogger.xpc.log("[KD] Server gui endpoint received: \(endpoint != nil)")
-                if let endpoint {
-                    continuation.resume(returning: endpoint)
-                } else {
-                    IKLogger.xpc.error("[KD] endpoint nil")
-                    continuation.resume(throwing: XPCError.serverGUIEndpointWasNil)
+        return try await withCheckedThrowingContinuation { continuation in
+            let continuation = XPCContinuation(continuation)
+            do {
+                let loginItemProxy = try loginItemAgentConnection.proxy(errorHandler: { error in
+                    IKLogger.xpc.error("[KD] Failed to get server gui endpoint: \(error)")
+                    Task { await continuation.resume(throwing: error) }
+                }, type: XPCLoginItemProtocol.self)
+                loginItemProxy.serverGuiEndpoint { endpoint in
+                    IKLogger.xpc.log("[KD] Server gui endpoint received: \(endpoint != nil)")
+                    if let endpoint {
+                        Task { await continuation.resume(returning: endpoint) }
+                    } else {
+                        IKLogger.xpc.error("[KD] endpoint nil")
+                        Task { await continuation.resume(throwing: XPCError.serverGUIEndpointWasNil) }
+                    }
                 }
+            } catch {
+                Task { await continuation.resume(throwing: error) }
             }
         }
     }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
@@ -245,19 +245,19 @@ import InfomaniakDI
             do {
                 let loginItemProxy = try loginItemAgentConnection.proxy(errorHandler: { error in
                     IKLogger.xpc.error("[KD] Failed to get server gui endpoint: \(error)")
-                    Task { await continuation.resume(throwing: error) }
+                    continuation.resume(throwing: error)
                 }, type: XPCLoginItemProtocol.self)
                 loginItemProxy.serverGuiEndpoint { endpoint in
                     IKLogger.xpc.log("[KD] Server gui endpoint received: \(endpoint != nil)")
                     if let endpoint {
-                        Task { await continuation.resume(returning: endpoint) }
+                        continuation.resume(returning: endpoint)
                     } else {
                         IKLogger.xpc.error("[KD] endpoint nil")
-                        Task { await continuation.resume(throwing: XPCError.serverGUIEndpointWasNil) }
+                        continuation.resume(throwing: XPCError.serverGUIEndpointWasNil)
                     }
                 }
             } catch {
-                Task { await continuation.resume(throwing: error) }
+                continuation.resume(throwing: error)
             }
         }
     }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionProvider.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionProvider.swift
@@ -62,9 +62,21 @@ extension XPCConnectionManager: XPCConnectionProvider {
         try await fetchServerEndpointFromLoginItemAgentAndConnectIfNeeded()
 
         let connection = try connection
-        let proxy = try connection.proxy(type: XPCGuiProtocol.self)
-
-        return await proxy.sendQueryAsync(requestData)
+        return try await withCheckedThrowingContinuation { continuation in
+            let continuation = XPCContinuation(continuation)
+            do {
+                let proxy = try connection.proxy(errorHandler: { error in
+                    IKLogger.xpc.error("[KD] Failed to send query to server: \(error)")
+                    Task { await continuation.resume(throwing: error) }
+                }, type: XPCGuiProtocol.self)
+                proxy.processQuery(requestData) { data in
+                    IKLogger.xpc.log("[KD] recv raw callback len: \(data.count)")
+                    Task { await continuation.resume(returning: data) }
+                }
+            } catch {
+                Task { await continuation.resume(throwing: error) }
+            }
+        }
     }
 
     public var guiConnectionStatePublisher: AnyPublisher<XPCConnectionState, Never> {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionProvider.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionProvider.swift
@@ -36,7 +36,7 @@ public enum XPCLoginItemAgentConnectionState: Sendable, Equatable {
 }
 
 public protocol XPCConnectionProvider: Sendable {
-    var guiConnection: XPCGuiProtocol { get async throws }
+    func sendQuery(_ requestData: Data) async throws -> Data
 
     var guiConnectionState: XPCConnectionState { get }
     var guiConnectionStatePublisher: AnyPublisher<XPCConnectionState, Never> { get }
@@ -58,15 +58,13 @@ extension XPCConnectionManager: XPCConnectionProvider {
         }
     }
 
-    public var guiConnection: XPCGuiProtocol {
-        get async throws {
-            try await fetchServerEndpointFromLoginItemAgentAndConnectIfNeeded()
+    public func sendQuery(_ requestData: Data) async throws -> Data {
+        try await fetchServerEndpointFromLoginItemAgentAndConnectIfNeeded()
 
-            let connection = try connection
-            let proxy = try connection.proxy(from: connection, type: XPCGuiProtocol.self)
+        let connection = try connection
+        let proxy = try connection.proxy(type: XPCGuiProtocol.self)
 
-            return proxy
-        }
+        return await proxy.sendQueryAsync(requestData)
     }
 
     public var guiConnectionStatePublisher: AnyPublisher<XPCConnectionState, Never> {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionProvider.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionProvider.swift
@@ -67,14 +67,14 @@ extension XPCConnectionManager: XPCConnectionProvider {
             do {
                 let proxy = try connection.proxy(errorHandler: { error in
                     IKLogger.xpc.error("[KD] Failed to send query to server: \(error)")
-                    Task { await continuation.resume(throwing: error) }
+                    continuation.resume(throwing: error)
                 }, type: XPCGuiProtocol.self)
                 proxy.processQuery(requestData) { data in
                     IKLogger.xpc.log("[KD] recv raw callback len: \(data.count)")
-                    Task { await continuation.resume(returning: data) }
+                    continuation.resume(returning: data)
                 }
             } catch {
-                Task { await continuation.resume(throwing: error) }
+                continuation.resume(throwing: error)
             }
         }
     }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift
@@ -52,7 +52,13 @@ struct XPCQueryFetcher: XPCQueryFetcherProtocol {
 
         let startTime = DispatchTime.now()
 
-        let replyData = try await xpcConnectionProvider.sendQuery(requestData)
+        let replyData: Data
+        do {
+            replyData = try await xpcConnectionProvider.sendQuery(requestData)
+        } catch {
+            logNoReply(error, context: logContext, since: startTime)
+            throw error
+        }
 
         let headerMessage = try decoder.decode(CallbackMessage<EmptyResponse>.self, from: replyData)
         logCallbackReceived(headerMessage, context: logContext, since: startTime)
@@ -84,6 +90,11 @@ private extension XPCQueryFetcher {
 
     func logRequestSent(_ context: RequestLogContext) {
         IKLogger.xpc.info("[KD] [Job →] #\(context.id) \(context.num)")
+    }
+
+    func logNoReply(_ error: Error, context: RequestLogContext, since start: DispatchTime) {
+        let elapsed = String(format: "%.1f", Self.elapsedMilliseconds(since: start))
+        IKLogger.xpc.error("[KD] [Job ←] #\(context.id) \(context.num) no reply data: \(error) (\(elapsed)ms)")
     }
 
     func logCallbackReceived(_ header: CallbackMessage<EmptyResponse>, context: RequestLogContext, since start: DispatchTime) {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift
@@ -40,7 +40,6 @@ struct XPCQueryFetcher: XPCQueryFetcherProtocol {
     }
 
     enum QueryError: Error {
-        case noReplyData
         case unableToDecodeReply(parsingError: Error)
     }
 
@@ -53,11 +52,7 @@ struct XPCQueryFetcher: XPCQueryFetcherProtocol {
 
         let startTime = DispatchTime.now()
 
-        let guiConnection = try await xpcConnectionProvider.guiConnection
-        guard let replyData = await guiConnection.sendQueryAsync(requestData) else {
-            logNoReply(logContext)
-            throw QueryError.noReplyData
-        }
+        let replyData = try await xpcConnectionProvider.sendQuery(requestData)
 
         let headerMessage = try decoder.decode(CallbackMessage<EmptyResponse>.self, from: replyData)
         logCallbackReceived(headerMessage, context: logContext, since: startTime)
@@ -89,10 +84,6 @@ private extension XPCQueryFetcher {
 
     func logRequestSent(_ context: RequestLogContext) {
         IKLogger.xpc.info("[KD] [Job →] #\(context.id) \(context.num)")
-    }
-
-    func logNoReply(_ context: RequestLogContext) {
-        IKLogger.xpc.error("[KD] [Job ←] #\(context.id) \(context.num) no reply data")
     }
 
     func logCallbackReceived(_ header: CallbackMessage<EmptyResponse>, context: RequestLogContext, since start: DispatchTime) {

--- a/src/gui4/macOS/kDriveTests/XPC/XPCContinuationTests.swift
+++ b/src/gui4/macOS/kDriveTests/XPC/XPCContinuationTests.swift
@@ -1,0 +1,54 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import kDriveCore
+import Testing
+
+struct XPCContinuationTests {
+    enum TestError: Error {
+        case proxyFailure
+    }
+
+    @Test func ignoresProxyErrorAfterReply() async throws {
+        let result: String = try await withCheckedThrowingContinuation { continuation in
+            let continuation = XPCContinuation(continuation)
+            Task {
+                await continuation.resume(returning: "reply")
+                await continuation.resume(throwing: TestError.proxyFailure)
+            }
+        }
+
+        #expect(result == "reply")
+    }
+
+    @Test func ignoresReplyAfterProxyError() async throws {
+        do {
+            let _: String = try await withCheckedThrowingContinuation { continuation in
+                let continuation = XPCContinuation<String>(continuation)
+                Task {
+                    await continuation.resume(throwing: TestError.proxyFailure)
+                    await continuation.resume(returning: "late reply")
+                }
+            }
+            Issue.record("Expected the proxy error to be thrown")
+        } catch {
+            #expect(error is TestError)
+        }
+    }
+}

--- a/src/gui4/macOS/kDriveTests/XPC/XPCContinuationTests.swift
+++ b/src/gui4/macOS/kDriveTests/XPC/XPCContinuationTests.swift
@@ -26,29 +26,55 @@ struct XPCContinuationTests {
     }
 
     @Test func ignoresProxyErrorAfterReply() async throws {
+        let replyCompleted = DispatchSemaphore(value: 0)
+        let errorCompleted = DispatchSemaphore(value: 0)
         let result: String = try await withCheckedThrowingContinuation { continuation in
             let continuation = XPCContinuation(continuation)
-            Task {
-                await continuation.resume(returning: "reply")
-                await continuation.resume(throwing: TestError.proxyFailure)
+            DispatchQueue.global().async {
+                continuation.resume(returning: "reply")
+                replyCompleted.signal()
+            }
+            DispatchQueue.global().async {
+                replyCompleted.wait()
+                continuation.resume(throwing: TestError.proxyFailure)
+                errorCompleted.signal()
             }
         }
 
         #expect(result == "reply")
+        let lateErrorCompleted = await didSignal(errorCompleted)
+        #expect(lateErrorCompleted)
     }
 
     @Test func ignoresReplyAfterProxyError() async throws {
+        let errorCompleted = DispatchSemaphore(value: 0)
+        let replyCompleted = DispatchSemaphore(value: 0)
         do {
             let _: String = try await withCheckedThrowingContinuation { continuation in
                 let continuation = XPCContinuation<String>(continuation)
-                Task {
-                    await continuation.resume(throwing: TestError.proxyFailure)
-                    await continuation.resume(returning: "late reply")
+                DispatchQueue.global().async {
+                    continuation.resume(throwing: TestError.proxyFailure)
+                    errorCompleted.signal()
+                }
+                DispatchQueue.global().async {
+                    errorCompleted.wait()
+                    continuation.resume(returning: "late reply")
+                    replyCompleted.signal()
                 }
             }
             Issue.record("Expected the proxy error to be thrown")
         } catch {
             #expect(error is TestError)
+            let lateReplyCompleted = await didSignal(replyCompleted)
+            #expect(lateReplyCompleted)
+        }
+    }
+
+    private func didSignal(_ semaphore: DispatchSemaphore) async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: semaphore.wait(timeout: .now() + 1) == .success)
+            }
         }
     }
 }

--- a/src/gui4/macOS/kDriveTests/XPC/XPCQueryFetcherTest.swift
+++ b/src/gui4/macOS/kDriveTests/XPC/XPCQueryFetcherTest.swift
@@ -20,45 +20,17 @@ import Combine
 @testable import kDriveCore
 import Testing
 
-// TODO: Test OK + ErrorCode + Corrupted
-
-class MCKXPCGuiProtocol: XPCGuiProtocol {
-    private let decoder = JSONDecoder()
-
-    let payloadFileName: String
-
-    init(payloadFileName: String) {
-        self.payloadFileName = payloadFileName
-    }
-
-    var responseData: Data {
+struct MCKXPCConnectionProvider: XPCConnectionProvider, @unchecked Sendable {
+    func sendQuery(_ requestData: Data) async throws -> Data {
         let bundle = Bundle(for: TestBundleMarker.self)
 
         guard let url = bundle.url(forResource: payloadFileName, withExtension: "json") else {
             fatalError("Unable to find specified JSON file")
         }
 
-        return try! Data(contentsOf: url)
+        return try Data(contentsOf: url)
     }
 
-    func processQuery(_ query: Data, callback: @escaping (Data) -> Void) {
-        callback(responseData)
-    }
-}
-
-class MCKXPCGuiProtocolWithData: XPCGuiProtocol {
-    init(responseData: Data) {
-        self.responseData = responseData
-    }
-
-    let responseData: Data
-
-    func processQuery(_ query: Data, callback: @escaping (Data) -> Void) {
-        callback(responseData)
-    }
-}
-
-struct MCKXPCConnectionProvider: XPCConnectionProvider {
     var guiConnectionState: kDriveCore.XPCConnectionState = .notConnected
 
     var guiConnectionStatePublisher: AnyPublisher<kDriveCore.XPCConnectionState, Never> = Just(.connected).eraseToAnyPublisher()
@@ -70,16 +42,60 @@ struct MCKXPCConnectionProvider: XPCConnectionProvider {
 
     let payloadFileName: String
 
-    var guiConnection: XPCGuiProtocol {
-        get async throws {
-            MCKXPCGuiProtocol(payloadFileName: payloadFileName)
-        }
+    func reconnectToLoginAgent() async {}
+}
+
+actor RequestRecorder {
+    private(set) var requestData: Data?
+
+    func record(_ requestData: Data) {
+        self.requestData = requestData
+    }
+}
+
+struct RecordingXPCConnectionProvider: XPCConnectionProvider, @unchecked Sendable {
+    var guiConnectionState: kDriveCore.XPCConnectionState = .notConnected
+
+    var guiConnectionStatePublisher: AnyPublisher<kDriveCore.XPCConnectionState, Never> = Just(.connected).eraseToAnyPublisher()
+
+    var loginItemAgentConnectionState: kDriveCore.XPCLoginItemAgentConnectionState = .connected
+
+    var loginItemAgentConnectionStatePublisher: AnyPublisher<kDriveCore.XPCLoginItemAgentConnectionState, Never> =
+        Just(.connected).eraseToAnyPublisher()
+
+    let recorder: RequestRecorder
+    let responseData: Data
+
+    func sendQuery(_ requestData: Data) async throws -> Data {
+        await recorder.record(requestData)
+        return responseData
     }
 
     func reconnectToLoginAgent() async {}
 }
 
-struct MCKXPCConnectionProviderWithData: XPCConnectionProvider {
+struct FailingXPCConnectionProvider: XPCConnectionProvider, @unchecked Sendable {
+    enum TransportError: Error {
+        case connectionLost
+    }
+
+    var guiConnectionState: kDriveCore.XPCConnectionState = .notConnected
+
+    var guiConnectionStatePublisher: AnyPublisher<kDriveCore.XPCConnectionState, Never> = Just(.connected).eraseToAnyPublisher()
+
+    var loginItemAgentConnectionState: kDriveCore.XPCLoginItemAgentConnectionState = .connected
+
+    var loginItemAgentConnectionStatePublisher: AnyPublisher<kDriveCore.XPCLoginItemAgentConnectionState, Never> =
+        Just(.connected).eraseToAnyPublisher()
+
+    func sendQuery(_ requestData: Data) async throws -> Data {
+        throw TransportError.connectionLost
+    }
+
+    func reconnectToLoginAgent() async {}
+}
+
+struct MCKXPCConnectionProviderWithData: XPCConnectionProvider, @unchecked Sendable {
     var guiConnectionState: kDriveCore.XPCConnectionState = .notConnected
 
     var guiConnectionStatePublisher: AnyPublisher<kDriveCore.XPCConnectionState, Never> = Just(.connected).eraseToAnyPublisher()
@@ -91,10 +107,8 @@ struct MCKXPCConnectionProviderWithData: XPCConnectionProvider {
 
     let responseData: Data
 
-    var guiConnection: XPCGuiProtocol {
-        get async throws {
-            MCKXPCGuiProtocolWithData(responseData: responseData)
-        }
+    func sendQuery(_ requestData: Data) async throws -> Data {
+        responseData
     }
 
     func reconnectToLoginAgent() async {}
@@ -103,6 +117,10 @@ struct MCKXPCConnectionProviderWithData: XPCConnectionProvider {
 typealias SendableCodable = Codable & Sendable
 
 struct XPCQueryFetcherTests {
+    struct TestQuery: Codable {
+        let value: String
+    }
+
     static let allResponseTypes: [any SendableCodable.Type] = [
         // UtilityJobs responses
         CallbackMessage<UtilityGetAppStateResponse>.self,
@@ -148,6 +166,31 @@ struct XPCQueryFetcherTests {
         #expect(decodedMessage.cause == KDC.ExitCause.Unknown)
     }
 
+    @Test func forwardsEncodedRequestToTransport() async throws {
+        let response = CallbackMessage<EmptyResponse>(code: .Ok, cause: .Unknown, id: 1, body: EmptyResponse())
+        let recorder = RequestRecorder()
+        let provider = try RecordingXPCConnectionProvider(recorder: recorder, responseData: JSONEncoder().encode(response))
+        let queryFetcher = XPCQueryFetcher(xpcConnectionProvider: provider)
+
+        try await queryFetcher.query(TestQuery(value: "request payload"), responseType: CallbackMessage<EmptyResponse>.self)
+
+        let recordedRequestData = await recorder.requestData
+        let requestData = try #require(recordedRequestData)
+        let request = try JSONDecoder().decode(TestQuery.self, from: requestData)
+        #expect(request.value == "request payload")
+    }
+
+    @Test func propagatesTransportError() async throws {
+        let queryFetcher = XPCQueryFetcher(xpcConnectionProvider: FailingXPCConnectionProvider())
+
+        do {
+            try await queryFetcher.query(EmptyQuery(), responseType: CallbackMessage<EmptyResponse>.self)
+            Issue.record("Expected the transport error to be thrown")
+        } catch {
+            #expect(error is FailingXPCConnectionProvider.TransportError)
+        }
+    }
+
     @Test(arguments: allResponseTypes)
     func decodingSomeErrorResponse(queryType: any SendableCodable.Type) async throws {
         // GIVEN
@@ -170,9 +213,7 @@ struct XPCQueryFetcherTests {
 
             // THEN
             Issue.record("We should throw")
-        }
-
-        catch {
+        } catch {
             guard let error = error as? CallbackError else {
                 Issue.record("unexpected error \(error)")
                 return
@@ -193,9 +234,7 @@ struct XPCQueryFetcherTests {
 
             // THEN
             Issue.record("We should throw")
-        }
-
-        catch {
+        } catch {
             guard let error = error as? XPCQueryFetcher.QueryError else {
                 Issue.record("unexpected error \(error)")
                 return


### PR DESCRIPTION
- Encapsulate XPC queries behind XPCConnectionProvider.sendQuery(_:)
- Prevent callers from accessing raw XPC proxies
- Use remoteObjectProxyWithErrorHandler for server queries and login-agent endpoint requests
- Propagate XPC transport failures through async throws
- Use a lock-protected one-shot continuation gate so the first callback wins synchronously
- Preserve callback arrival order and prevent double-resume crashes
- Restore request-correlated XPC failure logs with request ID, type, error, and elapsed time