### PR TITLE
fix(conflicting-files-corrector): Check error paths validity before resolving conflicts

### DIFF
--- a/src/libsyncengine/syncpal/conflictingfilescorrector.cpp
+++ b/src/libsyncengine/syncpal/conflictingfilescorrector.cpp
@@ -94,6 +94,14 @@ ExitInfo ConflictingFilesCorrector::resolveConflicts(const std::vector<Error> &e
 }
 
 bool ConflictingFilesCorrector::keepLocalVersion(const Error &error) {
+    // A corruption of `ParmsDb` can lead to unwanted deletion of files if the error paths are empty, so we check them here.
+    if (error.path().filename().empty() || error.destinationPath().filename().empty()) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Invalid error paths in ConflictingFilesCorrector::keepLocalVersion: "
+                                                        << Utility::formatSyncPath(error.path()) << L" / destination "
+                                                        << Utility::formatSyncPath(error.destinationPath()));
+        return false;
+    }
+
     // Delete remote version locally
     SyncPath originalAbsolutePath = _syncPal->localPath() / error.destinationPath().parent_path() / error.path().filename();
     SyncLocalDeleteJob deleteJob(_syncPal, originalAbsolutePath);
@@ -117,6 +125,15 @@ bool ConflictingFilesCorrector::keepLocalVersion(const Error &error) {
 }
 
 bool ConflictingFilesCorrector::keepRemoteVersion(const Error &error) {
+    // A corruption of `ParmsDb` can lead to unwanted deletion of files if the error destination path is empty, so we check it
+    // here.
+    if (error.destinationPath().filename().empty()) {
+        LOGW_WARN(Log::instance()->getLogger(),
+                  L"ConflictingFilesCorrector::keepRemoteVersion got an invalid error path: destination "
+                          << Utility::formatSyncPath(error.destinationPath()));
+        return false;
+    }
+
     // Delete local version
     SyncLocalDeleteJob deleteJob(_syncPal, _syncPal->localPath() / error.destinationPath());
     deleteJob.runSynchronously();


### PR DESCRIPTION
In a corrupted `ParmsDb`, the paths recorded in the `error` table can be empty and will cause unwanted files deletion if a conflict resolution is triggered by the user.

This PR makes sure that no local delete operation is performed when the `error` paths are empty. 