### PR TITLE
fix(syncengine): avoid restarting sync on thumbnail updates

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/filesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/filesystemobserverworker.h
@@ -74,6 +74,7 @@ class FileSystemObserverWorker : public ISyncWorker {
         friend class TestOperationProcessor;
         friend class TestSituationGenerator;
         friend class TestSyncPal;
+        friend class TestIntegration;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -96,7 +96,7 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem, NodeId &removedNodeId
     bool hasChanged = false;
     // Update old parent's children lists if the item already exists
     if (item) {
-        hasChanged = *item == newItem;
+        hasChanged = *item != newItem;
         parentChanged = item->id() != rootFolderId() && item->parentId() != newItem.parentId();
         // Remove children from previous parent
         if (parentChanged) {
@@ -132,13 +132,13 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem, NodeId &removedNodeId
     }
     if ((parentChanged || hasChanged) && !isOrphan(item->id())) {
         startUpdate();
+        if (ParametersCache::isExtendedLogEnabled()) {
+            LOGW_DEBUG(Log::instance()->getLogger(), L"Item: " << Utility::formatSyncName(item->name()) << L" ("
+                                                               << CommonUtility::s2ws(item->id()) << L") updated at:"
+                                                               << item->lastModified());
+        }
     }
-
-    if (ParametersCache::isExtendedLogEnabled()) {
-        LOGW_DEBUG(Log::instance()->getLogger(), L"Item: " << Utility::formatSyncName(item->name()) << L" ("
-                                                           << CommonUtility::s2ws(item->id()) << L") updated at:"
-                                                           << item->lastModified());
-    }
+    
     return true;
 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -130,7 +130,7 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem, NodeId &removedNodeId
             newParent->addChild(item);
         }
     }
