### PR TITLE
feat(activity): add ActivityListModel for Linux Activities list

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -35,6 +35,8 @@
   screen-specific drafts, such as proxy edition, belong to the owning UI/view model.
 - Keep per-sync runtime status and progress exclusively in `AppCache`. Consumers such as the system tray and future UI
   adapters must observe and query that shared state instead of maintaining private copies.
+- Design feature storage and presentation contracts for their intended final lifecycle. A temporarily unavailable UI or
+  action may remain inactive, but must not make the underlying model discard state needed by the completed feature.
 - In range-for loops over associative containers, prefer `std::views::keys` / `std::views::values` over structured
   bindings with an unused `_` element when only keys or only values are needed.
 - For Linux v4 model/UI checks, build only the `kdrive_qml` target unless a broader backend/server validation is
@@ -147,7 +149,7 @@
 - `app/cache/appcache.*`: graph-backed cache (`AppCache` QObject) - owns configured users/accounts/drives/syncs, the
   single volatile runtime snapshot for each sync, split sync/server errors, per-user available drives, cascade removals,
   and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.
-- `app/cache/activitystore.*`: process-local, per-sync file-activity history. It normalizes `SyncFileItemInfo` pushes,
+- `app/cache/activitystore.*`: process-local, per-sync file-activity history. It retains server status and direction,
   updates valid operation ids in place, removes failed entries superseded by a successful or in-progress activity for the
   same node, preserves distinct anonymous operations, and bounds retention to 500 entries per synchronization. It stays
   separate from the durable `AppCache` graph and is not exposed directly to QML.
@@ -169,6 +171,9 @@
   into classic and advanced synchronization rows and exposes only the presentation data required by the selector.
 - `app/mainwindow/mainsidebarcontroller.*`: QML-facing sidebar interaction controller. It exposes `SyncSelectorModel`,
   delegates sync selection to `MainSelectionStore`, and opens the selected local sync folder through desktop services.
+- `app/mainwindow/activitylistmodel.*`: selected-sync projection joining bounded recent activities with authoritative
+  active node errors. It maps server status and direction to the QML-facing presentation enums. Active errors remain
+  visible even when their recent activity has been evicted.
 - `app/mainwindow/homecontroller.*`: cache-backed QML adapter for the modular Home and toolbar sync controls. It
   resolves the selected sync into one central presentation state, exposes user/drive/error data, owns web-link
   construction, and delegates pause/resume to `SyncService`.

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -39,6 +39,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/parametersstore.h
         app/mainwindow/mainsidebarcontroller.cpp
         app/mainwindow/mainsidebarcontroller.h
+        app/mainwindow/activitylistmodel.cpp
+        app/mainwindow/activitylistmodel.h
         app/mainwindow/homecontroller.cpp
         app/mainwindow/homecontroller.h
         app/mainwindow/homestateresolver.cpp

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -35,8 +35,25 @@ bool isValidOperationId(const UniqueId operationId) {
 }
 
 /** @brief Returns whether an activity is currently being synchronized. */
-bool isInProgress(const ActivityStatus status) {
-    return status == ActivityStatus::InProgress;
+bool isInProgress(const SyncFileStatus status) {
+    return status == SyncFileStatus::Syncing;
+}
+
+/** @brief Returns whether an activity ended in a state that still requires user attention. */
+bool isFailed(const SyncFileStatus status) {
+    switch (status) {
+        case SyncFileStatus::Success:
+        case SyncFileStatus::Syncing:
+            return false;
+        case SyncFileStatus::Unknown:
+        case SyncFileStatus::Error:
+        case SyncFileStatus::Conflict:
+        case SyncFileStatus::Inconsistency:
+        case SyncFileStatus::Ignored:
+        case SyncFileStatus::EnumEnd:
+            return true;
+    }
+    return true;
 }
 
 /** @brief Returns whether two activities identify the same node through a non-empty local or remote identifier. */
@@ -47,14 +64,13 @@ bool hasMatchingNodeId(const ActivityEntry &entry, const SyncFileItemInfo &item)
 }
 
 /** @brief Removes failed activities superseded by a successful or in-progress activity for the same node. */
-void removeSupersededFailures(std::vector<ActivityEntry> &entries, const SyncFileItemInfo &item, const ActivityStatus status) {
-    if (status == ActivityStatus::Failed) {
+void removeSupersededFailures(std::vector<ActivityEntry> &entries, const SyncFileItemInfo &item) {
+    if (isFailed(item.status())) {
         return;
     }
 
-    (void) std::erase_if(entries, [&item](const ActivityEntry &entry) {
-        return entry.status == ActivityStatus::Failed && hasMatchingNodeId(entry, item);
-    });
+    (void) std::erase_if(
+            entries, [&item](const ActivityEntry &entry) { return isFailed(entry.status) && hasMatchingNodeId(entry, item); });
 }
 } // namespace
 
@@ -67,15 +83,13 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
         return;
     }
 
-    const auto normalizedStatus = normalizeStatus(item.status());
-    if (!normalizedStatus.has_value()) {
+    if (item.status() == SyncFileStatus::EnumEnd) {
         qCWarning(lcActivityStore) << "Activity ignored for unsupported status | syncDbId:" << syncDbId
                                    << "/ status:" << static_cast<int32_t>(item.status());
         return;
     }
 
-    const ActivitySource source = normalizeSource(item.direction());
-    if (source == ActivitySource::Unknown) {
+    if (item.direction() == SyncDirection::Unknown || item.direction() == SyncDirection::EnumEnd) {
         qCWarning(lcActivityStore) << "Activity received with unknown source | syncDbId:" << syncDbId
                                    << "/ direction:" << static_cast<int32_t>(item.direction());
     }
@@ -88,15 +102,15 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
                 return;
             }
 
-            *entryIt = makeEntry(syncDbId, item, *normalizedStatus, source, entryIt->localId);
-            removeSupersededFailures(entries, item, *normalizedStatus);
+            *entryIt = makeEntry(syncDbId, item, entryIt->localId);
+            removeSupersededFailures(entries, item);
             emit activitiesChanged(syncDbId);
             return;
         }
     }
 
-    removeSupersededFailures(entries, item, *normalizedStatus);
-    auto entry = makeEntry(syncDbId, item, *normalizedStatus, source, _nextLocalId++);
+    removeSupersededFailures(entries, item);
+    auto entry = makeEntry(syncDbId, item, _nextLocalId++);
     entries.push_back(std::move(entry));
     enforceCapacity(entries);
     emit activitiesChanged(syncDbId);
