### PR TITLE
feat: Add custom tooltip component

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -72,6 +72,8 @@
 - Render the future main-toolbar Search action as a standalone 36 px circular icon-only button, without a text label,
   and center its 16 px magnifier with 10 px between the SVG and each horizontal edge. Reuse the Support button component
   so both outer circles remain identical.
+- Use `IKToolTip` for every Linux v4 tooltip so controls share the rounded, theme-aware drive-name tooltip presentation;
+  do not use Qt's attached `ToolTip` styling, which falls back to the native yellow tooltip on some desktops.
 - For Activities status presentation, mirror the Windows fallback: `Unknown`, `Error`, `Conflict`, `Inconsistency`, and
   `Ignored` are all visible error activities; only `Success` and `Syncing` use non-error presentations.
 - Automated tests for the current Activities milestone are deferred. Do not add an Activities-specific test target or

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -148,6 +148,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKLoadingSpinner.qml
         ui/components/IKSidebarItem.qml
         ui/components/IKDriveSyncSelectorItem.qml
+        ui/components/IKToolTip.qml
         ui/components/IKTintedIcon.qml
         ui/windows/main/ActivitiesPlaceholder.qml
         ui/windows/main/BlockingErrorPlaceholder.qml

--- a/src/gui4/linux/ui/chrome/IKWindowControlButton.qml
+++ b/src/gui4/linux/ui/chrome/IKWindowControlButton.qml
@@ -74,9 +74,10 @@ ToolButton {
         }
     }
 