-    if ((parentChanged || hasChanged) && !isOrphan(item->id())) {
+    if (hasChanged || (parentChanged && !isOrphan(item->id()))) {
         startUpdate();
         if (ParametersCache::isExtendedLogEnabled()) {
             LOGW_DEBUG(Log::instance()->getLogger(), L"Item: " << Utility::formatSyncName(item->name()) << L" ("
@@ -138,7 +138,7 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem, NodeId &removedNodeId
                                                                << item->lastModified());
         }
     }
-    
+
     return true;
 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -93,8 +93,10 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem, NodeId &removedNodeId
 
     bool parentChanged = false;
     auto item = findItem(newItem.id());
+    bool hasChanged = false;
     // Update old parent's children lists if the item already exists
     if (item) {
+        hasChanged = *item == newItem;
         parentChanged = item->id() != rootFolderId() && item->parentId() != newItem.parentId();
         // Remove children from previous parent
         if (parentChanged) {
@@ -128,7 +130,7 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem, NodeId &removedNodeId
             newParent->addChild(item);
         }
     }
-    if (parentChanged || !isOrphan(item->id())) {
+    if ((parentChanged || hasChanged) && !isOrphan(item->id())) {
         startUpdate();
     }
 

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
@@ -64,7 +64,7 @@ class SnapshotItem {
         void setLastChangedSnapshotVersion(SnapshotRevision snapshotVersion);
         SnapshotRevision lastChangeRevision() const { return _lastChangeRevision; }
 
-        // Force update the last change revision to the next snapshot revision. 
+        // Force update the last change revision to the next snapshot revision.
         // This is useful when we want to mark an item as changed without actually changing its properties, for example when we
         // remove an item from tmp blacklist and want to make sure it is properly re-synced.
         void forceUpdateLastChangeRevision();
@@ -74,6 +74,7 @@ class SnapshotItem {
             _lastChangeRevision = _snapshotRevisionHandler ? _snapshotRevisionHandler->nextVersion() : 0;
         }
         SnapshotItem &operator=(const SnapshotItem &other);
+        bool operator==(const SnapshotItem &other) const = default;
 
         void copyExceptChildren(const SnapshotItem &other);
         void addChild(const std::shared_ptr<SnapshotItem> child);

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
@@ -74,7 +74,13 @@ class SnapshotItem {
             _lastChangeRevision = _snapshotRevisionHandler ? _snapshotRevisionHandler->nextVersion() : 0;
         }
         SnapshotItem &operator=(const SnapshotItem &other);
-        bool operator==(const SnapshotItem &other) const = default;
+        bool operator==(const SnapshotItem &other) const {
+            return _id == other._id && _parentId == other._parentId && _name == other._name &&
+                   _normalizedName == other._normalizedName && _createdAt == other._createdAt &&
+                   _lastModified == other._lastModified && _type == other._type && _size == other._size &&
+                   _isLink == other._isLink && _contentChecksum == other._contentChecksum && _canWrite == other._canWrite &&
+                   _canShare == other._canShare && _children == other._children;
+        }
 
         void copyExceptChildren(const SnapshotItem &other);
         void addChild(const std::shared_ptr<SnapshotItem> child);

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
@@ -79,7 +79,7 @@ class SnapshotItem {
                    _normalizedName == other._normalizedName && _createdAt == other._createdAt &&
                    _lastModified == other._lastModified && _type == other._type && _size == other._size &&
                    _isLink == other._isLink && _contentChecksum == other._contentChecksum && _canWrite == other._canWrite &&
-                   _canShare == other._canShare && _children == other._children;
+                   _canShare == other._canShare;
         }
 
         void copyExceptChildren(const SnapshotItem &other);

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -78,11 +78,11 @@ void TestIntegration::testLocalChanges() {
     CPPUNIT_ASSERT(!_syncPal->_localFSObserverWorker->_liveSnapshot.updated());
     SnapshotItem dummySnapshotItem(std::to_string(fileStat.inode), "1", filePath.filename(), fileStat.creationTime,
                                    fileStat.modificationTime, fileStat.nodeType, fileStat.size, false, true, true);
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(dummySnapshotItem);
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(dummySnapshotItem);
     CPPUNIT_ASSERT(!_syncPal->_localFSObserverWorker->_liveSnapshot.updated());
 
     dummySnapshotItem.setLastModified(dummySnapshotItem.lastModified() + 1);
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(dummySnapshotItem);
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(dummySnapshotItem);
     CPPUNIT_ASSERT(_syncPal->_localFSObserverWorker->_liveSnapshot.updated());
 
     // Generate a move operation.

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -74,6 +74,17 @@ void TestIntegration::testLocalChanges() {
     CPPUNIT_ASSERT_LESS(remoteTestFileInfo.size, prevRemoteTestFileInfo.size);
     logStep("test edit local file");
 
+    // Generate a dummy edit in local snapshot without changes
+    CPPUNIT_ASSERT(!_syncPal->_localFSObserverWorker->_liveSnapshot.updated());
+    SnapshotItem dummySnapshotItem(std::to_string(fileStat.inode), "1", filePath.filename(), fileStat.creationTime,
+                                   fileStat.modificationTime, fileStat.nodeType, fileStat.size, false, true, true);
+    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(dummySnapshotItem);
+    CPPUNIT_ASSERT(!_syncPal->_localFSObserverWorker->_liveSnapshot.updated());
+
+    dummySnapshotItem.setLastModified(dummySnapshotItem.lastModified() + 1);
+    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(dummySnapshotItem);
+    CPPUNIT_ASSERT(_syncPal->_localFSObserverWorker->_liveSnapshot.updated());
+
     // Generate a move operation.
     const SyncName newName = Str("testFileLocal_renamed");
     const std::filesystem::path destinationPath = subDirPath / newName;


### PR DESCRIPTION
Fixes a snapshot comparison bug in the file system observer so thumbnail-only updates are no longer treated as real file changes.

Also adds integration coverage to lock in the regression.