### PR TITLE
feat(activity): add ActivitiesController and ActivityService

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -174,6 +174,9 @@
 - `app/mainwindow/activitylistmodel.*`: selected-sync projection joining bounded recent activities with authoritative
   active node errors. It maps server status and direction to the QML-facing presentation enums. Active errors remain
   visible even when their recent activity has been evicted.
+- `app/mainwindow/activitiescontroller.*`: QML-facing Activities state and action boundary. It owns filtering and title
+  presentation, including the local title-state resolver, validates local paths, and delegates asynchronous link actions
+  to `ActivityService`.
 - `app/mainwindow/homecontroller.*`: cache-backed QML adapter for the modular Home and toolbar sync controls. It
   resolves the selected sync into one central presentation state, exposes user/drive/error data, owns web-link
   construction, and delegates pause/resume to `SyncService`.
@@ -228,6 +231,8 @@
   `CachePipeline`.
 - `app/services/driveservice.*`: targeted drive use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
+- `app/services/activityservice.*`: activity-row link facade. It resolves private/public URLs through `CommService`, owns
+  browser and clipboard side effects, and tracks concurrent actions without owning activity history.
 - `app/services/parametersservice.*`: targeted facade for application settings updates. It starts from the confirmed
   `ParametersStore` snapshot, sends the full `PARAMETERS_UPDATE` payload, and updates the store only after server
   confirmation.

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -39,6 +39,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/parametersstore.h
         app/mainwindow/mainsidebarcontroller.cpp
         app/mainwindow/mainsidebarcontroller.h
+        app/mainwindow/activitiescontroller.cpp
+        app/mainwindow/activitiescontroller.h
         app/mainwindow/activitylistmodel.cpp
         app/mainwindow/activitylistmodel.h
         app/mainwindow/homecontroller.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -81,6 +81,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         communicationlayer/tlscerthelper.h
         app/services/commservice.cpp
         app/services/commservice.h
+        app/services/activityservice.cpp
+        app/services/activityservice.h
         app/services/cachepopulator.cpp
         app/services/cachepopulator.h
         app/services/driveservice.cpp

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -49,6 +49,8 @@ ActivitiesTitleState resolveTitleState(const bool hasSync, const bool offline, c
         return ActivitiesTitleState::Loading;
     }
 