-    ToolTip.visible: hovered
-    ToolTip.text: text
-    ToolTip.delay: 500
+    IKToolTip {
+        visible: root.hovered || root.activeFocus
+        text: root.text
+    }
 
     background: Rectangle {
         color: {

--- a/src/gui4/linux/ui/components/IKDriveSyncSelectorItem.qml
+++ b/src/gui4/linux/ui/components/IKDriveSyncSelectorItem.qml
@@ -225,26 +225,8 @@ Button {
         cursorShape: root.interactive ? Qt.PointingHandCursor : Qt.ArrowCursor
     }
 
-    ToolTip {
-        id: truncatedTextTooltip
-
+    IKToolTip {
         visible: root.truncatedText.length > 0
-        delay: IKMainWindow.syncSelectorTooltipDelay
-        timeout: -1
         text: root.truncatedText
-        padding: IKMainWindow.syncSelectorTooltipPadding
-
-        contentItem: Text {
-            width: Math.min(implicitWidth, IKMainWindow.syncSelectorTooltipMaxWidth)
-            text: truncatedTextTooltip.text
-            color: IKColors.tooltipText
-            font.pixelSize: IKFonts.bodySize
-            wrapMode: Text.WordWrap
-        }
-
-        background: Rectangle {
-            radius: IKMainWindow.syncSelectorTooltipRadius
-            color: IKColors.tooltipSurface
-        }
     }
 }

--- a/src/gui4/linux/ui/components/IKToolTip.qml
+++ b/src/gui4/linux/ui/components/IKToolTip.qml
@@ -1,0 +1,41 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+ToolTip {
+    id: root
+
+    property real maximumTextWidth: IKMainWindow.syncSelectorTooltipMaxWidth
+    property color foregroundColor: IKColors.tooltipText
+    property color surfaceColor: IKColors.tooltipSurface
+    property real textLineHeight: 0
+
+    delay: IKMainWindow.syncSelectorTooltipDelay
+    timeout: -1
+    padding: IKMainWindow.syncSelectorTooltipPadding
+
+    contentItem: Text {
+        width: Math.min(implicitWidth, root.maximumTextWidth)
+        text: root.text
+        color: root.foregroundColor
+        font.pixelSize: IKFonts.bodySize
+        lineHeightMode: root.textLineHeight > 0 ? Text.FixedHeight : Text.ProportionalHeight
+        lineHeight: root.textLineHeight > 0 ? root.textLineHeight : 1
+        wrapMode: Text.WordWrap
+    }
+
+    background: Rectangle {
+        radius: IKMainWindow.syncSelectorTooltipRadius
+        color: root.surfaceColor
+    }
+}

--- a/src/gui4/linux/ui/components/IKToolTip.qml
+++ b/src/gui4/linux/ui/components/IKToolTip.qml
@@ -20,7 +20,7 @@ ToolTip {
     property color surfaceColor: IKColors.tooltipSurface
     property real textLineHeight: 0
 
-    delay: IKMainWindow.syncSelectorTooltipDelay
+    delay: IKMainWindow.tooltipDelay
     timeout: -1
     padding: IKMainWindow.syncSelectorTooltipPadding
 

--- a/src/gui4/linux/ui/tokens/IKMainWindow.qml
+++ b/src/gui4/linux/ui/tokens/IKMainWindow.qml
@@ -29,7 +29,7 @@ QtObject {
     readonly property real syncSelectorTooltipMaxWidth: 180
     readonly property real syncSelectorTooltipPadding: IKSpacing.s8
     readonly property real syncSelectorTooltipRadius: IKRadius.r8
-    readonly property int syncSelectorTooltipDelay: 250
+    readonly property int tooltipDelay: 400
     readonly property real errorBadgeSize: 8
     readonly property real notificationBadgeMinSize: 20
     readonly property real syncSelectorPopupMaxHeight: 260

--- a/src/gui4/linux/ui/windows/main/MainToolbar.qml
+++ b/src/gui4/linux/ui/windows/main/MainToolbar.qml
@@ -140,9 +140,10 @@ Rectangle {
             border.color: buttonRoot.visualFocus ? IKColors.accentPrimary : IKColors.surfaceTertiary
         }
 
-        ToolTip.visible: buttonRoot.hovered || buttonRoot.activeFocus
-        ToolTip.text: buttonRoot.tooltipText
-        ToolTip.delay: 500
+        IKToolTip {
+            visible: buttonRoot.hovered || buttonRoot.activeFocus
+            text: buttonRoot.tooltipText
+        }
     }
 
     component GroupedIconButton: ToolButton {
@@ -170,9 +171,10 @@ Rectangle {
             border.color: IKColors.accentPrimary
         }
 
-        ToolTip.visible: groupedButton.hovered || groupedButton.activeFocus
-        ToolTip.text: groupedButton.text
-        ToolTip.delay: 500
+        IKToolTip {
+            visible: groupedButton.hovered || groupedButton.activeFocus
+            text: groupedButton.text
+        }
     }
 
     component FutureGroupedIconButton: Item {
@@ -209,9 +211,10 @@ Rectangle {
             }
         }
 
-        ToolTip.visible: settingsButton.hovered || settingsButton.activeFocus
-        ToolTip.text: qsTrId("comingSoon")
-        ToolTip.delay: 500
+        IKToolTip {
+            visible: settingsButton.hovered || settingsButton.activeFocus
+            text: qsTrId("comingSoon")
+        }
     }
 
 }

--- a/src/gui4/linux/ui/windows/main/home/shortcuts/DriveWebShortcutsView.qml
+++ b/src/gui4/linux/ui/windows/main/home/shortcuts/DriveWebShortcutsView.qml
@@ -85,27 +85,9 @@ Rectangle {
                     acceptedButtons: Qt.NoButton
                 }
 
-                ToolTip {
-                    id: driveNameTooltip
-
+                IKToolTip {
                     visible: driveNamePointer.containsMouse && driveNameLabel.truncated
-                    delay: IKMainWindow.syncSelectorTooltipDelay
-                    timeout: -1
                     text: root.controller.driveName
-                    padding: IKMainWindow.syncSelectorTooltipPadding
-
-                    contentItem: Text {
-                        width: Math.min(implicitWidth, IKMainWindow.syncSelectorTooltipMaxWidth)
-                        text: driveNameTooltip.text
-                        color: IKColors.tooltipText
-                        font.pixelSize: IKFonts.bodySize
-                        wrapMode: Text.WordWrap
-                    }
-
-                    background: Rectangle {
-                        radius: IKMainWindow.syncSelectorTooltipRadius
-                        color: IKColors.tooltipSurface
-                    }
                 }
             }
         }

--- a/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
@@ -141,53 +141,25 @@ Item {
         }
     }
 
