### PR TITLE
fix(test-update-tree-worker): Ensures that node1 and node2 are deterministically used as parent and child in testResetNodesRecursiveDelete

### DIFF
--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -1326,17 +1326,17 @@ void TestUpdateTreeWorker::testResetNodesRecursiveDelete() {
                                              [](const auto &pair) { return pair.second->name() == Str("node1"); });
     CPPUNIT_ASSERT(parent != _remoteUpdateTree->_validNodes.end());
 
-    const auto children = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
-                                               [](const auto &pair) { return pair.second->name() == Str("node2"); });
-    CPPUNIT_ASSERT(children != _remoteUpdateTree->_validNodes.end());
+    const auto child = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
+                                            [](const auto &pair) { return pair.second->name() == Str("node2"); });
+    CPPUNIT_ASSERT(child != _remoteUpdateTree->_validNodes.end());
 
 
-    CPPUNIT_ASSERT(children->second->setParentNode(parent->second));
+    CPPUNIT_ASSERT(child->second->setParentNode(parent->second));
     parent->second->setStatus(NodeStatus::ToDelete);
-    CPPUNIT_ASSERT(parent->second->insertChild(children->second));
+    CPPUNIT_ASSERT(parent->second->insertChild(child->second));
 
     const auto parentId = *parent->second->id();
-    const auto childrenId = *children->second->id();
+    const auto childrenId = *child->second->id();
     CPPUNIT_ASSERT(_remoteUpdateTreeWorker->resetNodes());
 
     CPPUNIT_ASSERT(!_remoteUpdateTree->exists(parentId));

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -1322,14 +1322,16 @@ void TestUpdateTreeWorker::testResetNodesRecursiveDelete() {
     _remoteUpdateTree->insertNode(node2);
 
 
-    const auto parent = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
-                                             [](const auto &pair) { return pair.second->name() == Str("node1"); });
+    auto parent = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
+                                       [](const auto &pair) { return pair.second->name() == Str("node1"); });
     CPPUNIT_ASSERT(parent != _remoteUpdateTree->_validNodes.end());
 
-    const auto child = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
-                                            [](const auto &pair) { return pair.second->name() == Str("node2"); });
+    auto child = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
+                                      [](const auto &pair) { return pair.second->name() == Str("node2"); });
     CPPUNIT_ASSERT(child != _remoteUpdateTree->_validNodes.end());
 
+    // Make sure the parent will be listed before its child.
+    if (std::distance(child, parent) < 0) std::swap(child, parent);
 
     CPPUNIT_ASSERT(child->second->setParentNode(parent->second));
     parent->second->setStatus(NodeStatus::ToDelete);
@@ -1337,6 +1339,10 @@ void TestUpdateTreeWorker::testResetNodesRecursiveDelete() {
 
     const auto parentId = *parent->second->id();
     const auto childrenId = *child->second->id();
+
+    CPPUNIT_ASSERT(_remoteUpdateTree->exists(parentId));
+    CPPUNIT_ASSERT(_remoteUpdateTree->exists(childrenId));
+
     CPPUNIT_ASSERT(_remoteUpdateTreeWorker->resetNodes());
 
     CPPUNIT_ASSERT(!_remoteUpdateTree->exists(parentId));

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -1322,19 +1322,21 @@ void TestUpdateTreeWorker::testResetNodesRecursiveDelete() {
     _remoteUpdateTree->insertNode(node2);
 
 
-    auto parent = _remoteUpdateTree->_validNodes.begin();
-    if (parent->second == _remoteUpdateTree->rootNode()) ++parent;
+    const auto parent = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
+                                             [](const auto &pair) { return pair.second->name() == Str("node1"); });
+    CPPUNIT_ASSERT(parent != _remoteUpdateTree->_validNodes.end());
 
-    auto children = parent++;
-    if (children->second == _remoteUpdateTree->rootNode()) ++children;
+    const auto children = std::ranges::find_if(_remoteUpdateTree->_validNodes.begin(), _remoteUpdateTree->_validNodes.end(),
+                                               [](const auto &pair) { return pair.second->name() == Str("node2"); });
+    CPPUNIT_ASSERT(children != _remoteUpdateTree->_validNodes.end());
+
 
     CPPUNIT_ASSERT(children->second->setParentNode(parent->second));
-
     parent->second->setStatus(NodeStatus::ToDelete);
     CPPUNIT_ASSERT(parent->second->insertChild(children->second));
 
-    auto parentId = *parent->second->id();
-    auto childrenId = *children->second->id();
+    const auto parentId = *parent->second->id();
+    const auto childrenId = *children->second->id();
     CPPUNIT_ASSERT(_remoteUpdateTreeWorker->resetNodes());
 
     CPPUNIT_ASSERT(!_remoteUpdateTree->exists(parentId));


### PR DESCRIPTION
These changes ensure that we retrieves nodes from the update tree in an obvious deterministic way before calling `resetNodes` in the test `testResetNodesRecursiveDelete`.

This avoids the possible unwanted scenario during which the first of the two nodes is the update tree root node. 