### PR TITLE
feat(recovery-updater): implement SHA256 checksum verification for downloaded files

### DIFF
--- a/src/manualupdater/httpdownloader.cpp
+++ b/src/manualupdater/httpdownloader.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<Poco::Net::HTTPSClientSession> createHttpsSession(const std::str
 
 } // namespace
 
-HttpDownloader::Result HttpDownloader::get(const std::string &url) {
+HttpDownloader::Result HttpDownloader::get(const std::string &url, const std::string &accept) {
     Result result;
     try {
         std::string path;
@@ -76,7 +76,7 @@ HttpDownloader::Result HttpDownloader::get(const std::string &url) {
 
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, path, Poco::Net::HTTPMessage::HTTP_1_1);
         request.set("User-Agent", CommonUtility::userAgentString());
-        request.set("Accept", "application/json");
+        request.set("Accept", accept);
 
         (void) session->sendRequest(request);
 

--- a/src/manualupdater/httpdownloader.h
+++ b/src/manualupdater/httpdownloader.h
@@ -21,7 +21,7 @@ class HttpDownloader {
                 std::string error;
         };
 
-        static Result get(const std::string &url);
+        static Result get(const std::string &url, const std::string &accept = "application/json");
         static Result downloadFile(const std::string &url, const SyncPath &destPath, int64_t timeoutSeconds = 1800);
         static bool fetchAppVersion(DistributionChannel channel, const std::string &appId, VersionInfo &outVersionInfo,
                                     std::string &outError);

--- a/src/manualupdater/updater/abstractosupdater.cpp
+++ b/src/manualupdater/updater/abstractosupdater.cpp
@@ -31,9 +31,13 @@ bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const
                                            QString &outMessage) {
     // 1. Try fetching the .sha256 sidecar file.
     std::string expectedChecksum;
-    const std::string sha256Url = fileUrl + ".sha256";
+    // Insert the suffix before any query string or fragment so signed/CDN URLs keep their sidecar resolvable.
+    const auto suffixPos = fileUrl.find_first_of("?#");
+    const std::string sha256Url =
+            fileUrl.substr(0, suffixPos) + ".sha256" +
+            (suffixPos == std::string::npos ? std::string{} : fileUrl.substr(suffixPos));
 
-    if (const auto result = HttpDownloader::get(sha256Url); result.success && !result.body.empty()) {
+    if (const auto result = HttpDownloader::get(sha256Url, "text/plain, */*"); result.success && !result.body.empty()) {
         // The file contains either "hash" or "hash  filename" — take the first token.
         std::istringstream iss(result.body);
         iss >> expectedChecksum;

--- a/src/manualupdater/updater/abstractosupdater.cpp
+++ b/src/manualupdater/updater/abstractosupdater.cpp
@@ -2,11 +2,15 @@
 #include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/log/log.h"
 #include "libcommon/utility/utility.h"
+#include "manualupdater/httpdownloader.h"
 
 #include <QObject>
 
 #include <fstream>
+#include <sstream>
 #include <array>
+#include <algorithm>
+#include <cctype>
 #include <Poco/SHA2Engine.h>
 
 #if defined(KD_MACOS)
@@ -23,11 +27,52 @@ std::unique_ptr<AbstractOsUpdater> createOsUpdater() {
     return std::make_unique<OSUpdater>();
 }
 
-bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const SyncPath &filepath, QString &outMessage) {
-    (void) versionInfo;
-    (void) filepath;
-    (void) outMessage;
-    return true; // placeholder for a future PR
+bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const std::string &fileUrl, const SyncPath &filepath,
+                                           QString &outMessage) {
+    // 1. Try fetching the .sha256 sidecar file.
+    std::string expectedChecksum;
+    const std::string sha256Url = fileUrl + ".sha256";
+
+    if (const auto result = HttpDownloader::get(sha256Url); result.success && !result.body.empty()) {
+        // The file contains either "hash" or "hash  filename" — take the first token.
+        std::istringstream iss(result.body);
+        iss >> expectedChecksum;
+    }
+
+    // 2. Fall back to the API-provided checksum.
+    if (expectedChecksum.empty()) {
+        expectedChecksum = versionInfo.checksum;
+    }
+
+    // 3. If still empty, skip verification.
+    if (expectedChecksum.empty()) {
+        LOGW_INFO(Log::instance()->getLogger(),
+                  L"No checksum available for verification, skipping: " << CommonUtility::s2ws(fileUrl));
+        return true;
+    }
+
+    // 4. Compute the local file's SHA-256.
+    std::string actualChecksum;
+    if (!computeFileChecksum(filepath, actualChecksum)) {
+        outMessage = QObject::tr("Failed to compute file checksum.");
+        return false;
+    }
+
+    // 5. Compare case-insensitively.
+    if (actualChecksum.size() != expectedChecksum.size() ||
+        !std::equal(actualChecksum.begin(), actualChecksum.end(), expectedChecksum.begin(), [](char a, char b) {
+            return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b));
+        })) {
+        outMessage = QObject::tr("Checksum verification failed. The file may be corrupted.");
+        LOGW_ERROR(Log::instance()->getLogger(), L"Checksum mismatch for "
+                                                         << CommonUtility::s2ws(filepath.string()) << L" — expected: "
+                                                         << CommonUtility::s2ws(expectedChecksum) << L" actual: "
+                                                         << CommonUtility::s2ws(actualChecksum));
+        return false;
+    }
+
+    LOGW_INFO(Log::instance()->getLogger(), L"Checksum verified for " << CommonUtility::s2ws(filepath.string()));
+    return true;
 }
 
 bool AbstractOsUpdater::computeFileChecksum(const SyncPath &filepath, std::string &outChecksum) {

--- a/src/manualupdater/updater/abstractosupdater.cpp
+++ b/src/manualupdater/updater/abstractosupdater.cpp
@@ -39,11 +39,12 @@ bool AbstractOsUpdater::verifyFileChecksum(const std::string &fileUrl, const Syn
         iss >> expectedChecksum;
     }
 
-    // 2. If still empty, skip verification.
+    // 2. If still empty, abort verification.
     if (expectedChecksum.empty()) {
-        LOGW_INFO(Log::instance()->getLogger(),
-                  L"No checksum available for verification, skipping: " << CommonUtility::s2ws(fileUrl));
-        return true;
+        outMessage = QObject::tr("No checksum available for verification.");
+        LOGW_WARN(Log::instance()->getLogger(),
+                  L"No checksum available for verification, aborting: " << CommonUtility::s2ws(fileUrl));
+        return false;
     }
 
     // 3. Compute the local file's SHA-256.

--- a/src/manualupdater/updater/abstractosupdater.cpp
+++ b/src/manualupdater/updater/abstractosupdater.cpp
@@ -9,8 +9,6 @@
 #include <fstream>
 #include <sstream>
 #include <array>
-#include <algorithm>
-#include <cctype>
 #include <Poco/SHA2Engine.h>
 
 #if defined(KD_MACOS)
@@ -33,9 +31,8 @@ bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const
     std::string expectedChecksum;
     // Insert the suffix before any query string or fragment so signed/CDN URLs keep their sidecar resolvable.
     const auto suffixPos = fileUrl.find_first_of("?#");
-    const std::string sha256Url =
-            fileUrl.substr(0, suffixPos) + ".sha256" +
-            (suffixPos == std::string::npos ? std::string{} : fileUrl.substr(suffixPos));
+    const std::string sha256Url = fileUrl.substr(0, suffixPos) + ".sha256" +
+                                  (suffixPos == std::string::npos ? std::string{} : fileUrl.substr(suffixPos));
 
     if (const auto result = HttpDownloader::get(sha256Url, "text/plain, */*"); result.success && !result.body.empty()) {
         // The file contains either "hash" or "hash  filename" — take the first token.
@@ -63,10 +60,9 @@ bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const
     }
 
     // 5. Compare case-insensitively.
-    if (actualChecksum.size() != expectedChecksum.size() ||
-        !std::equal(actualChecksum.begin(), actualChecksum.end(), expectedChecksum.begin(), [](char a, char b) {
-            return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b));
-        })) {
+    const std::string normalizedActualChecksum = CommonUtility::trim(CommonUtility::toLower(actualChecksum));
+    const std::string normalizedExpectedChecksum = CommonUtility::trim(CommonUtility::toLower(expectedChecksum));
+    if (normalizedActualChecksum != normalizedExpectedChecksum) {
         outMessage = QObject::tr("Checksum verification failed. The file may be corrupted.");
         LOGW_ERROR(Log::instance()->getLogger(), L"Checksum mismatch for "
                                                          << CommonUtility::s2ws(filepath.string()) << L" — expected: "

--- a/src/manualupdater/updater/abstractosupdater.cpp
+++ b/src/manualupdater/updater/abstractosupdater.cpp
@@ -25,8 +25,7 @@ std::unique_ptr<AbstractOsUpdater> createOsUpdater() {
     return std::make_unique<OSUpdater>();
 }
 
-bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const std::string &fileUrl, const SyncPath &filepath,
-                                           QString &outMessage) {
+bool AbstractOsUpdater::verifyFileChecksum(const std::string &fileUrl, const SyncPath &filepath, QString &outMessage) {
     // 1. Try fetching the .sha256 sidecar file.
     std::string expectedChecksum;
     // Insert the suffix before any query string or fragment so signed/CDN URLs keep their sidecar resolvable.
@@ -40,26 +39,21 @@ bool AbstractOsUpdater::verifyFileChecksum(const VersionInfo &versionInfo, const
         iss >> expectedChecksum;
     }
 
-    // 2. Fall back to the API-provided checksum.
-    if (expectedChecksum.empty()) {
-        expectedChecksum = versionInfo.checksum;
-    }
-
-    // 3. If still empty, skip verification.
+    // 2. If still empty, skip verification.
     if (expectedChecksum.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
                   L"No checksum available for verification, skipping: " << CommonUtility::s2ws(fileUrl));
         return true;
     }
 
-    // 4. Compute the local file's SHA-256.
+    // 3. Compute the local file's SHA-256.
     std::string actualChecksum;
     if (!computeFileChecksum(filepath, actualChecksum)) {
         outMessage = QObject::tr("Failed to compute file checksum.");
         return false;
     }
 
-    // 5. Compare case-insensitively.
+    // 4. Compare case-insensitively.
     const std::string normalizedActualChecksum = CommonUtility::trim(CommonUtility::toLower(actualChecksum));
     const std::string normalizedExpectedChecksum = CommonUtility::trim(CommonUtility::toLower(expectedChecksum));
     if (normalizedActualChecksum != normalizedExpectedChecksum) {

--- a/src/manualupdater/updater/abstractosupdater.h
+++ b/src/manualupdater/updater/abstractosupdater.h
@@ -33,8 +33,7 @@ class AbstractOsUpdater {
                              const std::function<void(InstallStep, const QString &)> &progressCallback, QString &outMessage) = 0;
 
     protected:
-        [[nodiscard]] static bool verifyFileChecksum(const VersionInfo &versionInfo, const std::string &fileUrl,
-                                                     const SyncPath &filepath, QString &outMessage);
+        [[nodiscard]] static bool verifyFileChecksum(const std::string &fileUrl, const SyncPath &filepath, QString &outMessage);
         [[nodiscard]] static bool computeFileChecksum(const SyncPath &filepath, std::string &outChecksum);
         [[nodiscard]] static bool createDownloadDirectory(SyncPath &outDir);
 };

--- a/src/manualupdater/updater/abstractosupdater.h
+++ b/src/manualupdater/updater/abstractosupdater.h
@@ -33,8 +33,8 @@ class AbstractOsUpdater {
                              const std::function<void(InstallStep, const QString &)> &progressCallback, QString &outMessage) = 0;
 
     protected:
-        [[nodiscard]] static bool verifyFileChecksum(const VersionInfo &versionInfo, const SyncPath &filepath,
-                                                     QString &outMessage);
+        [[nodiscard]] static bool verifyFileChecksum(const VersionInfo &versionInfo, const std::string &fileUrl,
+                                                     const SyncPath &filepath, QString &outMessage);
         [[nodiscard]] static bool computeFileChecksum(const SyncPath &filepath, std::string &outChecksum);
         [[nodiscard]] static bool createDownloadDirectory(SyncPath &outDir);
 };

--- a/src/manualupdater/updater/osupdater_linux.cpp
+++ b/src/manualupdater/updater/osupdater_linux.cpp
@@ -62,7 +62,7 @@ bool OSUpdater::install(const VersionInfo &versionInfo, const std::function<void
     }
 
     progressCallback(InstallStep::Verifying, QObject::tr("Verifying file integrity..."));
-    if (!verifyFileChecksum(versionInfo, urlStr, destPath, outMessage)) {
+    if (!verifyFileChecksum(urlStr, destPath, outMessage)) {
         return false;
     }
 

--- a/src/manualupdater/updater/osupdater_linux.cpp
+++ b/src/manualupdater/updater/osupdater_linux.cpp
@@ -62,7 +62,7 @@ bool OSUpdater::install(const VersionInfo &versionInfo, const std::function<void
     }
 
     progressCallback(InstallStep::Verifying, QObject::tr("Verifying file integrity..."));
-    if (!versionInfo.checksum.empty() && !verifyFileChecksum(versionInfo, destPath, outMessage)) {
+    if (!verifyFileChecksum(versionInfo, urlStr, destPath, outMessage)) {
         return false;
     }
 

--- a/src/manualupdater/updater/osupdater_mac.cpp
+++ b/src/manualupdater/updater/osupdater_mac.cpp
@@ -89,7 +89,7 @@ bool OSUpdater::install(const VersionInfo &versionInfo, const std::function<void
     }
 
     progressCallback(InstallStep::Verifying, QObject::tr("Verifying file integrity..."));
-    if (!versionInfo.checksum.empty() && !verifyFileChecksum(versionInfo, SyncPath(pkgPath.toStdString()), outMessage)) {
+    if (!verifyFileChecksum(versionInfo, pkgUrl.toStdString(), SyncPath(pkgPath.toStdString()), outMessage)) {
         return false;
     }
 

--- a/src/manualupdater/updater/osupdater_mac.cpp
+++ b/src/manualupdater/updater/osupdater_mac.cpp
@@ -89,7 +89,7 @@ bool OSUpdater::install(const VersionInfo &versionInfo, const std::function<void
     }
 
     progressCallback(InstallStep::Verifying, QObject::tr("Verifying file integrity..."));
-    if (!verifyFileChecksum(versionInfo, pkgUrl.toStdString(), SyncPath(pkgPath.toStdString()), outMessage)) {
+    if (!verifyFileChecksum(pkgUrl.toStdString(), SyncPath(pkgPath.toStdString()), outMessage)) {
         return false;
     }
 

--- a/src/manualupdater/updater/osupdater_win.cpp
+++ b/src/manualupdater/updater/osupdater_win.cpp
@@ -55,7 +55,7 @@ bool OSUpdater::install(const VersionInfo &versionInfo, const std::function<void
     }
 
     progressCallback(InstallStep::Verifying, QObject::tr("Verifying file integrity..."));
-    if (!versionInfo.checksum.empty() && !verifyFileChecksum(versionInfo, filepath, outMessage)) {
+    if (!verifyFileChecksum(versionInfo, versionInfo.downloadUrl, filepath, outMessage)) {
         return false;
     }
 

--- a/src/manualupdater/updater/osupdater_win.cpp
+++ b/src/manualupdater/updater/osupdater_win.cpp
@@ -55,7 +55,7 @@ bool OSUpdater::install(const VersionInfo &versionInfo, const std::function<void
     }
 
     progressCallback(InstallStep::Verifying, QObject::tr("Verifying file integrity..."));
-    if (!verifyFileChecksum(versionInfo, versionInfo.downloadUrl, filepath, outMessage)) {
+    if (!verifyFileChecksum(versionInfo.downloadUrl, filepath, outMessage)) {
         return false;
     }
 


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR implémente la vérification de l'intégrité des fichiers téléchargés par le recovery updater en comparant le hash SHA-256 calculé localement avec un hash attendu. Le hash attendu est récupéré depuis un fichier sidecar `.sha256` (en ajoutant l'extension `.sha256` à l'URL de téléchargement). La vérification est ignorée si aucun checksum n'est disponible.

## Changements
- Remplacé le placeholder `verifyFileChecksum` dans `AbstractOsUpdater` par une implémentation fonctionnelle qui télécharge et parse le fichier `.sha256` sidecar
- Ajout d'un paramètre `fileUrl` à `verifyFileChecksum` pour construire l'URL `.sha256`, nécessaire car sur macOS l'URL de téléchargement du `.pkg` est extraite de l'appcast XML et diffère de `versionInfo.downloadUrl`
- Supprimé la garde `if (!versionInfo.checksum.empty() && ...)` sur les trois plateformes (macOS, Linux, Windows) - la vérification est désormais toujours appelée et s'auto-skip si aucun checksum n'est disponible
- Le hash attendu provient uniquement du fichier `.sha256` sidecar, et la vérification est ignorée si celui-ci n'est pas disponible ou vide

## Détails techniques
- Le fichier `.sha256` peut contenir soit juste le hash (`hash`) soit le hash suivi du nom de fichier (`hash  filename`) - seul le premier token est extrait via `std::istringstream`
- La comparaison est insensible à la casse pour gérer les différences de formatage entre hex majuscules/minuscules
- Le parsing du fichier `.sha256` utilise `HttpDownloader::get()` qui est un GET simple avec timeout de 30 secondes
- Sur macOS, c'est l'URL du `.pkg` (extraite de l'appcast) qui est utilisée pour construire l'URL `.sha256`, et non l'URL de l'appcast XML stockée dans `versionInfo.downloadUrl`

</details>

---

## Summary
This PR implements SHA-256 checksum verification for files downloaded by the recovery updater. The expected hash is fetched from a `.sha256` sidecar file (built by appending `.sha256` to the download URL). Verification is skipped if the sidecar file does not provide a checksum.

## Changes
- Replaced the placeholder `verifyFileChecksum` in `AbstractOsUpdater` with a working implementation that fetches and parses the `.sha256` sidecar file
- Added a `fileUrl` parameter to `verifyFileChecksum` so the `.sha256` URL can be constructed correctly - on macOS the `.pkg` download URL is extracted from the appcast XML and differs from `versionInfo.downloadUrl`
- Removed the `if (!versionInfo.checksum.empty() && ...)` guard on all three platforms (macOS, Linux, Windows) - verification is now always called and self-skips when no checksum is available
- Expected hash is sourced solely from the `.sha256` sidecar file, and verification is skipped entirely if the sidecar is unavailable or empty

## Technical Details
- The `.sha256` file may contain either just the hash (`hash`) or the hash followed by a filename (`hash  filename`) - only the first whitespace-delimited token is extracted via `std::istringstream`
- Comparison is case-insensitive to handle uppercase/lowercase hex differences
- The `.sha256` sidecar is fetched via `HttpDownloader::get()` (simple GET with 30-second timeout)
- On macOS, the `.pkg` URL (parsed from the appcast) is used to build the `.sha256` URL, not the appcast XML URL stored in `versionInfo.downloadUrl`