@@ -145,57 +159,13 @@ void ActivityStore::clear() {
 }
 
 /**
- * @brief Maps a server file status to the reduced presentation status used by Activities.
- * @param status File status received from the server.
- * @return The corresponding presentation status, or std::nullopt when the value requires unsupported-status handling.
- */
-std::optional<ActivityStatus> ActivityStore::normalizeStatus(const SyncFileStatus status) {
-    switch (status) {
-        case SyncFileStatus::Success:
-            return ActivityStatus::Synchronized;
-        case SyncFileStatus::Syncing:
-            return ActivityStatus::InProgress;
-        case SyncFileStatus::Error:
-        case SyncFileStatus::Conflict:
-        case SyncFileStatus::Inconsistency:
-        case SyncFileStatus::Unknown:
-        case SyncFileStatus::Ignored:
-            return ActivityStatus::Failed;
-        case SyncFileStatus::EnumEnd:
-            return std::nullopt;
-    }
-    return std::nullopt;
-}
-
-/**
- * @brief Maps a server synchronization direction to its presentation source.
- * @param direction Direction received from the server.
- * @return The corresponding presentation source, or ActivitySource::Unknown when no source can be inferred.
- */
-ActivitySource ActivityStore::normalizeSource(const SyncDirection direction) {
-    switch (direction) {
-        case SyncDirection::Up:
-            return ActivitySource::Computer;
-        case SyncDirection::Down:
-            return ActivitySource::Web;
-        case SyncDirection::Unknown:
-        case SyncDirection::EnumEnd:
-            return ActivitySource::Unknown;
-    }
-    return ActivitySource::Unknown;
-}
-
-/**
  * @brief Builds a process-local activity entry from a server DTO.
  * @param syncDbId Database identifier of the owning synchronization.
  * @param item Activity DTO received from the server.
- * @param status Normalized presentation status.
- * @param source Normalized presentation source.
  * @param localId Stable process-local identifier assigned to the entry.
  * @return A fully populated activity entry with a fresh receive timestamp and sequence number.
  */
-ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileItemInfo &item, const ActivityStatus status,
-                                       const ActivitySource source, const GenericId localId) {
+ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileItemInfo &item, const GenericId localId) {
     ActivityEntry entry;
     entry.localId = localId;
     entry.syncDbId = syncDbId;
@@ -207,9 +177,7 @@ ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileIt
     entry.remoteNodeId = item.remoteNodeId();
     entry.direction = item.direction();
     entry.instruction = item.instruction();
-    entry.rawStatus = item.status();
-    entry.status = status;
-    entry.source = source;
+    entry.status = item.status();
     entry.size = item.size();
     entry.progress = item.progress();
     entry.receivedAtUtc = QDateTime::currentDateTimeUtc();

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -171,8 +171,8 @@ ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileIt
     entry.syncDbId = syncDbId;
     entry.operationId = item.operationId();
     entry.nodeType = item.type();
-    entry.path = item.path();
-    entry.newPath = item.newPath();
+    entry.path = QStr2Path(item.path());
+    entry.newPath = QStr2Path(item.newPath());
     entry.localNodeId = item.localNodeId();
     entry.remoteNodeId = item.remoteNodeId();
     entry.direction = item.direction();

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -25,26 +25,11 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace KDC {
-
-/** @brief Presentation status used by the Linux Activities UI. */
-enum class ActivityStatus : uint8_t {
-    Synchronized,
-    InProgress,
-    Failed,
-};
-
-/** @brief Origin of a synchronization activity as presented to the user. */
-enum class ActivitySource : uint8_t {
-    Unknown,
-    Computer,
-    Web,
-};
 
 /** @brief Process-local representation of one file synchronization activity. */
 struct ActivityEntry {
@@ -58,9 +43,7 @@ struct ActivityEntry {
         QString remoteNodeId;
         SyncDirection direction{SyncDirection::Unknown};
         SyncFileInstruction instruction{SyncFileInstruction::None};
-        SyncFileStatus rawStatus{SyncFileStatus::Unknown};
-        ActivityStatus status{ActivityStatus::Synchronized};
-        ActivitySource source{ActivitySource::Unknown};
+        SyncFileStatus status{SyncFileStatus::Unknown};
         int64_t size{0};
         int32_t progress{0};
         QDateTime receivedAtUtc;
@@ -70,7 +53,7 @@ struct ActivityEntry {
 /**
  * @brief Process-local, bounded history of file synchronization activities for Linux.
  *
- * The store normalizes server DTOs and retains at most maxActivitiesPerSync entries for each synchronization. It is
+ * The store retains validated server DTO data and at most maxActivitiesPerSync entries for each synchronization. It is
  * intentionally separate from AppCache's durable entity graph and must only be mutated from its QObject thread.
  */
 class ActivityStore final : public QObject {
@@ -126,10 +109,7 @@ class ActivityStore final : public QObject {
         void activitiesChanged(SyncDbId syncDbId);
 
     private:
-        [[nodiscard]] static std::optional<ActivityStatus> normalizeStatus(SyncFileStatus status);
-        [[nodiscard]] static ActivitySource normalizeSource(SyncDirection direction);
-        [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, ActivityStatus status,
-                                              ActivitySource source, GenericId localId);
+        [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, GenericId localId);
         static void enforceCapacity(std::vector<ActivityEntry> &entries);
 
         std::unordered_map<SyncDbId, std::vector<ActivityEntry>> _activitiesBySyncDbId;

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -37,8 +37,8 @@ struct ActivityEntry {
         SyncDbId syncDbId{0};
         UniqueId operationId{0};
         NodeType nodeType{NodeType::Unknown};
-        QString path;
-        QString newPath;
+        SyncPath path;
+        SyncPath newPath;
         QString localNodeId;
         QString remoteNodeId;
         SyncDirection direction{SyncDirection::Unknown};

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -408,7 +408,7 @@ void ActivityListModel::resetProjection() {
 void ActivityListModel::reconcileProjection() {
     const auto nextRows = buildProjection();
     bool changed = removeMissingRows(nextRows);
-    changed = alignRows(nextRows) || changed;
+    changed = applyProjectionRows(nextRows) || changed;
     if (changed) {
         emit projectionChanged();
     }
@@ -431,7 +431,7 @@ bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
     return changed;
 }
 
-bool ActivityListModel::alignRows(const std::vector<Row> &nextRows) {
+bool ActivityListModel::applyProjectionRows(const std::vector<Row> &nextRows) {
     bool changed = false;
     for (qsizetype targetIndex = 0; targetIndex < static_cast<qsizetype>(nextRows.size()); ++targetIndex) {
         const auto &nextRow = nextRows[static_cast<std::size_t>(targetIndex)];

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -1,0 +1,555 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/mainwindow/activitylistmodel.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QCoreApplication>
+#include <QLoggingCategory>
+#include <QLocale>
+
+#include <algorithm>
+#include <chrono>
+#include <qtimezone.h>
+#include <ranges>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivityListModel, "gui.v4.activitylistmodel", QtInfoMsg)
+
+constexpr auto relativeTimeRefreshInterval = std::chrono::minutes{1};
+constexpr auto justNowThreshold = std::chrono::seconds{30};
+constexpr auto second = std::chrono::seconds{1};
+constexpr auto minute = std::chrono::minutes{1};
+constexpr auto hour = std::chrono::hours{1};
+constexpr auto day = std::chrono::days{1};
+constexpr auto relativeDateThreshold = std::chrono::days{4};
+
+QString activityRowId(const GenericId localId) {
+    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
+}
+
+QString errorRowId(const ErrorDbId errorDbId) {
+    return QStringLiteral("error:%1").arg(static_cast<qlonglong>(errorDbId));
+}
+
+SyncPath normalizedRelativePath(const SyncPath &path) {
+    return path.relative_path().lexically_normal();
+}
+
+SyncPath normalizedRelativePath(const QString &path) {
+    return normalizedRelativePath(QStr2Path(path));
+}
+
+QString itemName(const SyncPath &path) {
+    return Path2QStr(path.filename());
+}
+
+QString parentFolder(const SyncPath &path) {
+    const auto parent = path.parent_path();
+    return parent.empty() || parent == SyncPath{"."} ? QString{} : Path2QStr(parent);
+}
+
+QString formatSize(const NodeType nodeType, const int64_t size) {
+    if (nodeType == NodeType::Directory || size < 0) {
+        return {};
+    }
+    return QLocale().formattedDataSize(size);
+}
+
+QString formatAgo(const std::chrono::seconds elapsed, const std::chrono::seconds unit, const char *const unitTranslationId) {
+    const auto unitCount = elapsed / unit;
+    const QString duration = QStringLiteral("%1 %2").arg(unitCount).arg(qtTrId(unitTranslationId));
+    return qtTrId("labelAgo").arg(duration);
+}
+
+QString formatRelativeTime(const QDateTime &timestampUtc, const QDateTime &nowUtc = QDateTime::currentDateTimeUtc()) {
+    if (!timestampUtc.isValid()) {
+        return {};
+    }
+
+    const auto elapsed = std::chrono::seconds{std::max<qint64>(0, timestampUtc.secsTo(nowUtc))};
+    if (elapsed < justNowThreshold) {
+        return qtTrId("labelJustNow");
+    }
+
+    if (elapsed < minute) {
+        return formatAgo(elapsed, second, "labelShortSecond");
+    }
+    if (elapsed < hour) {
+        return formatAgo(elapsed, minute, "labelShortMinute");
+    }
+    if (elapsed < day) {
+        return formatAgo(elapsed, hour, "labelShortHour");
+    }
+    if (elapsed < relativeDateThreshold) {
+        return formatAgo(elapsed, day, "labelShortDay");
+    }
+    return QLocale().toString(timestampUtc.toLocalTime().date(), QLocale::ShortFormat);
+}
+
+ActivityListModel::Status toModelStatus(const SyncFileStatus status) {
+    switch (status) {
+        case SyncFileStatus::Success:
+            return ActivityListModel::Status::Synchronized;
+        case SyncFileStatus::Syncing:
+            return ActivityListModel::Status::InProgress;
+        case SyncFileStatus::Unknown:
+        case SyncFileStatus::Error:
+        case SyncFileStatus::Conflict:
+        case SyncFileStatus::Inconsistency:
+        case SyncFileStatus::Ignored:
+        case SyncFileStatus::EnumEnd:
+            return ActivityListModel::Status::Failed;
+    }
+    return ActivityListModel::Status::Failed;
+}
+
+ActivityListModel::Source toModelSource(const SyncDirection direction) {
+    switch (direction) {
+        case SyncDirection::Up:
+            return ActivityListModel::Source::Computer;
+        case SyncDirection::Down:
+            return ActivityListModel::Source::Web;
+        case SyncDirection::Unknown:
+        case SyncDirection::EnumEnd:
+            return ActivityListModel::Source::Unknown;
+    }
+    return ActivityListModel::Source::Unknown;
+}
+
+} // namespace
+
+ActivityListModel::ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
+                                     MainSelectionStore &selectionStore, QObject *const parent) :
+    QAbstractListModel(parent),
+    _activityStore(activityStore),
+    _appCache(appCache),
+    _selectionStore(selectionStore) {
+    (void) connect(&_activityStore, &ActivityStore::activitiesChanged, this, [this](const SyncDbId syncDbId) {
+        if (syncDbId == static_cast<SyncDbId>(_selectionStore.currentSyncDbId())) {
+            reconcileProjection();
+        }
+    });
+    (void) connect(&_appCache, &AppCache::syncErrorsChanged, this, &ActivityListModel::reconcileProjection);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncDbIdChanged, this, &ActivityListModel::resetProjection);
+
+    _relativeTimeTimer.setInterval(relativeTimeRefreshInterval);
+    (void) connect(&_relativeTimeTimer, &QTimer::timeout, this, &ActivityListModel::refreshRelativeTimes);
+    _relativeTimeTimer.start();
+    resetProjection();
+}
+
+int ActivityListModel::rowCount(const QModelIndex &parent) const {
+    return parent.isValid() ? 0 : static_cast<int>(_rows.size());
+}
+
+QVariant ActivityListModel::data(const QModelIndex &index, const int role) const {
+    if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) {
+        return {};
+    }
+
+    const auto &row = _rows[static_cast<std::size_t>(index.row())];
+    switch (role) {
+        case RowIdRole:
+            return row.rowId;
+        case NameRole:
+        case Qt::DisplayRole:
+            return row.name;
+        case FolderRole:
+            return row.folder;
+        case TimeTextRole:
+            return row.timeText;
+        case SizeTextRole:
+            return row.sizeText;
+        case NodeTypeRole:
+            return static_cast<int32_t>(row.nodeType);
+        case StatusRole:
+            return QVariant::fromValue(row.status);
+        case SourceRole:
+            return QVariant::fromValue(row.source);
+        case InstructionRole:
+            return static_cast<int32_t>(row.instruction);
+        case ProgressRole:
+            return row.progress;
+        case HasActiveErrorRole:
+            return !row.activeErrorDbIds.empty();
+        case ActiveErrorCountRole:
+            return static_cast<qint32>(row.activeErrorDbIds.size());
+        case HasOptionsRole:
+            return row.canOpenLocal || row.canOpenOnline || row.canCopyShareLink || row.canFixErrors;
+        case CanOpenLocalRole:
+            return row.canOpenLocal;
+        case CanOpenOnlineRole:
+            return row.canOpenOnline;
+        case CanCopyShareLinkRole:
+            return row.canCopyShareLink;
+        case CanFixErrorsRole:
+            return row.canFixErrors;
+        default:
+            return {};
+    }
+}
+
+QHash<int, QByteArray> ActivityListModel::roleNames() const {
+    return {
+            {RowIdRole, "rowId"},
+            {NameRole, "name"},
+            {FolderRole, "folder"},
+            {TimeTextRole, "timeText"},
+            {SizeTextRole, "sizeText"},
+            {NodeTypeRole, "nodeType"},
+            {StatusRole, "status"},
+            {SourceRole, "source"},
+            {InstructionRole, "instruction"},
+            {ProgressRole, "progress"},
+            {HasActiveErrorRole, "hasActiveError"},
+            {ActiveErrorCountRole, "activeErrorCount"},
+            {HasOptionsRole, "hasOptions"},
+            {CanOpenLocalRole, "canOpenLocal"},
+            {CanOpenOnlineRole, "canOpenOnline"},
+            {CanCopyShareLinkRole, "canCopyShareLink"},
+            {CanFixErrorsRole, "canFixErrors"},
+    };
+}
+
+void ActivityListModel::setFilter(const Filter filter) {
+    switch (filter) {
+        case Filter::MyActivityOnly:
+        case Filter::AllActivities:
+            break;
+        default:
+            qCWarning(lcActivityListModel) << "Invalid activity filter ignored | filter:" << static_cast<int32_t>(filter);
+            return;
+    }
+    if (_filter == filter) {
+        return;
+    }
+    _filter = filter;
+    emit filterChanged();
+    resetProjection();
+}
+
+std::optional<ActivityListModel::ActionTarget> ActivityListModel::actionTarget(const QString &rowId) const {
+    const auto rowIt = std::ranges::find(_rows, rowId, &Row::rowId);
+    if (rowIt == _rows.end()) {
+        return std::nullopt;
+    }
+    return ActionTarget{
+            .activityLocalId = rowIt->activityLocalId,
+            .syncDbId = rowIt->syncDbId,
+            .relativePath = rowIt->relativePath,
+            .nodeType = rowIt->nodeType,
+            .remoteNodeId = rowIt->remoteNodeId,
+            .activeErrorDbIds = rowIt->activeErrorDbIds,
+            .canOpenLocal = rowIt->canOpenLocal,
+            .canOpenOnline = rowIt->canOpenOnline,
+            .canCopyShareLink = rowIt->canCopyShareLink,
+            .canFixErrors = rowIt->canFixErrors,
+    };
+}
+
+std::vector<ActivityListModel::Row> ActivityListModel::buildProjection() const {
+    const auto syncDbId = static_cast<SyncDbId>(_selectionStore.currentSyncDbId());
+    if (syncDbId <= 0) {
+        return {};
+    }
+
+    auto rows = activityRows(syncDbId);
+    appendActiveErrors(syncDbId, _appCache.errorsForSync(syncDbId), rows);
+    finalizeProjection(rows);
+    return rows;
+}
+
+std::vector<ActivityListModel::Row> ActivityListModel::activityRows(const SyncDbId syncDbId) const {
+    std::vector<Row> rows;
+    const auto activities = _activityStore.activities(syncDbId);
+    rows.reserve(activities.size());
+    for (const auto &activity: activities) {
+        rows.push_back(makeActivityRow(syncDbId, activity));
+    }
+    return rows;
+}
+
+void ActivityListModel::appendActiveErrors(const SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows) {
+    for (const auto &error: errors) {
+        if (error.level() != ErrorLevel::Node) {
+            continue;
+        }
+        appendActiveError(syncDbId, error, rows);
+    }
+}
+
+void ActivityListModel::appendActiveError(const SyncDbId syncDbId, const Error &error, std::vector<Row> &rows) {
+    if (auto *const matchingRow = findMatchingActivity(rows, error); matchingRow != nullptr) {
+        matchingRow->activeErrorDbIds.push_back(error.dbId());
+        return;
+    }
+    rows.push_back(makeErrorRow(syncDbId, error));
+}
+
+ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbId, const ActivityEntry &activity) {
+    const QString currentPath =
+            activity.instruction == SyncFileInstruction::Move && !activity.newPath.isEmpty() ? activity.newPath : activity.path;
+    const SyncPath relativePath = normalizedRelativePath(currentPath);
+    const auto status = toModelStatus(activity.status);
+    const bool synchronizedWithOptions = status == Status::Synchronized && activity.instruction != SyncFileInstruction::Remove;
+
+    Row row;
+    row.rowId = activityRowId(activity.localId);
+    row.activityLocalId = activity.localId;
+    row.syncDbId = syncDbId;
+    row.name = itemName(relativePath);
+    row.folder = parentFolder(relativePath);
+    row.timeText = formatRelativeTime(activity.receivedAtUtc);
+    row.sizeText = formatSize(activity.nodeType, activity.size);
+    row.nodeType = activity.nodeType;
+    row.status = status;
+    row.source = toModelSource(activity.direction);
+    row.instruction = activity.instruction;
+    row.progress = activity.progress;
+    row.timestampUtc = activity.receivedAtUtc;
+    row.receivedSequence = activity.receivedSequence;
+    row.relativePath = relativePath;
+    row.sourcePath = normalizedRelativePath(activity.path);
+    row.destinationPath = normalizedRelativePath(activity.newPath);
+    row.localNodeId = activity.localNodeId.toStdString();
+    row.remoteNodeId = activity.remoteNodeId.toStdString();
+    row.canOpenLocal = synchronizedWithOptions && !relativePath.empty();
+    row.canOpenOnline = synchronizedWithOptions && !row.remoteNodeId.empty();
+    row.canCopyShareLink = row.canOpenOnline;
+    return row;
+}
+
+ActivityListModel::Row ActivityListModel::makeErrorRow(const SyncDbId syncDbId, const Error &error) {
+    const SyncPath relativePath =
+            normalizedRelativePath(error.destinationPath().empty() ? error.path() : error.destinationPath());
+    const QDateTime timestampUtc = error.time() > 0 ? QDateTime::fromSecsSinceEpoch(error.time(), QTimeZone::UTC) : QDateTime{};
+
+    Row row;
+    row.rowId = errorRowId(error.dbId());
+    row.syncDbId = syncDbId;
+    row.name = itemName(relativePath);
+    row.folder = parentFolder(relativePath);
+    row.timeText = formatRelativeTime(timestampUtc);
+    row.nodeType = error.nodeType();
+    row.status = Status::Failed;
+    row.timestampUtc = timestampUtc;
+    row.relativePath = relativePath;
+    row.localNodeId = error.localNodeId();
+    row.remoteNodeId = error.remoteNodeId();
+    row.activeErrorDbIds.push_back(error.dbId());
+    return row;
+}
+
+ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row> &rows, const Error &error) {
+    Row *matchingRow = nullptr;
+    int32_t bestScore = 0;
+    for (auto &row: rows) {
+        if (row.status != Status::Failed) {
+            continue;
+        }
+        if (const int32_t score = errorMatchScore(row, error);
+            score > bestScore ||
+            (score == bestScore && score > 0 && matchingRow != nullptr && row.receivedSequence > matchingRow->receivedSequence)) {
+            matchingRow = &row;
+            bestScore = score;
+        }
+    }
+    return matchingRow;
+}
+
+void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
+    for (auto &row: rows) {
+        std::ranges::sort(row.activeErrorDbIds);
+        const auto uniqueResult = std::ranges::unique(row.activeErrorDbIds);
+        const auto duplicateIt = uniqueResult.begin();
+        row.activeErrorDbIds.erase(duplicateIt, row.activeErrorDbIds.end());
+        row.canFixErrors = row.status == Status::Failed && !row.activeErrorDbIds.empty();
+    }
+
+    std::erase_if(rows, [this](const Row &row) {
+        return row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
+    });
+    std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
+        const bool lhsInProgress = lhs.status == Status::InProgress;
+        const bool rhsInProgress = rhs.status == Status::InProgress;
+        if (lhsInProgress != rhsInProgress) {
+            return lhsInProgress;
+        }
+        if (lhs.timestampUtc != rhs.timestampUtc) {
+            return lhs.timestampUtc > rhs.timestampUtc;
+        }
+        if (lhs.receivedSequence != rhs.receivedSequence) {
+            return lhs.receivedSequence > rhs.receivedSequence;
+        }
+        return lhs.rowId < rhs.rowId;
+    });
+}
+
+/**
+ * Returns the strongest non-empty node identity shared by an activity row and an active node error.
+ *
+ * The comparisons mirror the server's `selectErrorByNodeInfo` lookup: local node id, remote node id, source path, then
+ * destination path. A stronger match wins when several recent failed activities could represent the same error.
+ */
+int32_t ActivityListModel::errorMatchScore(const Row &row, const Error &error) {
+    if (!row.localNodeId.empty() && row.localNodeId == error.localNodeId()) {
+        return 3;
+    }
+    if (!row.remoteNodeId.empty() && row.remoteNodeId == error.remoteNodeId()) {
+        return 2;
+    }
+    if (!error.path().empty() && row.sourcePath == normalizedRelativePath(error.path())) {
+        return 1;
+    }
+    if (!error.destinationPath().empty() && row.destinationPath == normalizedRelativePath(error.destinationPath())) {
+        return 1;
+    }
+    return 0;
+}
+
+void ActivityListModel::resetProjection() {
+    auto nextRows = buildProjection();
+    if (_rows == nextRows) {
+        return;
+    }
+    beginResetModel();
+    _rows = std::move(nextRows);
+    endResetModel();
+    emit projectionChanged();
+}
+
+void ActivityListModel::reconcileProjection() {
+    const auto nextRows = buildProjection();
+    bool changed = removeMissingRows(nextRows);
+    changed = alignRows(nextRows) || changed;
+    if (changed) {
+        emit projectionChanged();
+    }
+}
+
+bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
+    bool changed = false;
+    for (qsizetype rowIndex = static_cast<qsizetype>(_rows.size()) - 1; rowIndex >= 0; --rowIndex) {
+        const auto rowExists = std::ranges::any_of(nextRows, [this, rowIndex](const Row &row) {
+            return row.rowId == _rows[static_cast<std::size_t>(rowIndex)].rowId;
+        });
+        if (rowExists) {
+            continue;
+        }
+        beginRemoveRows({}, rowIndex, rowIndex);
+        _rows.erase(_rows.begin() + rowIndex);
+        endRemoveRows();
+        changed = true;
+    }
+    return changed;
+}
+
+bool ActivityListModel::alignRows(const std::vector<Row> &nextRows) {
+    bool changed = false;
+    for (qsizetype targetIndex = 0; targetIndex < static_cast<qsizetype>(nextRows.size()); ++targetIndex) {
+        const auto &nextRow = nextRows[static_cast<std::size_t>(targetIndex)];
+        if (targetIndex >= static_cast<qsizetype>(_rows.size())) {
+            beginInsertRows({}, targetIndex, targetIndex);
+            _rows.push_back(nextRow);
+            endInsertRows();
+            changed = true;
+            continue;
+        }
+
+        if (_rows[static_cast<std::size_t>(targetIndex)].rowId != nextRow.rowId) {
+            const auto matchingIt = std::ranges::find(_rows.begin() + targetIndex + 1, _rows.end(), nextRow.rowId, &Row::rowId);
+            if (matchingIt == _rows.end()) {
+                beginInsertRows({}, targetIndex, targetIndex);
+                _rows.insert(_rows.begin() + targetIndex, nextRow);
+                endInsertRows();
+                changed = true;
+                continue;
+            }
+
+            const qsizetype sourceIndex = std::distance(_rows.begin(), matchingIt);
+            beginMoveRows({}, sourceIndex, sourceIndex, {}, targetIndex);
+            auto movedRow = std::move(*matchingIt);
+            _rows.erase(matchingIt);
+            _rows.insert(_rows.begin() + targetIndex, std::move(movedRow));
+            endMoveRows();
+            changed = true;
+        }
+        changed = updateRow(targetIndex, nextRow) || changed;
+    }
+    return changed;
+}
+
+bool ActivityListModel::updateRow(const qsizetype rowIndex, const Row &nextRow) {
+    auto &row = _rows[static_cast<std::size_t>(rowIndex)];
+    if (row == nextRow) {
+        return false;
+    }
+
+    QList<int> changedRoles;
+    const auto addRoleIf = [&changedRoles](const bool changed, const Role role) {
+        if (changed) {
+            changedRoles.push_back(role);
+        }
+    };
+    addRoleIf(row.name != nextRow.name, NameRole);
+    addRoleIf(row.folder != nextRow.folder, FolderRole);
+    addRoleIf(row.timeText != nextRow.timeText, TimeTextRole);
+    addRoleIf(row.sizeText != nextRow.sizeText, SizeTextRole);
+    addRoleIf(row.nodeType != nextRow.nodeType, NodeTypeRole);
+    addRoleIf(row.status != nextRow.status, StatusRole);
+    addRoleIf(row.source != nextRow.source, SourceRole);
+    addRoleIf(row.instruction != nextRow.instruction, InstructionRole);
+    addRoleIf(row.progress != nextRow.progress, ProgressRole);
+    addRoleIf(row.activeErrorDbIds.empty() != nextRow.activeErrorDbIds.empty(), HasActiveErrorRole);
+    addRoleIf(row.activeErrorDbIds.size() != nextRow.activeErrorDbIds.size(), ActiveErrorCountRole);
+    addRoleIf(row.canOpenLocal != nextRow.canOpenLocal || row.canOpenOnline != nextRow.canOpenOnline ||
+                      row.canCopyShareLink != nextRow.canCopyShareLink || row.canFixErrors != nextRow.canFixErrors,
+              HasOptionsRole);
+    addRoleIf(row.canOpenLocal != nextRow.canOpenLocal, CanOpenLocalRole);
+    addRoleIf(row.canOpenOnline != nextRow.canOpenOnline, CanOpenOnlineRole);
+    addRoleIf(row.canCopyShareLink != nextRow.canCopyShareLink, CanCopyShareLinkRole);
+    addRoleIf(row.canFixErrors != nextRow.canFixErrors, CanFixErrorsRole);
+
+    row = nextRow;
+    if (!changedRoles.empty()) {
+        emit dataChanged(index(rowIndex, 0), index(rowIndex, 0), changedRoles);
+    }
+    return true;
+}
+
+void ActivityListModel::refreshRelativeTimes() {
+    if (_rows.empty()) {
+        return;
+    }
+    const QDateTime nowUtc = QDateTime::currentDateTimeUtc();
+    for (qsizetype rowIndex = 0; rowIndex < static_cast<qsizetype>(_rows.size()); ++rowIndex) {
+        auto &row = _rows[static_cast<std::size_t>(rowIndex)];
+        const QString nextTimeText = formatRelativeTime(row.timestampUtc, nowUtc);
+        if (row.timeText == nextTimeText) {
+            continue;
+        }
+        row.timeText = nextTimeText;
+        emit dataChanged(index(rowIndex, 0), index(rowIndex, 0), {TimeTextRole});
+    }
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -50,10 +50,6 @@ SyncPath normalizedRelativePath(const SyncPath &path) {
     return path.relative_path().lexically_normal();
 }
 
-SyncPath normalizedRelativePath(const QString &path) {
-    return normalizedRelativePath(QStr2Path(path));
-}
-
 QString itemName(const SyncPath &path) {
     return Path2QStr(path.filename());
 }
@@ -286,8 +282,8 @@ void ActivityListModel::appendActiveError(const SyncDbId syncDbId, const Error &
 }
 
 ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbId, const ActivityEntry &activity) {
-    const QString currentPath =
-            activity.instruction == SyncFileInstruction::Move && !activity.newPath.isEmpty() ? activity.newPath : activity.path;
+    const SyncPath &currentPath =
+            activity.instruction == SyncFileInstruction::Move && !activity.newPath.empty() ? activity.newPath : activity.path;
     const SyncPath relativePath = normalizedRelativePath(currentPath);
     const auto status = toModelStatus(activity.status);
 

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -337,14 +337,14 @@ ActivityListModel::Row ActivityListModel::makeErrorRow(const SyncDbId syncDbId, 
 
 ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row> &rows, const Error &error) {
     Row *matchingRow = nullptr;
-    int32_t bestScore = 0;
+    MatchScore bestScore = noMatchScore;
     for (auto &row: rows) {
         if (row.status != Status::Failed) {
             continue;
         }
-        if (const int32_t score = errorMatchScore(row, error);
-            score > bestScore ||
-            (score == bestScore && score > 0 && matchingRow != nullptr && row.receivedSequence > matchingRow->receivedSequence)) {
+        if (const MatchScore score = errorMatchScore(row, error);
+            score > bestScore || (score == bestScore && score > noMatchScore && matchingRow != nullptr &&
+                                  row.receivedSequence > matchingRow->receivedSequence)) {
             matchingRow = &row;
             bestScore = score;
         }
@@ -378,20 +378,20 @@ void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
  * The comparisons mirror the server's `selectErrorByNodeInfo` lookup: local node id, remote node id, source path, then
  * destination path. A stronger match wins when several recent failed activities could represent the same error.
  */
-int32_t ActivityListModel::errorMatchScore(const Row &row, const Error &error) {
+ActivityListModel::MatchScore ActivityListModel::errorMatchScore(const Row &row, const Error &error) {
     if (!row.localNodeId.empty() && row.localNodeId == error.localNodeId()) {
-        return 3;
+        return localNodeIdMatchScore;
     }
     if (!row.remoteNodeId.empty() && row.remoteNodeId == error.remoteNodeId()) {
-        return 2;
+        return remoteNodeIdMatchScore;
     }
     if (!error.path().empty() && row.sourcePath == normalizedRelativePath(error.path())) {
-        return 1;
+        return pathMatchScore;
     }
     if (!error.destinationPath().empty() && row.destinationPath == normalizedRelativePath(error.destinationPath())) {
-        return 1;
+        return pathMatchScore;
     }
-    return 0;
+    return noMatchScore;
 }
 
 void ActivityListModel::resetProjection() {

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -193,16 +193,6 @@ QVariant ActivityListModel::data(const QModelIndex &index, const int role) const
             return !row.activeErrorDbIds.empty();
         case ActiveErrorCountRole:
             return static_cast<qint32>(row.activeErrorDbIds.size());
-        case HasOptionsRole:
-            return row.canOpenLocal || row.canOpenOnline || row.canCopyShareLink || row.canFixErrors;
-        case CanOpenLocalRole:
-            return row.canOpenLocal;
-        case CanOpenOnlineRole:
-            return row.canOpenOnline;
-        case CanCopyShareLinkRole:
-            return row.canCopyShareLink;
-        case CanFixErrorsRole:
-            return row.canFixErrors;
         default:
             return {};
     }
@@ -222,11 +212,6 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const {
             {ProgressRole, "progress"},
             {HasActiveErrorRole, "hasActiveError"},
             {ActiveErrorCountRole, "activeErrorCount"},
-            {HasOptionsRole, "hasOptions"},
-            {CanOpenLocalRole, "canOpenLocal"},
-            {CanOpenOnlineRole, "canOpenOnline"},
-            {CanCopyShareLinkRole, "canCopyShareLink"},
-            {CanFixErrorsRole, "canFixErrors"},
     };
 }
 
@@ -256,13 +241,8 @@ std::optional<ActivityListModel::ActionTarget> ActivityListModel::actionTarget(c
             .activityLocalId = rowIt->activityLocalId,
             .syncDbId = rowIt->syncDbId,
             .relativePath = rowIt->relativePath,
-            .nodeType = rowIt->nodeType,
             .remoteNodeId = rowIt->remoteNodeId,
             .activeErrorDbIds = rowIt->activeErrorDbIds,
-            .canOpenLocal = rowIt->canOpenLocal,
-            .canOpenOnline = rowIt->canOpenOnline,
-            .canCopyShareLink = rowIt->canCopyShareLink,
-            .canFixErrors = rowIt->canFixErrors,
     };
 }
 
@@ -310,7 +290,6 @@ ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbI
             activity.instruction == SyncFileInstruction::Move && !activity.newPath.isEmpty() ? activity.newPath : activity.path;
     const SyncPath relativePath = normalizedRelativePath(currentPath);
     const auto status = toModelStatus(activity.status);
-    const bool synchronizedWithOptions = status == Status::Synchronized && activity.instruction != SyncFileInstruction::Remove;
 
     Row row;
     row.rowId = activityRowId(activity.localId);
@@ -332,9 +311,6 @@ ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbI
     row.destinationPath = normalizedRelativePath(activity.newPath);
     row.localNodeId = activity.localNodeId.toStdString();
     row.remoteNodeId = activity.remoteNodeId.toStdString();
-    row.canOpenLocal = synchronizedWithOptions && !relativePath.empty();
-    row.canOpenOnline = synchronizedWithOptions && !row.remoteNodeId.empty();
-    row.canCopyShareLink = row.canOpenOnline;
     return row;
 }
 
@@ -377,10 +353,6 @@ ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row>
 }
 
 void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
-    for (auto &row: rows) {
-        row.canFixErrors = row.status == Status::Failed && !row.activeErrorDbIds.empty();
-    }
-
     (void) std::erase_if(rows, [this](const Row &row) {
         return row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
     });
@@ -524,13 +496,6 @@ bool ActivityListModel::updateRow(const qsizetype rowIndex, const Row &nextRow) 
     addRoleIf(row.progress != nextRow.progress, ProgressRole);
     addRoleIf(row.activeErrorDbIds.empty() != nextRow.activeErrorDbIds.empty(), HasActiveErrorRole);
     addRoleIf(row.activeErrorDbIds.size() != nextRow.activeErrorDbIds.size(), ActiveErrorCountRole);
-    addRoleIf(row.canOpenLocal != nextRow.canOpenLocal || row.canOpenOnline != nextRow.canOpenOnline ||
-                      row.canCopyShareLink != nextRow.canCopyShareLink || row.canFixErrors != nextRow.canFixErrors,
-              HasOptionsRole);
-    addRoleIf(row.canOpenLocal != nextRow.canOpenLocal, CanOpenLocalRole);
-    addRoleIf(row.canOpenOnline != nextRow.canOpenOnline, CanOpenOnlineRole);
-    addRoleIf(row.canCopyShareLink != nextRow.canCopyShareLink, CanCopyShareLinkRole);
-    addRoleIf(row.canFixErrors != nextRow.canFixErrors, CanFixErrorsRole);
 
     row = nextRow;
     if (!changedRoles.empty()) {

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -42,10 +42,6 @@ constexpr auto hour = std::chrono::hours{1};
 constexpr auto day = std::chrono::days{1};
 constexpr auto relativeDateThreshold = std::chrono::days{4};
 
-QString activityRowId(const GenericId localId) {
-    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
-}
-
 QString errorRowId(const ErrorDbId errorDbId) {
     return QStringLiteral("error:%1").arg(static_cast<qlonglong>(errorDbId));
 }
@@ -136,6 +132,10 @@ ActivityListModel::Source toModelSource(const SyncDirection direction) {
 }
 
 } // namespace
+
+QString ActivityListModel::activityRowId(const GenericId localId) {
+    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
+}
 
 ActivityListModel::ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
                                      MainSelectionStore &selectionStore, QObject *const parent) :
@@ -378,17 +378,13 @@ ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row>
 
 void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
     for (auto &row: rows) {
-        std::ranges::sort(row.activeErrorDbIds);
-        const auto uniqueResult = std::ranges::unique(row.activeErrorDbIds);
-        const auto duplicateIt = uniqueResult.begin();
-        row.activeErrorDbIds.erase(duplicateIt, row.activeErrorDbIds.end());
         row.canFixErrors = row.status == Status::Failed && !row.activeErrorDbIds.empty();
     }
 
-    std::erase_if(rows, [this](const Row &row) {
+    (void) std::erase_if(rows, [this](const Row &row) {
         return row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
     });
-    std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
+    (void) std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
         const bool lhsInProgress = lhs.status == Status::InProgress;
         const bool rhsInProgress = rhs.status == Status::InProgress;
         if (lhsInProgress != rhsInProgress) {
@@ -456,7 +452,7 @@ bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
             continue;
         }
         beginRemoveRows({}, rowIndex, rowIndex);
-        _rows.erase(_rows.begin() + rowIndex);
+        (void) _rows.erase(_rows.begin() + rowIndex);
         endRemoveRows();
         changed = true;
     }
@@ -479,17 +475,24 @@ bool ActivityListModel::alignRows(const std::vector<Row> &nextRows) {
             const auto matchingIt = std::ranges::find(_rows.begin() + targetIndex + 1, _rows.end(), nextRow.rowId, &Row::rowId);
             if (matchingIt == _rows.end()) {
                 beginInsertRows({}, targetIndex, targetIndex);
-                _rows.insert(_rows.begin() + targetIndex, nextRow);
+                (void) _rows.insert(_rows.begin() + targetIndex, nextRow);
                 endInsertRows();
                 changed = true;
                 continue;
             }
 
-            const qsizetype sourceIndex = std::distance(_rows.begin(), matchingIt);
-            beginMoveRows({}, sourceIndex, sourceIndex, {}, targetIndex);
+            if (const qsizetype sourceIndex = std::distance(_rows.begin(), matchingIt);
+                !beginMoveRows({}, sourceIndex, sourceIndex, {}, targetIndex)) {
+                qCWarning(lcActivityListModel) << "Incremental row move rejected; resetting activity projection"
+                                               << "| sourceIndex:" << sourceIndex << "| targetIndex:" << targetIndex;
+                beginResetModel();
+                _rows = nextRows;
+                endResetModel();
+                return true;
+            }
             auto movedRow = std::move(*matchingIt);
-            _rows.erase(matchingIt);
-            _rows.insert(_rows.begin() + targetIndex, std::move(movedRow));
+            (void) _rows.erase(matchingIt);
+            (void) _rows.insert(_rows.begin() + targetIndex, std::move(movedRow));
             endMoveRows();
             changed = true;
         }

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -1,0 +1,170 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/activitystore.h"
+#include "app/cache/appcache.h"
+#include "app/cache/mainselectionstore.h"
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QList>
+#include <QString>
+#include <QTimer>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace KDC {
+
+/**
+ * QML-facing projection of recent activities and active node errors for the selected synchronization.
+ *
+ * ActivityStore remains the bounded recent-history owner and AppCache remains the authoritative active-error owner.
+ * This model joins both sources without moving either lifecycle into the presentation layer.
+ */
+class ActivityListModel final : public QAbstractListModel {
+        Q_OBJECT
+
+    public:
+        enum class Filter : uint8_t {
+            MyActivityOnly,
+            AllActivities,
+        };
+        Q_ENUM(Filter)
+
+        enum class Status : uint8_t {
+            Synchronized,
+            InProgress,
+            Failed,
+        };
+        Q_ENUM(Status)
+
+        enum class Source : uint8_t {
+            Unknown,
+            Computer,
+            Web,
+        };
+        Q_ENUM(Source)
+
+        enum Role {
+            RowIdRole = Qt::UserRole + 1,
+            NameRole,
+            FolderRole,
+            TimeTextRole,
+            SizeTextRole,
+            NodeTypeRole,
+            StatusRole,
+            SourceRole,
+            InstructionRole,
+            ProgressRole,
+            HasActiveErrorRole,
+            ActiveErrorCountRole,
+            HasOptionsRole,
+            CanOpenLocalRole,
+            CanOpenOnlineRole,
+            CanCopyShareLinkRole,
+            CanFixErrorsRole,
+        };
+        Q_ENUM(Role)
+
+        struct ActionTarget {
+                GenericId activityLocalId{0};
+                SyncDbId syncDbId{0};
+                SyncPath relativePath;
+                NodeType nodeType{NodeType::Unknown};
+                NodeId remoteNodeId;
+                std::vector<ErrorDbId> activeErrorDbIds;
+                bool canOpenLocal{false};
+                bool canOpenOnline{false};
+                bool canCopyShareLink{false};
+                bool canFixErrors{false};
+        };
+
+        explicit ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
+                                   MainSelectionStore &selectionStore, QObject *parent = nullptr);
+
+        [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+        [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+        [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+
+        [[nodiscard]] Filter filter() const { return _filter; }
+        void setFilter(Filter filter);
+        [[nodiscard]] std::optional<ActionTarget> actionTarget(const QString &rowId) const;
+
+    signals:
+        void filterChanged();
+        void projectionChanged();
+
+    private:
+        struct Row {
+                QString rowId;
+                GenericId activityLocalId{0};
+                SyncDbId syncDbId{0};
+                QString name;
+                QString folder;
+                QString timeText;
+                QString sizeText;
+                NodeType nodeType{NodeType::Unknown};
+                Status status{Status::Synchronized};
+                Source source{Source::Unknown};
+                SyncFileInstruction instruction{SyncFileInstruction::None};
+                int32_t progress{0};
+                QDateTime timestampUtc;
+                Count receivedSequence{0};
+                SyncPath relativePath;
+                SyncPath sourcePath;
+                SyncPath destinationPath;
+                NodeId localNodeId;
+                NodeId remoteNodeId;
+                std::vector<ErrorDbId> activeErrorDbIds;
+                bool canOpenLocal{false};
+                bool canOpenOnline{false};
+                bool canCopyShareLink{false};
+                bool canFixErrors{false};
+
+                friend bool operator==(const Row &lhs, const Row &rhs) = default;
+        };
+
+        [[nodiscard]] std::vector<Row> buildProjection() const;
+        [[nodiscard]] std::vector<Row> activityRows(SyncDbId syncDbId) const;
+        static void appendActiveErrors(SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows);
+        static void appendActiveError(SyncDbId syncDbId, const Error &error, std::vector<Row> &rows);
+        [[nodiscard]] static Row makeActivityRow(SyncDbId syncDbId, const ActivityEntry &activity);
+        [[nodiscard]] static Row makeErrorRow(SyncDbId syncDbId, const Error &error);
+        [[nodiscard]] static Row *findMatchingActivity(std::vector<Row> &rows, const Error &error);
+        [[nodiscard]] static int32_t errorMatchScore(const Row &row, const Error &error);
+        void finalizeProjection(std::vector<Row> &rows) const;
+        void resetProjection();
+        void reconcileProjection();
+        [[nodiscard]] bool removeMissingRows(const std::vector<Row> &nextRows);
+        [[nodiscard]] bool alignRows(const std::vector<Row> &nextRows);
+        [[nodiscard]] bool updateRow(qsizetype rowIndex, const Row &nextRow);
+        void refreshRelativeTimes();
+
+        const ActivityStore &_activityStore;
+        const AppCache &_appCache;
+        MainSelectionStore &_selectionStore;
+        std::vector<Row> _rows;
+        Filter _filter{Filter::MyActivityOnly};
+        QTimer _relativeTimeTimer;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -107,6 +107,13 @@ class ActivityListModel final : public QAbstractListModel {
         void projectionChanged();
 
     private:
+        using MatchScore = uint8_t;
+
+        static constexpr MatchScore noMatchScore = 0;
+        static constexpr MatchScore pathMatchScore = 1;
+        static constexpr MatchScore remoteNodeIdMatchScore = 2;
+        static constexpr MatchScore localNodeIdMatchScore = 3;
+
         struct Row {
                 QString rowId;
                 GenericId activityLocalId{0};
@@ -139,7 +146,7 @@ class ActivityListModel final : public QAbstractListModel {
         [[nodiscard]] static Row makeActivityRow(SyncDbId syncDbId, const ActivityEntry &activity);
         [[nodiscard]] static Row makeErrorRow(SyncDbId syncDbId, const Error &error);
         [[nodiscard]] static Row *findMatchingActivity(std::vector<Row> &rows, const Error &error);
-        [[nodiscard]] static int32_t errorMatchScore(const Row &row, const Error &error);
+        [[nodiscard]] static MatchScore errorMatchScore(const Row &row, const Error &error);
         void finalizeProjection(std::vector<Row> &rows) const;
         void resetProjection();
         void reconcileProjection();

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -151,7 +151,7 @@ class ActivityListModel final : public QAbstractListModel {
         void resetProjection();
         void reconcileProjection();
         [[nodiscard]] bool removeMissingRows(const std::vector<Row> &nextRows);
-        [[nodiscard]] bool alignRows(const std::vector<Row> &nextRows);
+        [[nodiscard]] bool applyProjectionRows(const std::vector<Row> &nextRows);
         [[nodiscard]] bool updateRow(qsizetype rowIndex, const Row &nextRow);
         void refreshRelativeTimes();
 

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -77,11 +77,6 @@ class ActivityListModel final : public QAbstractListModel {
             ProgressRole,
             HasActiveErrorRole,
             ActiveErrorCountRole,
-            HasOptionsRole,
-            CanOpenLocalRole,
-            CanOpenOnlineRole,
-            CanCopyShareLinkRole,
-            CanFixErrorsRole,
         };
         Q_ENUM(Role)
 
@@ -89,13 +84,8 @@ class ActivityListModel final : public QAbstractListModel {
                 GenericId activityLocalId{0};
                 SyncDbId syncDbId{0};
                 SyncPath relativePath;
-                NodeType nodeType{NodeType::Unknown};
                 NodeId remoteNodeId;
                 std::vector<ErrorDbId> activeErrorDbIds;
-                bool canOpenLocal{false};
-                bool canOpenOnline{false};
-                bool canCopyShareLink{false};
-                bool canFixErrors{false};
         };
 
         explicit ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
@@ -138,10 +128,6 @@ class ActivityListModel final : public QAbstractListModel {
                 NodeId localNodeId;
                 NodeId remoteNodeId;
                 std::vector<ErrorDbId> activeErrorDbIds;
-                bool canOpenLocal{false};
-                bool canOpenOnline{false};
-                bool canCopyShareLink{false};
-                bool canFixErrors{false};
 
                 friend bool operator==(const Row &lhs, const Row &rhs) = default;
         };

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -101,6 +101,9 @@ class ActivityListModel final : public QAbstractListModel {
         explicit ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
                                    MainSelectionStore &selectionStore, QObject *parent = nullptr);
 
+        /** Returns the stable model row identifier for an activity. */
+        [[nodiscard]] static QString activityRowId(GenericId localId);
+
         [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
         [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
         [[nodiscard]] QHash<int, QByteArray> roleNames() const override;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR introduit `ActivityListModel`, le modèle Qt exposé au QML qui alimente la vue Activités de la sidebar Linux v4. Elle simplifie également `ActivityStore` en supprimant une couche de normalisation devenue redondante maintenant que la logique de présentation vit dans le nouveau modèle.

## Changements
- Ajout de `app/mainwindow/activitylistmodel.{h,cpp}` : un `QAbstractListModel` qui joint l'historique borné et récent de `ActivityStore` avec les erreurs actives faisant autorité de `AppCache` pour la synchronisation sélectionnée.
- Le modèle expose les rôles QML nécessaires à l'affichage (nom, dossier, texte de temps relatif, taille, type de nœud, statut, source, instruction, progression) ainsi que des indicateurs d'actions disponibles (ouvrir en local, ouvrir en ligne, copier le lien de partage, corriger les erreurs).
- Les erreurs actives sur un nœud restent visibles même si l'activité récente correspondante a été évincée de l'historique borné ; le rapprochement entre une erreur et une activité repose sur un score de correspondance (id de nœud local, id de nœud distant, chemin source, chemin destination), à l'image de `selectErrorByNodeInfo` côté serveur.
- Ajout d'un filtre `MyActivityOnly` / `AllActivities` et d'une réconciliation incrémentale de la liste (insertions, suppressions, déplacements, mises à jour de rôles ciblées) plutôt qu'une réinitialisation complète à chaque changement, avec repli sur un reset complet si un déplacement incrémental échoue.
- Un `QTimer` rafraîchit périodiquement les textes de temps relatif ("à l'instant", "il y a 2 min", etc.) sans reconstruire toute la projection.
- Simplification de `ActivityStore` : suppression des enums de présentation `ActivityStatus` / `ActivitySource` et de la normalisation associée (`normalizeStatus`, `normalizeSource`) au profit du `SyncFileStatus` brut du serveur, désormais mappé directement dans `ActivityListModel`. Le calcul de "échec" est centralisé dans une fonction `isFailed` locale à `activitystore.cpp`.
- Mise à jour de `CMakeLists.txt` pour intégrer les nouveaux fichiers sources, et documentation du nouveau composant ainsi que de la contrainte de conception associée dans `src/gui4/linux/AGENTS.md`.

## Notes
Ce modèle n'est pas encore câblé dans le QML de la sidebar ; cette intégration fera l'objet d'un travail de suivi.

</details>

---

## Summary
This PR introduces `ActivityListModel`, the QML-facing Qt model that will power the Activities view in the Linux v4 sidebar. It also simplifies `ActivityStore` by removing a normalization layer that became redundant now that presentation logic lives in the new model.

## Changes
- Added `app/mainwindow/activitylistmodel.{h,cpp}`: a `QAbstractListModel` that joins `ActivityStore`'s bounded recent history with `AppCache`'s authoritative active node errors for the currently selected synchronization.
- The model exposes the QML roles needed for display (name, folder, relative time text, size, node type, status, source, instruction, progress) plus available-action flags (open locally, open online, copy share link, fix errors).
- Active node errors remain visible even when their corresponding recent activity has been evicted from the bounded history; matching an error to an activity uses a scored comparison (local node id, remote node id, source path, destination path), mirroring the server's `selectErrorByNodeInfo` lookup.
- Added a `MyActivityOnly` / `AllActivities` filter and incremental list reconciliation (targeted inserts, removals, moves, and role updates) instead of a full reset on every change, falling back to a full reset if an incremental move is rejected.
- A `QTimer` periodically refreshes relative time text ("just now", "2 min ago", etc.) without rebuilding the whole projection.
- Simplified `ActivityStore`: removed the presentation-only `ActivityStatus` / `ActivitySource` enums and their normalization (`normalizeStatus`, `normalizeSource`) in favor of the raw server `SyncFileStatus`, now mapped directly in `ActivityListModel`. The "failed" determination is centralized in a local `isFailed` helper in `activitystore.cpp`.
- Updated `CMakeLists.txt` to include the new source files, and documented the new component along with its design constraint in `src/gui4/linux/AGENTS.md`.

## Notes
This model is not yet wired into the sidebar QML; that integration is planned as follow-up work.