-    ToolTip {
-        id: longDriveNameTooltip
-
+    IKToolTip {
         visible: root.cellEnabled && cellMouseArea.containsMouse && root.driveNameContainsMouse() && driveNameText.truncated
         delay: IKOnboarding.driveSelectionTooltipDelay
-        timeout: -1
         text: root.driveName
         padding: IKOnboarding.driveSelectionTooltipPadding
-
-        contentItem: Text {
-            width: Math.min(implicitWidth, IKOnboarding.driveSelectionTooltipMaxWidth)
-            text: longDriveNameTooltip.text
-            color: IKColors.onboardingTooltipText
-            font.pixelSize: IKFonts.bodySize
-            lineHeightMode: Text.FixedHeight
-            lineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
-            wrapMode: Text.WordWrap
-        }
-
-        background: Rectangle {
-            radius: IKOnboarding.driveSelectionTooltipRadius
-            color: IKColors.onboardingTooltipSurface
-        }
+        maximumTextWidth: IKOnboarding.driveSelectionTooltipMaxWidth
+        foregroundColor: IKColors.onboardingTooltipText
+        surfaceColor: IKColors.onboardingTooltipSurface
+        textLineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
     }
 
-    ToolTip {
-        id: disabledCellTooltip
-
+    IKToolTip {
         visible: !root.cellEnabled && cellMouseArea.containsMouse && root.disabledTooltip.length > 0
         delay: IKOnboarding.driveSelectionTooltipDelay
-        timeout: -1
         text: root.disabledTooltip
         padding: IKOnboarding.driveSelectionTooltipPadding
-
-        contentItem: Text {
-            width: Math.min(implicitWidth, IKOnboarding.driveSelectionTooltipMaxWidth)
-            text: disabledCellTooltip.text
-            color: IKColors.onboardingTooltipText
-            font.pixelSize: IKFonts.bodySize
-            lineHeightMode: Text.FixedHeight
-            lineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
-            wrapMode: Text.WordWrap
-        }
-
-        background: Rectangle {
-            radius: IKOnboarding.driveSelectionTooltipRadius
-            color: IKColors.onboardingTooltipSurface
-        }
+        maximumTextWidth: IKOnboarding.driveSelectionTooltipMaxWidth
+        foregroundColor: IKColors.onboardingTooltipText
+        surfaceColor: IKColors.onboardingTooltipSurface
+        textLineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
     }
 }

--- a/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
@@ -195,29 +195,15 @@ Item {
                         id: advancedButtonHoverHandler
                     }
 
-                    ToolTip {
-                        id: advancedButtonTooltip
-
+                    IKToolTip {
                         visible: advancedButtonHoverHandler.hovered
                         delay: IKOnboarding.driveSelectionTooltipDelay
-                        timeout: -1
                         text: qsTr("Not available yet.")
                         padding: IKOnboarding.driveSelectionTooltipPadding
-
-                        contentItem: Text {
-                            width: Math.min(implicitWidth, IKOnboarding.driveSelectionTooltipMaxWidth)
-                            text: advancedButtonTooltip.text
-                            color: IKColors.onboardingTooltipText
-                            font.pixelSize: IKFonts.bodySize
-                            lineHeightMode: Text.FixedHeight
-                            lineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
-                            wrapMode: Text.WordWrap
-                        }
-
-                        background: Rectangle {
-                            radius: IKOnboarding.driveSelectionTooltipRadius
-                            color: IKColors.onboardingTooltipSurface
-                        }
+                        maximumTextWidth: IKOnboarding.driveSelectionTooltipMaxWidth
+                        foregroundColor: IKColors.onboardingTooltipText
+                        surfaceColor: IKColors.onboardingTooltipSurface
+                        textLineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
                     }
                 }
 


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR introduit `IKToolTip`, un composant de tooltip partagé, arrondi et adapté au thème, et le déploie sur l'ensemble de la GUI Linux v4. Chaque tooltip Linux v4 doit désormais passer par `IKToolTip` pour partager la présentation déjà utilisée pour le tooltip de nom de drive.

## Changements
- Ajout de `ui/components/IKToolTip.qml` : encapsule `ToolTip` avec `delay`, `timeout: -1`, `padding` et un `contentItem`/`background` communs (texte thémé, coins arrondis), et expose `maximumTextWidth`, `foregroundColor`, `surfaceColor` et `textLineHeight` comme points de personnalisation pour les call sites dont la présentation diffère légèrement (onboarding).
- Renommage du token `IKMainWindow.syncSelectorTooltipDelay` (250 ms) en `tooltipDelay` (400 ms), désormais partagé par tous les tooltips plutôt que réservé au sélecteur de synchronisation.
- Migration de tous les call sites Linux v4 vers `IKToolTip` : remplacement des propriétés attachées `ToolTip.*` dans `IKWindowControlButton` et les trois boutons de `MainToolbar`, et remplacement des `ToolTip` entièrement redéfinis (avec leur propre `contentItem`/`background`) dans `IKDriveSyncSelectorItem`, `DriveWebShortcutsView`, `DriveCellView` (deux tooltips) et `DriveSelectionView`.
- `IKWindowControlButton` et les boutons de `MainToolbar` affichent désormais aussi le tooltip au focus clavier (`activeFocus`), pas uniquement au survol.
- Enregistrement de `IKToolTip.qml` dans `CMakeLists.txt` et documentation de la règle d'usage dans `src/gui4/linux/AGENTS.md`.

## Détails techniques
- Les propriétés `maximumTextWidth`, `foregroundColor`, `surfaceColor` et `textLineHeight` permettent à `DriveCellView` et `DriveSelectionView` de conserver la présentation propre à l'onboarding (couleurs et largeur `IKOnboarding.*`) sans dupliquer le `contentItem`/`background`.
- Le renommage de `syncSelectorTooltipDelay` en `tooltipDelay` reflète le fait que ce délai n'est plus spécifique au sélecteur de synchronisation ; sa valeur passe de 250 ms à 400 ms pour ce nouvel usage générique.

</details>

---

## Summary
This PR introduces `IKToolTip`, a shared, rounded, theme-aware tooltip component, and adopts it across the entire Linux v4 GUI. Every Linux v4 tooltip should now go through `IKToolTip` to share the presentation already used for the drive-name tooltip.

## Changes
- Added `ui/components/IKToolTip.qml`: wraps `ToolTip` with `delay`, `timeout: -1`, `padding`, and a shared `contentItem`/`background` (themed text, rounded corners), and exposes `maximumTextWidth`, `foregroundColor`, `surfaceColor`, and `textLineHeight` as customization points for call sites whose presentation differs slightly (onboarding).
- Renamed the `IKMainWindow.syncSelectorTooltipDelay` token (250ms) to `tooltipDelay` (400ms), now shared by every tooltip instead of being reserved for the sync selector.
- Migrated every Linux v4 call site to `IKToolTip`: replaced the attached `ToolTip.*` properties in `IKWindowControlButton` and the three `MainToolbar` buttons, and replaced fully re-implemented `ToolTip`s (each with its own `contentItem`/`background`) in `IKDriveSyncSelectorItem`, `DriveWebShortcutsView`, `DriveCellView` (two tooltips), and `DriveSelectionView`.
- `IKWindowControlButton` and the `MainToolbar` buttons now also show the tooltip on keyboard focus (`activeFocus`), not only on hover.
- Registered `IKToolTip.qml` in `CMakeLists.txt` and documented the usage rule in `src/gui4/linux/AGENTS.md`.

## Technical Details
- The `maximumTextWidth`, `foregroundColor`, `surfaceColor`, and `textLineHeight` properties let `DriveCellView` and `DriveSelectionView` keep the onboarding-specific presentation (`IKOnboarding.*` colors and width) without duplicating the `contentItem`/`background`.
- Renaming `syncSelectorTooltipDelay` to `tooltipDelay` reflects that this delay is no longer specific to the sync selector; its value moves from 250ms to 400ms for this new generic usage.

---
| Dark Theme | Light Theme |
| --- | --- |
|<img width="1120" height="520" alt="iktooltip-drive-name-dark" src="https://github.com/user-attachments/assets/2319959c-aab0-41ba-b9be-f610acb36e8a" /> | <img width="1120" height="520" alt="iktooltip-drive-name-light" src="https://github.com/user-attachments/assets/3e85eae4-ac87-42b0-a934-617294272c26" /> |

(The blue outline indicates an element with a tooltip.)

---

Depends on #2307