+    // Select the title by priority: runtime availability, synchronization state, list content, then stable runtime state.
+    // This keeps a meaningful synchronization state visible even before the first activity is received.
     switch (*runtimeStatus) {
         case SyncStatus::Undefined:
         case SyncStatus::EnumEnd:

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -153,8 +153,8 @@ void ActivitiesController::setFilter(const ActivityListModel::Filter filter) {
 
 void ActivitiesController::openLocal(const QString &rowId) {
     const auto target = _model.actionTarget(rowId);
-    if (!target.has_value() || !target->canOpenLocal) {
-        qCWarning(lcActivitiesController) << "Local activity action rejected for unavailable row | rowId:" << rowId;
+    if (!target.has_value()) {
+        qCWarning(lcActivitiesController) << "Local activity action rejected for unknown row | rowId:" << rowId;
         emit actionFailed(rowId);
         return;
     }
@@ -196,8 +196,8 @@ void ActivitiesController::openLocal(const QString &rowId) {
 
 void ActivitiesController::openOnline(const QString &rowId) {
     const auto target = _model.actionTarget(rowId);
-    if (!target.has_value() || !target->canOpenOnline) {
-        qCWarning(lcActivitiesController) << "Online activity action rejected for unavailable row | rowId:" << rowId;
+    if (!target.has_value() || target->remoteNodeId.empty()) {
+        qCWarning(lcActivitiesController) << "Online activity action rejected for unavailable node | rowId:" << rowId;
         emit actionFailed(rowId);
         return;
     }
@@ -211,8 +211,8 @@ void ActivitiesController::openOnline(const QString &rowId) {
 
 void ActivitiesController::copyShareLink(const QString &rowId) {
     const auto target = _model.actionTarget(rowId);
-    if (!target.has_value() || !target->canCopyShareLink) {
-        qCWarning(lcActivitiesController) << "Share-link activity action rejected for unavailable row | rowId:" << rowId;
+    if (!target.has_value() || target->remoteNodeId.empty()) {
+        qCWarning(lcActivitiesController) << "Share-link activity action rejected for unavailable node | rowId:" << rowId;
         emit actionFailed(rowId);
         return;
     }
@@ -226,7 +226,7 @@ void ActivitiesController::copyShareLink(const QString &rowId) {
 
 void ActivitiesController::requestFixErrors(const QString &rowId) const {
     const auto target = _model.actionTarget(rowId);
-    if (!target.has_value() || !target->canFixErrors) {
+    if (!target.has_value() || target->activeErrorDbIds.empty()) {
         qCInfo(lcActivitiesController) << "Activity error resolution ignored because the row has no active error"
                                        << "| rowId:" << rowId;
         return;

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -1,0 +1,286 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/mainwindow/activitiescontroller.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QDesktopServices>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QUrl>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivitiesController, "gui.v4.activitiescontroller", QtInfoMsg)
+
+enum class ActivitiesTitleState : uint8_t {
+    Loading,
+    Offline,
+    InProgress,
+    NoActivity,
+    Idle,
+    Paused,
+};
+
+ActivitiesTitleState resolveTitleState(const bool hasSync, const bool offline, const std::optional<SyncStatus> runtimeStatus,
+                                       const bool hasActivities) {
+    if (!hasSync || !runtimeStatus.has_value()) {
+        return ActivitiesTitleState::Loading;
+    }
+
+    switch (*runtimeStatus) {
+        case SyncStatus::Undefined:
+        case SyncStatus::EnumEnd:
+            return ActivitiesTitleState::Loading;
+        case SyncStatus::Idle:
+        case SyncStatus::Paused:
+            if (offline) {
+                return ActivitiesTitleState::Offline;
+            }
+            break;
+        case SyncStatus::Starting:
+        case SyncStatus::Running:
+        case SyncStatus::PauseAsked:
+        case SyncStatus::StopAsked:
+            return ActivitiesTitleState::InProgress;
+        case SyncStatus::Stopped:
+        case SyncStatus::Error:
+            break;
+    }
+
+    if (!hasActivities) {
+        return ActivitiesTitleState::NoActivity;
+    }
+    return *runtimeStatus == SyncStatus::Idle ? ActivitiesTitleState::Idle : ActivitiesTitleState::Paused;
+}
+
+QString titleForState(const ActivitiesTitleState state) {
+    switch (state) {
+        case ActivitiesTitleState::Loading:
+            return {};
+        case ActivitiesTitleState::Offline:
+            return qtTrId("activitiesTitleOffline");
+        case ActivitiesTitleState::InProgress:
+            return qtTrId("activitiesTitleInProgress");
+        case ActivitiesTitleState::NoActivity:
+            return qtTrId("activitiesTitleNoActivity");
+        case ActivitiesTitleState::Idle:
+            return qtTrId("activitiesTitleIdle");
+        case ActivitiesTitleState::Paused:
+            return qtTrId("activitiesTitlePause");
+    }
+    return {};
+}
+
+std::optional<SyncPath> safeRelativePath(const SyncPath &path) {
+    if (path.has_root_name()) {
+        return std::nullopt;
+    }
+    SyncPath normalizedPath = path.relative_path().lexically_normal();
+    if (normalizedPath.empty() || normalizedPath == SyncPath{"."}) {
+        return std::nullopt;
+    }
+    if (std::ranges::any_of(normalizedPath, [](const SyncPath &component) { return component == SyncPath{".."}; })) {
+        return std::nullopt;
+    }
+    return normalizedPath;
+}
+
+bool isContainedIn(const SyncPath &root, const SyncPath &candidate) {
+    const SyncPath normalizedRoot = root.lexically_normal();
+    const SyncPath normalizedCandidate = candidate.lexically_normal();
+    auto candidateIt = normalizedCandidate.begin();
+    for (auto rootIt = normalizedRoot.begin(); rootIt != normalizedRoot.end(); ++rootIt, ++candidateIt) {
+        if (candidateIt == normalizedCandidate.end() || *candidateIt != *rootIt) {
+            return false;
+        }
+    }
+    return true;
+}
+
+QString activityRowId(const GenericId localId) {
+    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
+}
+} // namespace
+
+ActivitiesController::ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
+                                           MainSelectionStore &selectionStore, const NetworkStatusObserver &networkStatusObserver,
+                                           ActivityService &activityService, QObject *const parent) :
+    QObject(parent),
+    _appCache(appCache),
+    _selectionStore(selectionStore),
+    _networkStatusObserver(networkStatusObserver),
+    _activityService(activityService),
+    _model(activityStore, appCache, selectionStore, this) {
+    (void) connect(&_model, &ActivityListModel::filterChanged, this, &ActivitiesController::filterChanged);
+    (void) connect(&_model, &ActivityListModel::projectionChanged, this, &ActivitiesController::refreshPageState);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentContextChanged, this, &ActivitiesController::refreshPageState);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncRuntimeInfoChanged, this,
+                   &ActivitiesController::refreshPageState);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncStatusChanged, this,
+                   &ActivitiesController::refreshPageState);
+    (void) connect(&_networkStatusObserver, &NetworkStatusObserver::offlineChanged, this,
+                   &ActivitiesController::refreshPageState);
+    (void) connect(&_activityService, &ActivityService::shareLinkCopied, this,
+                   [this](const GenericId activityLocalId) { emit shareLinkCopied(activityRowId(activityLocalId)); });
+    (void) connect(&_activityService, &ActivityService::actionFailed, this,
+                   [this](const GenericId activityLocalId) { emit actionFailed(activityRowId(activityLocalId)); });
+    refreshPageState();
+}
+
+void ActivitiesController::setFilter(const ActivityListModel::Filter filter) {
+    _model.setFilter(filter);
+}
+
+void ActivitiesController::openLocal(const QString &rowId) {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canOpenLocal) {
+        qCWarning(lcActivitiesController) << "Local activity action rejected for unavailable row | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+    const auto context = actionSyncContext(*target, rowId);
+    const auto relativePath = safeRelativePath(target->relativePath);
+    if (!context.has_value() || !relativePath.has_value()) {
+        qCWarning(lcActivitiesController) << "Local activity action rejected for invalid path | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+
+    const SyncPath rootPath = context->syncInfo.localPath().lexically_normal();
+    const QFileInfo rootInfo{Path2QStr(rootPath)};
+    const SyncPath targetPath = (rootPath / *relativePath).lexically_normal();
+    const QFileInfo targetInfo{Path2QStr(targetPath)};
+    if (!rootInfo.exists() || !rootInfo.isDir() || !targetInfo.exists()) {
+        qCWarning(lcActivitiesController) << "Local activity target is missing or outside the synchronization root"
+                                          << "| rowId:" << rowId << "| target:" << Path2QStr(targetPath);
+        emit actionFailed(rowId);
+        return;
+    }
+
+    const auto canonicalRootPath = QStr2Path(rootInfo.canonicalFilePath());
+    const auto canonicalTargetPath = QStr2Path(targetInfo.canonicalFilePath());
+    if (canonicalRootPath.empty() || canonicalTargetPath.empty() || !isContainedIn(canonicalRootPath, canonicalTargetPath)) {
+        qCWarning(lcActivitiesController) << "Local activity target resolves outside the synchronization root"
+                                          << "| rowId:" << rowId << "| target:" << Path2QStr(targetPath);
+        emit actionFailed(rowId);
+        return;
+    }
+
+    if (const SyncPath folderToOpen = targetInfo.isDir() ? canonicalTargetPath : canonicalTargetPath.parent_path();
+        folderToOpen.empty() || !QDesktopServices::openUrl(QUrl::fromLocalFile(Path2QStr(folderToOpen)))) {
+        qCWarning(lcActivitiesController) << "Desktop service failed to open local activity folder"
+                                          << "| rowId:" << rowId << "| folder:" << Path2QStr(folderToOpen);
+        emit actionFailed(rowId);
+    }
+}
+
+void ActivitiesController::openOnline(const QString &rowId) {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canOpenOnline) {
+        qCWarning(lcActivitiesController) << "Online activity action rejected for unavailable row | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+    const auto context = actionSyncContext(*target, rowId);
+    if (!context.has_value()) {
+        emit actionFailed(rowId);
+        return;
+    }
+    _activityService.openOnline(target->activityLocalId, context->drive.dbId(), target->remoteNodeId);
+}
+
+void ActivitiesController::copyShareLink(const QString &rowId) {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canCopyShareLink) {
+        qCWarning(lcActivitiesController) << "Share-link activity action rejected for unavailable row | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+    const auto context = actionSyncContext(*target, rowId);
+    if (!context.has_value()) {
+        emit actionFailed(rowId);
+        return;
+    }
+    _activityService.copyShareLink(target->activityLocalId, context->drive.dbId(), target->remoteNodeId);
+}
+
+void ActivitiesController::requestFixErrors(const QString &rowId) const {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canFixErrors) {
+        qCInfo(lcActivitiesController) << "Activity error resolution ignored because the row has no active error"
+                                       << "| rowId:" << rowId;
+        return;
+    }
+    qCInfo(lcActivitiesController) << "Activity error resolution is not implemented yet"
+                                   << "| rowId:" << rowId << "| activeErrorCount:" << target->activeErrorDbIds.size();
+}
+
+void ActivitiesController::requestFixAllErrors() const {
+    const auto context = _selectionStore.currentSyncContext();
+    qCInfo(lcActivitiesController) << "Global activity error resolution is not implemented yet"
+                                   << "| syncDbId:" << _selectionStore.currentSyncDbId()
+                                   << "| activeErrorCount:" << (context.has_value() ? context->errors.size() : 0);
+}
+
+void ActivitiesController::refreshPageState() {
+    const bool nextHasActivities = _model.rowCount() > 0;
+    const auto context = _selectionStore.currentSyncContext();
+    const qint32 nextErrorCount = context.has_value() ? static_cast<qint32>(context->errors.size()) : 0;
+    const auto runtimeInfo = _selectionStore.currentSyncRuntimeInfo();
+    const auto runtimeStatus = runtimeInfo.has_value() ? std::make_optional(runtimeInfo->status) : std::nullopt;
+    const auto titleState =
+            resolveTitleState(context.has_value(), _networkStatusObserver.offline(), runtimeStatus, nextHasActivities);
+    const bool nextLoading = titleState == ActivitiesTitleState::Loading;
+    const QString nextTitle = titleForState(titleState);
+
+    if (_hasActivities != nextHasActivities) {
+        _hasActivities = nextHasActivities;
+        emit hasActivitiesChanged();
+    }
+    if (_errorCount != nextErrorCount) {
+        _errorCount = nextErrorCount;
+        emit errorCountChanged();
+    }
+    if (_loading != nextLoading) {
+        _loading = nextLoading;
+        emit loadingChanged();
+    }
+    if (_title != nextTitle) {
+        _title = nextTitle;
+        emit titleChanged();
+    }
+}
+
+std::optional<SyncContext> ActivitiesController::actionSyncContext(const ActivityListModel::ActionTarget &target,
+                                                                   const QString &rowId) const {
+    auto context = _appCache.syncContext(target.syncDbId);
+    if (!context.has_value() || context->syncInfo.dbId() != target.syncDbId || context->drive.dbId() <= 0) {
+        qCWarning(lcActivitiesController) << "Activity action rejected because its synchronization context disappeared"
+                                          << "| rowId:" << rowId << "| syncDbId:" << target.syncDbId;
+        return std::nullopt;
+    }
+    return context;
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -19,6 +19,7 @@
 #include "app/mainwindow/activitiescontroller.h"
 
 #include "libcommon/utility/types.h"
+#include "libcommon/utility/utility.h"
 
 #include <QDesktopServices>
 #include <QFileInfo>
@@ -106,18 +107,6 @@ std::optional<SyncPath> safeRelativePath(const SyncPath &path) {
     return normalizedPath;
 }
 
-bool isContainedIn(const SyncPath &root, const SyncPath &candidate) {
-    const SyncPath normalizedRoot = root.lexically_normal();
-    const SyncPath normalizedCandidate = candidate.lexically_normal();
-    auto candidateIt = normalizedCandidate.begin();
-    for (auto rootIt = normalizedRoot.begin(); rootIt != normalizedRoot.end(); ++rootIt, ++candidateIt) {
-        if (candidateIt == normalizedCandidate.end() || *candidateIt != *rootIt) {
-            return false;
-        }
-    }
-    return true;
-}
-
 } // namespace
 
 ActivitiesController::ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
@@ -179,7 +168,8 @@ void ActivitiesController::openLocal(const QString &rowId) {
 
     const auto canonicalRootPath = QStr2Path(rootInfo.canonicalFilePath());
     const auto canonicalTargetPath = QStr2Path(targetInfo.canonicalFilePath());
-    if (canonicalRootPath.empty() || canonicalTargetPath.empty() || !isContainedIn(canonicalRootPath, canonicalTargetPath)) {
+    if (canonicalRootPath.empty() || canonicalTargetPath.empty() ||
+        !CommonUtility::isSubDir(canonicalRootPath, canonicalTargetPath)) {
         qCWarning(lcActivitiesController) << "Local activity target resolves outside the synchronization root"
                                           << "| rowId:" << rowId << "| target:" << Path2QStr(targetPath);
         emit actionFailed(rowId);

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -118,9 +118,6 @@ bool isContainedIn(const SyncPath &root, const SyncPath &candidate) {
     return true;
 }
 
-QString activityRowId(const GenericId localId) {
-    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
-}
 } // namespace
 
 ActivitiesController::ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
@@ -141,10 +138,12 @@ ActivitiesController::ActivitiesController(const ActivityStore &activityStore, c
                    &ActivitiesController::refreshPageState);
     (void) connect(&_networkStatusObserver, &NetworkStatusObserver::offlineChanged, this,
                    &ActivitiesController::refreshPageState);
-    (void) connect(&_activityService, &ActivityService::shareLinkCopied, this,
-                   [this](const GenericId activityLocalId) { emit shareLinkCopied(activityRowId(activityLocalId)); });
-    (void) connect(&_activityService, &ActivityService::actionFailed, this,
-                   [this](const GenericId activityLocalId) { emit actionFailed(activityRowId(activityLocalId)); });
+    (void) connect(&_activityService, &ActivityService::shareLinkCopied, this, [this](const GenericId activityLocalId) {
+        emit shareLinkCopied(ActivityListModel::activityRowId(activityLocalId));
+    });
+    (void) connect(&_activityService, &ActivityService::actionFailed, this, [this](const GenericId activityLocalId) {
+        emit actionFailed(ActivityListModel::activityRowId(activityLocalId));
+    });
     refreshPageState();
 }
 

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -94,7 +94,7 @@ QString titleForState(const ActivitiesTitleState state) {
 }
 
 std::optional<SyncPath> safeRelativePath(const SyncPath &path) {
-    if (path.has_root_name()) {
+    if (path.has_root_path()) {
         return std::nullopt;
     }
     SyncPath normalizedPath = path.relative_path().lexically_normal();
@@ -148,9 +148,14 @@ void ActivitiesController::openLocal(const QString &rowId) {
         return;
     }
     const auto context = actionSyncContext(*target, rowId);
+    if (!context.has_value()) {
+        emit actionFailed(rowId);
+        return;
+    }
     const auto relativePath = safeRelativePath(target->relativePath);
-    if (!context.has_value() || !relativePath.has_value()) {
-        qCWarning(lcActivitiesController) << "Local activity action rejected for invalid path | rowId:" << rowId;
+    if (!relativePath.has_value()) {
+        qCWarning(lcActivitiesController) << "Local activity action rejected for invalid path"
+                                          << "| rowId:" << rowId << "| path:" << Path2QStr(target->relativePath);
         emit actionFailed(rowId);
         return;
     }

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.h
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.h
@@ -1,0 +1,93 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/cache/mainselectionstore.h"
+#include "app/mainwindow/activitylistmodel.h"
+#include "app/mainwindow/networkstatusobserver.h"
+#include "app/services/activityservice.h"
+
+#include <QObject>
+#include <QString>
+
+namespace KDC {
+
+/**
+ * QML-facing state and interaction controller for the Activities page.
+ *
+ * It owns the selected-sync projection, resolves page-level presentation state, validates local actions, and delegates
+ * asynchronous web actions to ActivityService. It does not own recent history or active errors.
+ */
+class ActivitiesController final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(ActivityListModel *model READ model CONSTANT)
+        Q_PROPERTY(ActivityListModel::Filter filter READ filter WRITE setFilter NOTIFY filterChanged)
+        Q_PROPERTY(QString title READ title NOTIFY titleChanged)
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(bool hasActivities READ hasActivities NOTIFY hasActivitiesChanged)
+        Q_PROPERTY(qint32 errorCount READ errorCount NOTIFY errorCountChanged)
+        Q_PROPERTY(bool hasErrors READ hasErrors NOTIFY errorCountChanged)
+
+    public:
+        explicit ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
+                                      MainSelectionStore &selectionStore, const NetworkStatusObserver &networkStatusObserver,
+                                      ActivityService &activityService, QObject *parent = nullptr);
+
+        [[nodiscard]] ActivityListModel *model() { return &_model; }
+        [[nodiscard]] ActivityListModel::Filter filter() const { return _model.filter(); }
+        void setFilter(ActivityListModel::Filter filter);
+        [[nodiscard]] const QString &title() const { return _title; }
+        [[nodiscard]] bool loading() const { return _loading; }
+        [[nodiscard]] bool hasActivities() const { return _hasActivities; }
+        [[nodiscard]] qint32 errorCount() const { return _errorCount; }
+        [[nodiscard]] bool hasErrors() const { return _errorCount > 0; }
+
+        Q_INVOKABLE void openLocal(const QString &rowId);
+        Q_INVOKABLE void openOnline(const QString &rowId);
+        Q_INVOKABLE void copyShareLink(const QString &rowId);
+        Q_INVOKABLE void requestFixErrors(const QString &rowId) const;
+        Q_INVOKABLE void requestFixAllErrors() const;
+
+    signals:
+        void filterChanged();
+        void titleChanged();
+        void loadingChanged();
+        void hasActivitiesChanged();
+        void errorCountChanged();
+        void shareLinkCopied(const QString &rowId);
+        void actionFailed(const QString &rowId);
+
+    private:
+        void refreshPageState();
+        [[nodiscard]] std::optional<SyncContext> actionSyncContext(const ActivityListModel::ActionTarget &target,
+                                                                   const QString &rowId) const;
+
+        const AppCache &_appCache;
+        MainSelectionStore &_selectionStore;
+        const NetworkStatusObserver &_networkStatusObserver;
+        ActivityService &_activityService;
+        ActivityListModel _model;
+        QString _title;
+        bool _loading{true};
+        bool _hasActivities{false};
+        qint32 _errorCount{0};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/activityservice.cpp
+++ b/src/gui4/linux/app/services/activityservice.cpp
@@ -40,6 +40,17 @@ namespace KDC {
 
 namespace {
 Q_LOGGING_CATEGORY(lcActivityService, "gui.v4.activityservice", QtInfoMsg)
+
+bool validateActivityTarget(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId,
+                            const DriveDbId driveDbId, const NodeId &remoteNodeId) {
+    if (activityLocalId > 0 && driveDbId > 0 && !remoteNodeId.empty()) {
+        return true;
+    }
+    qCWarning(lcActivityService) << "Activity action rejected because its target is incomplete"
+                                 << "| action:" << actionKey << "| activityLocalId:" << activityLocalId
+                                 << "| driveDbId:" << driveDbId << "| remoteNodeId:" << QString::fromStdString(remoteNodeId);
+    return false;
+}
 } // namespace
 
 ActivityService::ActivityService(CommService &commService, ServiceActionTracker &serviceActionTracker,
@@ -61,9 +72,7 @@ bool ActivityService::loading() const {
 }
 
 void ActivityService::openOnline(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
-    if (activityLocalId <= 0 || driveDbId <= 0 || remoteNodeId.empty()) {
-        qCWarning(lcActivityService) << "Online activity action rejected because its target is incomplete"
-                                     << "| activityLocalId:" << activityLocalId << "| driveDbId:" << driveDbId;
+    if (!validateActivityTarget(actionOpenOnline, activityLocalId, driveDbId, remoteNodeId)) {
         emit actionFailed(activityLocalId);
         return;
     }
@@ -82,9 +91,7 @@ void ActivityService::openOnline(const GenericId activityLocalId, const DriveDbI
 }
 
 void ActivityService::copyShareLink(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
-    if (activityLocalId <= 0 || driveDbId <= 0 || remoteNodeId.empty()) {
-        qCWarning(lcActivityService) << "Share-link activity action rejected because its target is incomplete"
-                                     << "| activityLocalId:" << activityLocalId << "| driveDbId:" << driveDbId;
+    if (!validateActivityTarget(actionCopyShareLink, activityLocalId, driveDbId, remoteNodeId)) {
         emit actionFailed(activityLocalId);
         return;
     }

--- a/src/gui4/linux/app/services/activityservice.cpp
+++ b/src/gui4/linux/app/services/activityservice.cpp
@@ -72,30 +72,13 @@ void ActivityService::openOnline(const GenericId activityLocalId, const DriveDbI
     }
 
     const QPointer<ActivityService> guard{this};
-    _commService.requestSyncGetPrivateLinkUrl(
-            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
-                if (guard.isNull()) {
-                    return;
-                }
-                guard->endAction(actionOpenOnline, activityLocalId);
-                if (!exitInfo) {
-                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPRIVATELINKURL, activityLocalId);
-                    return;
-                }
-
-                const QUrl url{urlText};
-                if (!isSupportedWebUrl(url)) {
-                    qCWarning(lcActivityService) << "Private activity URL is empty or invalid"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                    return;
-                }
-                if (!QDesktopServices::openUrl(url)) {
-                    qCWarning(lcActivityService) << "Desktop service failed to open private activity URL"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                }
-            });
+    _commService.requestSyncGetPrivateLinkUrl(driveDbId, remoteNodeId,
+                                              [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                                                  if (guard.isNull()) {
+                                                      return;
+                                                  }
+                                                  guard->handlePrivateLinkUrl(exitInfo, urlText, activityLocalId);
+                                              });
 }
 
 void ActivityService::copyShareLink(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
@@ -110,34 +93,59 @@ void ActivityService::copyShareLink(const GenericId activityLocalId, const Drive
     }
 
     const QPointer<ActivityService> guard{this};
-    _commService.requestSyncGetPublicLinkUrl(
-            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
-                if (guard.isNull()) {
-                    return;
-                }
-                guard->endAction(actionCopyShareLink, activityLocalId);
-                if (!exitInfo) {
-                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPUBLICLINKURL, activityLocalId);
-                    return;
-                }
+    _commService.requestSyncGetPublicLinkUrl(driveDbId, remoteNodeId,
+                                             [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                                                 if (guard.isNull()) {
+                                                     return;
+                                                 }
+                                                 guard->handlePublicLinkUrl(exitInfo, urlText, activityLocalId);
+                                             });
+}
 
-                const QUrl url{urlText};
-                if (!isSupportedWebUrl(url)) {
-                    qCWarning(lcActivityService) << "Public activity URL is empty or invalid"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                    return;
-                }
-                auto *const clipboard = QGuiApplication::clipboard();
-                if (clipboard == nullptr) {
-                    qCWarning(lcActivityService) << "Clipboard unavailable for activity share link"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                    return;
-                }
-                clipboard->setText(url.toString());
-                emit guard->shareLinkCopied(activityLocalId);
-            });
+void ActivityService::handlePrivateLinkUrl(const ExitInfo &exitInfo, const QString &urlText, const GenericId activityLocalId) {
+    endAction(actionOpenOnline, activityLocalId);
+    if (!exitInfo) {
+        notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPRIVATELINKURL, activityLocalId);
+        return;
+    }
+
+    const QUrl url{urlText};
+    if (!isSupportedWebUrl(url)) {
+        qCWarning(lcActivityService) << "Private activity URL is empty or invalid"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    if (!QDesktopServices::openUrl(url)) {
+        qCWarning(lcActivityService) << "Desktop service failed to open private activity URL"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+    }
+}
+
+void ActivityService::handlePublicLinkUrl(const ExitInfo &exitInfo, const QString &urlText, const GenericId activityLocalId) {
+    endAction(actionCopyShareLink, activityLocalId);
+    if (!exitInfo) {
+        notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPUBLICLINKURL, activityLocalId);
+        return;
+    }
+
+    const QUrl url{urlText};
+    if (!isSupportedWebUrl(url)) {
+        qCWarning(lcActivityService) << "Public activity URL is empty or invalid"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    auto *const clipboard = QGuiApplication::clipboard();
+    if (clipboard == nullptr) {
+        qCWarning(lcActivityService) << "Clipboard unavailable for activity share link"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    clipboard->setText(url.toString());
+    emit shareLinkCopied(activityLocalId);
 }
 
 bool ActivityService::beginAction(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId) const {

--- a/src/gui4/linux/app/services/activityservice.cpp
+++ b/src/gui4/linux/app/services/activityservice.cpp
@@ -1,0 +1,166 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/services/activityservice.h"
+
+#include <QClipboard>
+#include <QDesktopServices>
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QPointer>
+#include <QUrl>
+
+namespace {
+constexpr char serviceKeyActivity[] = "activity";
+constexpr char actionOpenOnline[] = "openOnline";
+constexpr char actionCopyShareLink[] = "copyShareLink";
+
+bool isSupportedWebUrl(const QUrl &url) {
+    return url.isValid() && !url.isEmpty() && !url.host().isEmpty() &&
+           (url.scheme() == QStringLiteral("https") || url.scheme() == QStringLiteral("http"));
+}
+} // namespace
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivityService, "gui.v4.activityservice", QtInfoMsg)
+} // namespace
+
+ActivityService::ActivityService(CommService &commService, ServiceActionTracker &serviceActionTracker,
+                                 ServiceEventBus &serviceEventBus, QObject *const parent) :
+    QObject(parent),
+    _commService(commService),
+    _serviceActionTracker(serviceActionTracker),
+    _serviceEventBus(serviceEventBus) {
+    (void) connect(&_serviceActionTracker, &ServiceActionTracker::servicePendingChanged, this,
+                   [this](const ServiceActionTracker::ServiceKey &serviceKey, const bool) {
+                       if (serviceKey == serviceKeyActivity) {
+                           emit loadingChanged();
+                       }
+                   });
+}
+
+bool ActivityService::loading() const {
+    return _serviceActionTracker.isServicePending(serviceKeyActivity);
+}
+
+void ActivityService::openOnline(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
+    if (activityLocalId <= 0 || driveDbId <= 0 || remoteNodeId.empty()) {
+        qCWarning(lcActivityService) << "Online activity action rejected because its target is incomplete"
+                                     << "| activityLocalId:" << activityLocalId << "| driveDbId:" << driveDbId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    if (!beginAction(actionOpenOnline, activityLocalId)) {
+        return;
+    }
+
+    const QPointer<ActivityService> guard{this};
+    _commService.requestSyncGetPrivateLinkUrl(
+            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                if (guard.isNull()) {
+                    return;
+                }
+                guard->endAction(actionOpenOnline, activityLocalId);
+                if (!exitInfo) {
+                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPRIVATELINKURL, activityLocalId);
+                    return;
+                }
+
+                const QUrl url{urlText};
+                if (!isSupportedWebUrl(url)) {
+                    qCWarning(lcActivityService) << "Private activity URL is empty or invalid"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                    return;
+                }
+                if (!QDesktopServices::openUrl(url)) {
+                    qCWarning(lcActivityService) << "Desktop service failed to open private activity URL"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                }
+            });
+}
+
+void ActivityService::copyShareLink(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
+    if (activityLocalId <= 0 || driveDbId <= 0 || remoteNodeId.empty()) {
+        qCWarning(lcActivityService) << "Share-link activity action rejected because its target is incomplete"
+                                     << "| activityLocalId:" << activityLocalId << "| driveDbId:" << driveDbId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    if (!beginAction(actionCopyShareLink, activityLocalId)) {
+        return;
+    }
+
+    const QPointer<ActivityService> guard{this};
+    _commService.requestSyncGetPublicLinkUrl(
+            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                if (guard.isNull()) {
+                    return;
+                }
+                guard->endAction(actionCopyShareLink, activityLocalId);
+                if (!exitInfo) {
+                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPUBLICLINKURL, activityLocalId);
+                    return;
+                }
+
+                const QUrl url{urlText};
+                if (!isSupportedWebUrl(url)) {
+                    qCWarning(lcActivityService) << "Public activity URL is empty or invalid"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                    return;
+                }
+                auto *const clipboard = QGuiApplication::clipboard();
+                if (clipboard == nullptr) {
+                    qCWarning(lcActivityService) << "Clipboard unavailable for activity share link"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                    return;
+                }
+                clipboard->setText(url.toString());
+                emit guard->shareLinkCopied(activityLocalId);
+            });
+}
+
+bool ActivityService::beginAction(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId) const {
+    if (_serviceActionTracker.isActionPending(serviceKeyActivity, actionKey, activityLocalId)) {
+        qCDebug(lcActivityService) << "Duplicate activity action ignored"
+                                   << "| action:" << actionKey << "| activityLocalId:" << activityLocalId;
+        return false;
+    }
+    _serviceActionTracker.beginAction(serviceKeyActivity, actionKey, activityLocalId);
+    return true;
+}
+
+void ActivityService::endAction(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId) const {
+    _serviceActionTracker.endAction(serviceKeyActivity, actionKey, activityLocalId);
+}
+
+void ActivityService::notifyRequestFailure(const ExitInfo &exitInfo, const RequestNum requestNum,
+                                           const GenericId activityLocalId) {
+    qCWarning(lcActivityService) << "Activity service request failed"
+                                 << "| request:" << static_cast<int32_t>(requestNum) << "| code:" << exitInfo.code()
+                                 << "| cause:" << exitInfo.cause() << "| activityLocalId:" << activityLocalId;
+    _serviceEventBus.notifyGenericError(exitInfo, requestNum);
+    emit actionFailed(activityLocalId);
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/activityservice.h
+++ b/src/gui4/linux/app/services/activityservice.h
@@ -1,0 +1,63 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/services/commservice.h"
+#include "app/services/serviceactiontracker.h"
+#include "app/services/serviceeventbus.h"
+#include "libcommon/utility/types.h"
+
+#include <QObject>
+
+namespace KDC {
+
+/**
+ * High-level facade for asynchronous actions initiated from an activity row.
+ *
+ * It owns link resolution, browser and clipboard side effects, pending-action tracking, and backend failure reporting.
+ * Activity projection and local-path validation remain outside this service.
+ */
+class ActivityService final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+
+    public:
+        explicit ActivityService(CommService &commService, ServiceActionTracker &serviceActionTracker,
+                                 ServiceEventBus &serviceEventBus, QObject *parent = nullptr);
+
+        [[nodiscard]] bool loading() const;
+        void openOnline(GenericId activityLocalId, DriveDbId driveDbId, const NodeId &remoteNodeId);
+        void copyShareLink(GenericId activityLocalId, DriveDbId driveDbId, const NodeId &remoteNodeId);
+
+    signals:
+        void loadingChanged();
+        void shareLinkCopied(GenericId activityLocalId);
+        void actionFailed(GenericId activityLocalId);
+
+    private:
+        [[nodiscard]] bool beginAction(const ServiceActionTracker::ActionKey &actionKey, GenericId activityLocalId) const;
+        void endAction(const ServiceActionTracker::ActionKey &actionKey, GenericId activityLocalId) const;
+        void notifyRequestFailure(const ExitInfo &exitInfo, RequestNum requestNum, GenericId activityLocalId);
+
+        CommService &_commService;
+        ServiceActionTracker &_serviceActionTracker;
+        ServiceEventBus &_serviceEventBus;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/activityservice.h
+++ b/src/gui4/linux/app/services/activityservice.h
@@ -55,6 +55,9 @@ class ActivityService final : public QObject {
         void endAction(const ServiceActionTracker::ActionKey &actionKey, GenericId activityLocalId) const;
         void notifyRequestFailure(const ExitInfo &exitInfo, RequestNum requestNum, GenericId activityLocalId);
 
+        void handlePrivateLinkUrl(const ExitInfo &exitInfo, const QString &urlText, GenericId activityLocalId);
+        void handlePublicLinkUrl(const ExitInfo &exitInfo, const QString &urlText, GenericId activityLocalId);
+
         CommService &_commService;
         ServiceActionTracker &_serviceActionTracker;
         ServiceEventBus &_serviceEventBus;

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -82,6 +82,10 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
                                                          "SyncSelectorModel is owned by MainSidebarController.");
     (void) qmlRegisterUncreatableType<HomeController>("kDrive.UI", 1, 0, "HomeController",
                                                       "HomeController is owned by AppClientLinux.");
+    (void) qmlRegisterUncreatableType<ActivityListModel>("kDrive.UI", 1, 0, "ActivityListModel",
+                                                         "ActivityListModel is owned by ActivitiesController.");
+    (void) qmlRegisterUncreatableType<ActivitiesController>("kDrive.UI", 1, 0, "ActivitiesController",
+                                                            "ActivitiesController is owned by AppClientLinux.");
     (void) qmlRegisterUncreatableMetaObject(AppConstants::WebDrive::staticMetaObject, "kDrive.UI", 1, 0, "WebDrive",
                                             QStringLiteral("WebDrive only exposes enums."));
     _qmlEngine.setOutputWarningsToStandardError(false);
@@ -94,6 +98,7 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
             {QStringLiteral("appRouter"), QVariant::fromValue<QObject *>(&_appRouter)},
             {QStringLiteral("mainSidebarController"), QVariant::fromValue<QObject *>(&_mainSidebarController)},
             {QStringLiteral("homeController"), QVariant::fromValue<QObject *>(&_homeController)},
+            {QStringLiteral("activitiesController"), QVariant::fromValue<QObject *>(&_activitiesController)},
             {QStringLiteral("onboardingSessionManager"), QVariant::fromValue<QObject *>(&_onboardingSessionManager)},
             {QStringLiteral("systemTrayController"), QVariant::fromValue<QObject *>(&_systemTrayController)},
     });

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -23,6 +23,7 @@
 #include "app/cache/cachepipeline.h"
 #include "app/cache/mainselectionstore.h"
 #include "app/cache/parametersstore.h"
+#include "app/mainwindow/activitiescontroller.h"
 #include "app/mainwindow/homecontroller.h"
 #include "app/mainwindow/mainsidebarcontroller.h"
 #include "app/mainwindow/networkstatusobserver.h"
@@ -30,6 +31,7 @@
 #include "app/onboarding/onboardingsessionmanager.h"
 #include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
+#include "app/services/activityservice.h"
 #include "app/services/driveservice.h"
 #include "app/services/parametersservice.h"
 #include "app/services/sentryservice.h"
@@ -59,7 +61,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcAppClientLinux)
  * - IPC transport, server-signal dispatch, and the typed communication facade.
  * - AppCache, ActivityStore, ParametersStore, their live push pipeline, and the two-branch bootstrap population.
  * - Application services, action tracking, transient service events, and Sentry coordination.
- * - Main selection, navigation, sidebar, Home, and the ephemeral onboarding-session manager.
+ * - Main selection, navigation, sidebar, Home, Activities, and the ephemeral onboarding-session manager.
  * - Linux system tray, network observation, frameless-window integration, translations, and the QML runtime.
  *
  * Construction configures logging, translations, application identity, the system tray, signal connections, and the QML
@@ -127,6 +129,7 @@ class AppClientLinux : public QApplication {
         AppRouter _appRouter{this};
         ServiceActionTracker _serviceActionTracker{this};
         ServiceEventBus _serviceEventBus{this};
+        ActivityService _activityService{_serverCommService, _serviceActionTracker, _serviceEventBus, this};
         SentryService _sentryService{_parametersService, _appCache, _parametersStore, this};
         CachePopulator _cachePopulator{_serverCommService, _appCache, _parametersStore, this};
         UserService _userService{_serverCommService, _appCache, _serviceActionTracker, _serviceEventBus, this};
@@ -139,6 +142,8 @@ class AppClientLinux : public QApplication {
         NetworkStatusObserver _networkStatusObserver{this};
         HomeController _homeController{
                 _appCache, _mainSelectionStore, _syncService, _appRouter, _systemTrayController, _networkStatusObserver, this};
+        ActivitiesController _activitiesController{_activityStore,         _appCache,        _mainSelectionStore,
+                                                   _networkStatusObserver, _activityService, this};
         QTranslator _baseTranslator{this};
         QTranslator _localizedTranslator{this};
         QQmlApplicationEngine _qmlEngine;

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -28,6 +28,7 @@ IKShadowedWindow {
     id: mainWindow
 
     required property var appRouter
+    required property var activitiesController
     required property var homeController
     required property var mainSidebarController
     required property var onboardingSessionManager


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR câble la page Activités de la sidebar Linux v4 : elle ajoute `ActivitiesController`, le contrôleur QML qui pilote l'état et les actions de la page, ainsi que `ActivityService`, la façade qui exécute les actions web asynchrones (ouverture en ligne, copie du lien de partage). Elle s'appuie sur `ActivityListModel` introduit précédemment et l'enregistre dans le moteur QML.

## Changements
- Ajout de `app/services/activityservice.{h,cpp}` : façade de haut niveau pour les actions asynchrones déclenchées depuis une ligne d'activité. Elle résout les URL privées/publiques via `CommService`, ouvre le lien dans le navigateur ou le copie dans le presse-papiers, et suit les actions en cours via `ServiceActionTracker` pour éviter les doublons.
- Ajout de `app/mainwindow/activitiescontroller.{h,cpp}` : contrôleur QML qui possède la projection `ActivityListModel` de la synchronisation sélectionnée, résout l'état de présentation de la page (titre selon l'état hors ligne/en cours/en pause/sans activité), valide les chemins locaux avant d'ouvrir un fichier (résolution canonique, vérification que la cible reste dans la racine de synchronisation) et délègue les actions web à `ActivityService`.
- `ActivitiesController` expose `openLocal`, `openOnline`, `copyShareLink`, `requestFixErrors` et `requestFixAllErrors` en `Q_INVOKABLE` ; les deux dernières méthodes journalisent seulement pour l'instant, la résolution d'erreurs n'étant pas encore implémentée.
- Enregistrement de `ActivityListModel` et `ActivitiesController` comme types QML non créables dans `appclientlinux.cpp`, instanciation d'`ActivityService` et d'`ActivitiesController` dans `appclientlinux.h`, et exposition d'`activitiesController` au contexte QML racine ainsi qu'en propriété requise de `Main.qml`.
- Mise à jour de `CMakeLists.txt` pour inclure les nouveaux fichiers sources et documentation des deux nouveaux composants dans `src/gui4/linux/AGENTS.md`.
- Refactorings mineurs inclus dans la plage : simplification de la gestion des URL de lien privé/public dans `ActivityService` et partage des identifiants de ligne d'activité entre `ActivityListModel` et `ActivitiesController` (`ActivityListModel::activityRowId`).

## Notes
La résolution des erreurs (`requestFixErrors` / `requestFixAllErrors`) n'est pas encore implémentée ; ces méthodes journalisent l'intention pour l'instant et feront l'objet d'un travail de suivi.

</details>

---

## Summary
This PR wires up the Linux v4 sidebar Activities page: it adds `ActivitiesController`, the QML-facing controller driving the page's state and actions, and `ActivityService`, the facade that executes asynchronous web actions (open online, copy share link). It builds on the previously introduced `ActivityListModel` and registers everything in the QML engine.

## Changes
- Added `app/services/activityservice.{h,cpp}`: a high-level facade for asynchronous actions triggered from an activity row. It resolves private/public URLs through `CommService`, opens the link in the browser or copies it to the clipboard, and tracks in-flight actions via `ServiceActionTracker` to reject duplicates.
- Added `app/mainwindow/activitiescontroller.{h,cpp}`: a QML controller that owns the `ActivityListModel` projection for the selected synchronization, resolves page-level presentation state (title based on offline/in-progress/paused/no-activity states), validates local paths before opening a file (canonical resolution, checking the target stays within the sync root) and delegates web actions to `ActivityService`.
- `ActivitiesController` exposes `openLocal`, `openOnline`, `copyShareLink`, `requestFixErrors`, and `requestFixAllErrors` as `Q_INVOKABLE` methods; the last two currently only log intent since error resolution is not implemented yet.
- Registered `ActivityListModel` and `ActivitiesController` as uncreatable QML types in `appclientlinux.cpp`, instantiated `ActivityService` and `ActivitiesController` in `appclientlinux.h`, and exposed `activitiesController` on the root QML context plus as a required property on `Main.qml`.
- Updated `CMakeLists.txt` to include the new source files and documented both new components in `src/gui4/linux/AGENTS.md`.
- Minor refactors included in this range: simplified private/public link URL handling in `ActivityService`, and shared activity row identifiers between `ActivityListModel` and `ActivitiesController` (`ActivityListModel::activityRowId`).

## Notes
Error resolution (`requestFixErrors` / `requestFixAllErrors`) is not implemented yet; these methods currently only log intent and are planned as follow-up work.