### PR TITLE
fix(test-integration): Adapts the logic of testNegativeModificationTime to recent changes in computefsoperationworker.cpp

### DIFF
--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -594,6 +594,7 @@ void TestIntegration::testNegativeModificationTime() {
         bool found = false;
         IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
         (void) IoHelper::setFileDates(filepath, fileStat.creationTime, timeInput, false);
+        const SyncTime beforeComputeFsOperationsTime = CommonUtility::getCurrentSyncTime();
         waitForSyncToBeIdle(std::source_location::current());
 
         DbNode dbNode;
@@ -601,7 +602,7 @@ void TestIntegration::testNegativeModificationTime() {
 
         GetFileInfoJob fileInfoJob(_driveDbId, *dbNode.nodeIdRemote());
         (void) fileInfoJob.runSynchronously();
-        CPPUNIT_ASSERT_EQUAL(timeInput, fileInfoJob.modificationTime());
+        CPPUNIT_ASSERT_GREATEREQUAL(beforeComputeFsOperationsTime, fileInfoJob.modificationTime());
     }
     waitForSyncToBeIdle(std::source_location::current());
     {
@@ -639,6 +640,7 @@ void TestIntegration::testNegativeModificationTime() {
         bool found = false;
         IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
         (void) IoHelper::setFileDates(filepath, timeInput, timeInput, false);
+        const SyncTime beforeComputeFsOperationsTime = CommonUtility::getCurrentSyncTime();
         waitForSyncToBeIdle(std::source_location::current());
 
         DbNode dbNode;
@@ -650,10 +652,10 @@ void TestIntegration::testNegativeModificationTime() {
         // Linux: Creation date cannot be changed.
         CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, fileInfoJob.creationTime());
 #else
-        // Setting both a negative creation and modification date is accepted.
+        // Setting a negative creation date is accepted.
         CPPUNIT_ASSERT_EQUAL(timeInput, fileInfoJob.creationTime());
 #endif
-        CPPUNIT_ASSERT_EQUAL(timeInput, fileInfoJob.modificationTime());
+        CPPUNIT_ASSERT_GREATEREQUAL(beforeComputeFsOperationsTime, fileInfoJob.modificationTime());
     }
 
     logStep("testNegativeModificationTime");

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -593,8 +593,8 @@ void TestIntegration::testNegativeModificationTime() {
         FileStat fileStat;
         bool found = false;
         IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
-        (void) IoHelper::setFileDates(filepath, fileStat.creationTime, timeInput, false);
         const SyncTime beforeComputeFsOperationsTime = CommonUtility::getCurrentSyncTime();
+        (void) IoHelper::setFileDates(filepath, fileStat.creationTime, timeInput, false);
         waitForSyncToBeIdle(std::source_location::current());
 
         DbNode dbNode;
@@ -639,8 +639,8 @@ void TestIntegration::testNegativeModificationTime() {
         FileStat fileStat;
         bool found = false;
         IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
-        (void) IoHelper::setFileDates(filepath, timeInput, timeInput, false);
         const SyncTime beforeComputeFsOperationsTime = CommonUtility::getCurrentSyncTime();
+        (void) IoHelper::setFileDates(filepath, timeInput, timeInput, false);
         waitForSyncToBeIdle(std::source_location::current());
 
         DbNode dbNode;


### PR DESCRIPTION
Adapts the logic of the extended test `testNegativeModificationTime` to recent changes in `computefsoperationworker.cpp`, i.e., https://github.com/Infomaniak/desktop-kDrive/pull/2187.