### PR TITLE
fix(test-utility): Handles the special configuration of the Linux Max CI runner used for the extended tests workflow when executing the test testFileSystemInfo

### DIFF
--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -74,8 +74,8 @@ jobs:
             & "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\Launch-VsDevShell.ps1" `
             -Arch amd64 `
             -HostArch amd64 `
-            -SkipAutomaticLocation      
-            
+            -SkipAutomaticLocation
+
             ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT_THUMBPRINT -ci -unitTests
         shell: powershell
 
@@ -185,6 +185,7 @@ jobs:
     runs-on: [ self-hosted, Linux, X64, desktop-kdrive ]
     env:
       KDRIVE_TEST_CI_8MO_PARTITION_PATH: ${{ vars.KDRIVE_TEST_CI_8MO_PARTITION_PATH_LINUX }}
+      KDRIVE_LINUX_CI_EXTENDED_TEST_MOUNT_POINT: ${{ vars.KDRIVE_LINUX_CI_EXTENDED_TEST_MOUNT_POINT }}
       QT_QPA_PLATFORM: "offscreen"
     steps:
       - name: Checkout the code

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -989,8 +989,15 @@ void TestUtility::testFileSystemInfo() {
     // /!\ Docker containers use overlayfs
     CPPUNIT_ASSERT(CommonUtility::fileSystemInfo("/", fsType, mountPoint) &&
                    (fsType == fsType::EXT234 || fsType == "OVERLAYFS") && mountPoint == "/");
+
     CPPUNIT_ASSERT(CommonUtility::fileSystemInfo(std::filesystem::weakly_canonical("."), fsType, mountPoint) &&
-                   (fsType == fsType::EXT234 || fsType == "OVERLAYFS") && mountPoint == "/");
+                   (fsType == fsType::EXT234 || fsType == "OVERLAYFS"));
+    CPPUNIT_ASSERT(
+            mountPoint == "/" ||
+            (testhelpers::isRunningOnCI() &&
+             mountPoint ==
+                     "/mnt/data")); // Linux Max CI special setup when running the extended tests workflow (cf. Linux MAX conf).
+
     // TODO: implement these tests on the CI.
     // External disk.
     /*

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -992,11 +992,10 @@ void TestUtility::testFileSystemInfo() {
 
     CPPUNIT_ASSERT(CommonUtility::fileSystemInfo(std::filesystem::weakly_canonical("."), fsType, mountPoint) &&
                    (fsType == fsType::EXT234 || fsType == "OVERLAYFS"));
-    CPPUNIT_ASSERT(
-            mountPoint == "/" ||
-            (testhelpers::isRunningOnCI() &&
-             mountPoint ==
-                     "/mnt/data")); // Linux Max CI special setup when running the extended tests workflow (cf. Linux MAX conf).
+
+    const bool mandatory = false;
+    const auto extendedTestsMountPoint = testhelpers::loadEnvVariable("KDRIVE_LINUX_CI_EXTENDED_TEST_MOUNT_POINT", mandatory);
+    CPPUNIT_ASSERT(mountPoint == "/" || (!extendedTestsMountPoint.empty() && mountPoint == extendedTestsMountPoint));
 
     // TODO: implement these tests on the CI.
     // External disk.


### PR DESCRIPTION
These changes prevent the failure of the test `TestUtility::testFileSystemInfo` caused by the specific configuration of the CI Linux runner used to run extended tests.