### PR TITLE
feat(recovery-updater): enforce strict TLS verification and load system CAs

### DIFF
--- a/src/manualupdater/httpdownloader.cpp
+++ b/src/manualupdater/httpdownloader.cpp
@@ -48,7 +48,7 @@ Poco::Net::Context::Ptr createSslContext() {
 
     if (!TrustStoreHelper::loadSystemCAs(context->sslContext())) {
         LOG_ERROR(Log::instance()->getLogger(), "Failed to load system CAs, peer verification may fail");
-        throw std::runtime_error("Failed to load system certificate store, cannot verify server identity");
+        throw HttpDownloader::TrustStoreError("Failed to load system certificate store, cannot verify server identity");
     }
     return context;
 }

--- a/src/manualupdater/httpdownloader.cpp
+++ b/src/manualupdater/httpdownloader.cpp
@@ -20,6 +20,7 @@
 #include "libcommon/utility/urlhelper.h"
 #include "libcommonserver/log/log.h"
 #include "libcommonserver/utility/jsonparserutility.h"
+#include "libcommonserver/utility/truststorehelper.h"
 
 #include <Poco/JSON/Parser.h>
 #include <Poco/Net/Context.h>
@@ -41,8 +42,14 @@ namespace {
 
 Poco::Net::Context::Ptr createSslContext() {
     Poco::Net::Context::Ptr context =
-            new Poco::Net::Context(Poco::Net::Context::TLS_CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
+            new Poco::Net::Context(Poco::Net::Context::TLS_CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_STRICT, 9, false);
     context->requireMinimumProtocol(Poco::Net::Context::PROTO_TLSV1_2);
+
+
+    if (!TrustStoreHelper::loadSystemCAs(context->sslContext())) {
+        LOG_ERROR(Log::instance()->getLogger(), "Failed to load system CAs, peer verification may fail");
+        throw std::runtime_error("Failed to load system certificate store, cannot verify server identity");
+    }
     return context;
 }
 

--- a/src/manualupdater/httpdownloader.h
+++ b/src/manualupdater/httpdownloader.h
@@ -2,13 +2,18 @@
 
 #include "libcommon/utility/types.h"
 
-#include <string>
 #include <Poco/Net/HTTPResponse.h>
+#include <stdexcept>
+#include <string>
 
 namespace KDC {
 
 class HttpDownloader {
     public:
+        struct TrustStoreError : std::runtime_error {
+                using std::runtime_error::runtime_error;
+        };
+
         struct Result {
                 bool success = false;
                 uint16_t statusCode = 0;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Le téléchargeur HTTP du module de mise à jour manuelle désactivait la vérification des certificats TLS (`VERIFY_NONE`), ce qui le rendait vulnérable aux attaques de type homme du milieu. Cette PR active la vérification stricte (`VERIFY_STRICT`) et charge le magasin de certificats natif de la plateforme via `TrustStoreHelper::loadSystemCAs`.

## Changements
- Remplacement de `VERIFY_NONE` par `VERIFY_STRICT` avec une profondeur de chaîne de 9 et `loadDefaultCAs` désactivé dans `createSslContext()`
- Ajout de l'appel à `TrustStoreHelper::loadSystemCAs()` pour charger le magasin de confiance natif (trousseau macOS, magasin de certificats Windows, ca-certificates Linux) dans le contexte OpenSSL sous-jacent
- Ajout de l'inclusion de `libcommonserver/utility/truststorehelper.h`
- En cas d'échec du chargement des CA, une erreur est journalisée et une exception `std::runtime_error` est levée, qui est ensuite interceptée par les blocs `try/catch` existants dans `get()` et `downloadFile()`

## Détails techniques
Le module `manualupdater` ne peut pas s'appuyer sur le `loadDefaultCAs` d'OpenSSL car la version embarquée d'OpenSSL n'inclut pas de bundle de CA. L'approche adoptée est identique à celle déjà utilisée dans `src/libsyncengine/jobs/network/abstractnetworkjob.cpp`. En cas d'échec de `loadSystemCAs`, une exception est levée plutôt que de continuer avec un contexte non sécurisé. Les appelants (`get()` et `downloadFile()`) propagent déjà l'erreur via `result.error`.

## Tests
Vérifier que le téléchargement de mise à jour fonctionne sur macOS, Windows et Linux avec un certificat serveur valide. Vérifier que la connexion échoue avec un message d'erreur approprié si le magasin de certificats système est indisponible.

</details>

---

## Summary
The manual updater HTTP downloader disabled TLS certificate verification (`VERIFY_NONE`), making it vulnerable to man-in-the-middle attacks. This PR enables strict verification (`VERIFY_STRICT`) and loads the platform-native trust store via `TrustStoreHelper::loadSystemCAs`.

## Changes
- Replaced `VERIFY_NONE` with `VERIFY_STRICT` (chain depth 9, `loadDefaultCAs` disabled) in `createSslContext()`
- Added `TrustStoreHelper::loadSystemCAs()` call to load the native trust store (macOS keychain, Windows certificate store, Linux ca-certificates) into the underlying OpenSSL SSL_CTX
- Added include for `libcommonserver/utility/truststorehelper.h`
- On CA load failure, logs an error and throws `std::runtime_error`, which is caught by the existing `try/catch` blocks in `get()` and `downloadFile()`

## Technical Details
The `manualupdater` cannot rely on OpenSSL's `loadDefaultCAs` because the bundled OpenSSL build does not ship a CA bundle. The approach mirrors the existing pattern in `src/libsyncengine/jobs/network/abstractnetworkjob.cpp`. If `loadSystemCAs` fails, the function throws rather than continuing with an unsecured context. The callers (`get()` and `downloadFile()`) already propagate the exception via `result.error`.

## Testing
Verify that update downloads work on macOS, Windows, and Linux with a valid server certificate. Verify that the connection fails with an appropriate error message when the system certificate store is unavailable.
