### PR TITLE
feat(activity): reconcile in-progress rows, open folder, add icons

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -16,6 +16,8 @@
 - In versioned documentation, use repo-relative paths, not hardcoded absolute paths.
 - Do not add links to `.md` files that are not versioned in git.
 - Never launch a build unless explicitly asked by the user.
+- For the Activities PR stack, preparing a PR means isolating and staging its changes only. Leave commit, push, and PR
+  creation to the user unless they explicitly ask Codex to publish them.
 - Treat native Wayland as the default Linux runtime on current Ubuntu/GNOME systems. XCB/XWayland is a compatibility
   path, not the primary platform; window-shell changes must cover both paths explicitly.
 - Keep the Linux frameless header and custom shadow on native Wayland without depending on `Qt6::GuiPrivate`. Accept
@@ -37,6 +39,8 @@
   adapters must observe and query that shared state instead of maintaining private copies.
 - Design feature storage and presentation contracts for their intended final lifecycle. A temporarily unavailable UI or
   action may remain inactive, but must not make the underlying model discard state needed by the completed feature.
+- For the bounded Activities projection, prefer the score-based linear error matcher over rebuilding temporary identity
+  indexes unless profiling demonstrates that matching is a bottleneck.
 - In range-for loops over associative containers, prefer `std::views::keys` / `std::views::values` over structured
   bindings with an unused `_` element when only keys or only values are needed.
 - For Linux v4 model/UI checks, build only the `kdrive_qml` target unless a broader backend/server validation is
@@ -76,6 +80,10 @@
   do not use Qt's attached `ToolTip` styling, which falls back to the native yellow tooltip on some desktops.
 - For Activities status presentation, mirror the Windows fallback: `Unknown`, `Error`, `Conflict`, `Inconsistency`, and
   `Ignored` are all visible error activities; only `Success` and `Syncing` use non-error presentations.
+- On Activities, a retry in progress for an actively errored node shares the same projected row, and displayed Folder
+  values open that exact folder even when the activity target no longer exists.
+- On Activities, keep actual in-progress transfers above failed and synchronized rows; surface active errors separately
+  without displacing transfers that are still running.
 - Automated tests for the current Activities milestone are deferred. Do not add an Activities-specific test target or
   files under `test/gui4/linux/` until the user explicitly reopens that scope.
 - Main-sidebar selection changes only the row background; it must not recolor the icon or increase the label weight.
@@ -125,6 +133,8 @@
 - `appclientlinux.*`: top-level app wiring (logging, QML warning forwarding, IPC lifecycle,
   dispatcher/service/coordinator ownership).
 - `app/appconstants.h`: app-level non-translatable constants, mirroring the Windows `AppConstants` role where useful.
+- `app/fileiconresolver.*`: reusable, cached `QMimeDatabase::MatchExtension` classifier mapping local file names to the
+  semantic document-icon asset names consumed by QML views.
 - `app/systraycontroller.*`: Linux system tray ownership, 5-state tray icon selection derived from `AppCache` plus
   updater availability, GNOME-compatible tray menu actions, fallback-to-window startup behavior, retry loop for late
   tray availability, and main QML window show/hide behavior.
@@ -153,8 +163,9 @@
   and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.
 - `app/cache/activitystore.*`: process-local, per-sync file-activity history. It retains server status and direction,
   updates valid operation ids in place, removes failed entries superseded by a successful or in-progress activity for the
-  same node, preserves distinct anonymous operations, and bounds retention to 500 entries per synchronization. It stays
-  separate from the durable `AppCache` graph and is not exposed directly to QML.
+  same node, clears interrupted in-progress entries when a synchronization becomes inactive, preserves distinct anonymous
+  operations, and bounds retention to 500 entries per synchronization. It stays separate from the durable `AppCache`
+  graph and is not exposed directly to QML.
 - `app/cache/cachepipeline.*`: unique bridge for `CommService -> AppCache/ActivityStore` push signals.
     - Routes entity, sync-runtime, and file-activity pushes after population; drops and logs earlier pushes as invariant
       violations.
@@ -174,11 +185,12 @@
 - `app/mainwindow/mainsidebarcontroller.*`: QML-facing sidebar interaction controller. It exposes `SyncSelectorModel`,
   delegates sync selection to `MainSelectionStore`, and opens the selected local sync folder through desktop services.
 - `app/mainwindow/activitylistmodel.*`: selected-sync projection joining bounded recent activities with authoritative
-  active node errors. It maps server status and direction to the QML-facing presentation enums. Active errors remain
-  visible even when their recent activity has been evicted.
+  active node errors. It omits failed activities after their active error is resolved, maps server status and direction to
+  the QML-facing presentation enums, keeps actual in-progress rows first, coalesces bursty cache invalidations, and keeps
+  active errors visible even when their recent activity has been evicted.
 - `app/mainwindow/activitiescontroller.*`: QML-facing Activities state and action boundary. It owns filtering and title
-  presentation, including the local title-state resolver, validates local paths, and delegates asynchronous link actions
-  to `ActivityService`.
+  presentation, including the local title-state resolver, validates local paths, opens activity and displayed-folder
+  locations, and delegates asynchronous link actions to `ActivityService`.
 - `app/mainwindow/homecontroller.*`: cache-backed QML adapter for the modular Home and toolbar sync controls. It
   resolves the selected sync into one central presentation state, exposes user/drive/error data, owns web-link
   construction, and delegates pause/resume to `SyncService`.

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -117,17 +117,17 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
 }
 
 std::vector<ActivityEntry> ActivityStore::activities(const SyncDbId syncDbId) const {
-    const auto syncIt = _activitiesBySyncDbId.find(syncDbId);
-    return syncIt == _activitiesBySyncDbId.end() ? std::vector<ActivityEntry>{} : syncIt->second;
+    const auto activitiesIt = _activitiesBySyncDbId.find(syncDbId);
+    return activitiesIt == _activitiesBySyncDbId.end() ? std::vector<ActivityEntry>{} : activitiesIt->second;
 }
 
 void ActivityStore::removeInProgress(const SyncDbId syncDbId) {
-    const auto syncIt = _activitiesBySyncDbId.find(syncDbId);
-    if (syncIt == _activitiesBySyncDbId.end()) {
+    const auto activitiesIt = _activitiesBySyncDbId.find(syncDbId);
+    if (activitiesIt == _activitiesBySyncDbId.end()) {
         return;
     }
 
-    if (auto &entries = syncIt->second;
+    if (auto &entries = activitiesIt->second;
         std::erase_if(entries, [](const ActivityEntry &entry) { return isInProgress(entry.status); }) == 0) {
         return;
     }
@@ -144,14 +144,14 @@ void ActivityStore::removeSync(const SyncDbId syncDbId) {
 
 void ActivityStore::retainSyncs(const std::unordered_set<SyncDbId> &syncDbIds) {
     std::vector<SyncDbId> removedSyncDbIds;
-    for (auto syncIt = _activitiesBySyncDbId.begin(); syncIt != _activitiesBySyncDbId.end();) {
-        if (syncDbIds.contains(syncIt->first)) {
-            ++syncIt;
+    for (auto activitiesIt = _activitiesBySyncDbId.begin(); activitiesIt != _activitiesBySyncDbId.end();) {
+        if (syncDbIds.contains(activitiesIt->first)) {
+            ++activitiesIt;
             continue;
         }
 
-        removedSyncDbIds.push_back(syncIt->first);
-        syncIt = _activitiesBySyncDbId.erase(syncIt);
+        removedSyncDbIds.push_back(activitiesIt->first);
+        activitiesIt = _activitiesBySyncDbId.erase(activitiesIt);
     }
 
     for (const SyncDbId syncDbId: removedSyncDbIds) {

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -121,6 +121,20 @@ std::vector<ActivityEntry> ActivityStore::activities(const SyncDbId syncDbId) co
     return syncIt == _activitiesBySyncDbId.end() ? std::vector<ActivityEntry>{} : syncIt->second;
 }
 
+void ActivityStore::removeInProgress(const SyncDbId syncDbId) {
+    const auto syncIt = _activitiesBySyncDbId.find(syncDbId);
+    if (syncIt == _activitiesBySyncDbId.end()) {
+        return;
+    }
+
+    if (auto &entries = syncIt->second;
+        std::erase_if(entries, [](const ActivityEntry &entry) { return isInProgress(entry.status); }) == 0) {
+        return;
+    }
+
+    emit activitiesChanged(syncDbId);
+}
+
 void ActivityStore::removeSync(const SyncDbId syncDbId) {
     if (_activitiesBySyncDbId.erase(syncDbId) == 0) {
         return;

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -87,6 +87,12 @@ class ActivityStore final : public QObject {
         [[nodiscard]] std::vector<ActivityEntry> activities(SyncDbId syncDbId) const;
 
         /**
+         * @brief Removes every in-progress activity owned by one synchronization.
+         * @param syncDbId Database identifier of the synchronization whose interrupted activities must be removed.
+         */
+        void removeInProgress(SyncDbId syncDbId);
+
+        /**
          * @brief Removes every retained activity owned by one synchronization.
          * @param syncDbId Database identifier of the synchronization to remove.
          */

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -28,6 +28,11 @@ namespace KDC {
 namespace {
 Q_LOGGING_CATEGORY(lcCachePipeline, "gui.v4.cachepipeline", QtInfoMsg)
 
+bool preventsInProgressActivities(const SyncStatus status) {
+    return status == SyncStatus::Idle || status == SyncStatus::Paused || status == SyncStatus::Stopped ||
+           status == SyncStatus::Error;
+}
+
 template<typename Signal, typename Slot>
 struct CacheConnection {
         const char *signalName;
@@ -87,6 +92,8 @@ void CachePipeline::connectLivePipeline() {
             directCacheConnections);
     (void) connect(&_commService, &CommService::itemCompleted, this, &CachePipeline::routeActivity, Qt::UniqueConnection);
     (void) connect(&_appCache, &AppCache::syncsChanged, this, &CachePipeline::reconcileActivities, Qt::UniqueConnection);
+    (void) connect(&_appCache, &AppCache::syncStatusChanged, this, &CachePipeline::reconcileInProgressActivities,
+                   Qt::UniqueConnection);
 }
 
 void CachePipeline::markPopulated() {
@@ -110,7 +117,23 @@ void CachePipeline::routeActivity(const SyncDbId syncDbId, const SyncFileItemInf
                                    << "/ operationId:" << item.operationId();
         return;
     }
+
+    if (item.status() == SyncFileStatus::Syncing) {
+        if (const auto runtimeInfo = _appCache.syncRuntimeInfo(syncDbId);
+            runtimeInfo.has_value() && preventsInProgressActivities(runtimeInfo->status)) {
+            return;
+        }
+    }
     _activityStore.ingest(syncDbId, item);
+}
+
+void CachePipeline::reconcileInProgressActivities(const SyncDbId syncDbId) const {
+    if (const auto runtimeInfo = _appCache.syncRuntimeInfo(syncDbId);
+        !runtimeInfo.has_value() || !preventsInProgressActivities(runtimeInfo->status)) {
+        return;
+    }
+
+    _activityStore.removeInProgress(syncDbId);
 }
 
 void CachePipeline::reconcileActivities() const {

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -28,6 +28,12 @@ namespace KDC {
 namespace {
 Q_LOGGING_CATEGORY(lcCachePipeline, "gui.v4.cachepipeline", QtInfoMsg)
 
+/**
+ *
+ * @param status the SyncStatus to evaluate
+ * @return true if the status is one of the states that prevents in-progress activities from being routed to the ActivityStore,
+ * false otherwise.
+ */
 bool preventsInProgressActivities(const SyncStatus status) {
     return status == SyncStatus::Idle || status == SyncStatus::Paused || status == SyncStatus::Stopped ||
            status == SyncStatus::Error;

--- a/src/gui4/linux/app/cache/cachepipeline.h
+++ b/src/gui4/linux/app/cache/cachepipeline.h
@@ -57,6 +57,7 @@ class CachePipeline : public QObject {
         void connectDropPipeline();
         void connectLivePipeline();
         void routeActivity(SyncDbId syncDbId, const SyncFileItemInfo &item) const;
+        void reconcileInProgressActivities(SyncDbId syncDbId) const;
         void reconcileActivities() const;
         static void logDroppedPush(const char *signalName);
 

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -142,10 +142,18 @@ void ActivitiesController::setFilter(const ActivityListModel::Filter filter) {
     _model.setFilter(filter);
 }
 
+/**
+ * Opens the file or folder represented by the activity target, or the parent folder if the target is a file.
+ * @param rowId the stable model row identifier for the activity or error
+ */
 void ActivitiesController::openLocal(const QString &rowId) {
     openLocalPath(rowId, false);
 }
 
+/**
+ * Opens the parent folder of the activity target.
+ * @param rowId the stable model row identifier for the activity or error
+ */
 void ActivitiesController::openFolder(const QString &rowId) {
     openLocalPath(rowId, true);
 }

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -143,6 +143,19 @@ void ActivitiesController::setFilter(const ActivityListModel::Filter filter) {
 }
 
 void ActivitiesController::openLocal(const QString &rowId) {
+    openLocalPath(rowId, false);
+}
+
+void ActivitiesController::openFolder(const QString &rowId) {
+    openLocalPath(rowId, true);
+}
+
+/**
+ * Opens either the activity target according to its node type, or the exact parent represented by the Folder column.
+ * Both variants resolve and canonicalize the destination below the selected synchronization root before invoking the
+ * desktop service. The Folder action deliberately does not require the activity target itself to still exist.
+ */
+void ActivitiesController::openLocalPath(const QString &rowId, const bool openDisplayedFolder) {
     const auto target = _model.actionTarget(rowId);
     if (!target.has_value()) {
         qCWarning(lcActivitiesController) << "Local activity action rejected for unknown row | rowId:" << rowId;
@@ -164,7 +177,8 @@ void ActivitiesController::openLocal(const QString &rowId) {
 
     const SyncPath rootPath = context->syncInfo.localPath().lexically_normal();
     const QFileInfo rootInfo{Path2QStr(rootPath)};
-    const SyncPath targetPath = (rootPath / *relativePath).lexically_normal();
+    const SyncPath requestedRelativePath = openDisplayedFolder ? relativePath->parent_path() : *relativePath;
+    const SyncPath targetPath = (rootPath / requestedRelativePath).lexically_normal();
     const QFileInfo targetInfo{Path2QStr(targetPath)};
     if (!rootInfo.exists() || !rootInfo.isDir() || !targetInfo.exists()) {
         qCWarning(lcActivitiesController) << "Local activity target is missing or outside the synchronization root"
@@ -183,7 +197,8 @@ void ActivitiesController::openLocal(const QString &rowId) {
         return;
     }
 
-    if (const SyncPath folderToOpen = targetInfo.isDir() ? canonicalTargetPath : canonicalTargetPath.parent_path();
+    if (const SyncPath folderToOpen =
+                openDisplayedFolder || targetInfo.isDir() ? canonicalTargetPath : canonicalTargetPath.parent_path();
         folderToOpen.empty() || !QDesktopServices::openUrl(QUrl::fromLocalFile(Path2QStr(folderToOpen)))) {
         qCWarning(lcActivitiesController) << "Desktop service failed to open local activity folder"
                                           << "| rowId:" << rowId << "| folder:" << Path2QStr(folderToOpen);

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.h
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.h
@@ -60,6 +60,7 @@ class ActivitiesController final : public QObject {
         [[nodiscard]] bool hasErrors() const { return _errorCount > 0; }
 
         Q_INVOKABLE void openLocal(const QString &rowId);
+        Q_INVOKABLE void openFolder(const QString &rowId);
         Q_INVOKABLE void openOnline(const QString &rowId);
         Q_INVOKABLE void copyShareLink(const QString &rowId);
         Q_INVOKABLE void requestFixErrors(const QString &rowId) const;
@@ -76,6 +77,7 @@ class ActivitiesController final : public QObject {
 
     private:
         void refreshPageState();
+        void openLocalPath(const QString &rowId, bool openDisplayedFolder);
         [[nodiscard]] std::optional<SyncContext> actionSyncContext(const ActivityListModel::ActionTarget &target,
                                                                    const QString &rowId) const;
 

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -131,8 +131,8 @@ ActivityListModel::Source toModelSource(const SyncDirection direction) {
 
 QString activityActionText(const ActivityEntry &activity) {
     switch (activity.instruction) {
-        case SyncFileInstruction::UpdateMetadata: // We can't receive an UpdateMetadata on linux, reserved instruction for macOS
-                                                  // and Windows for the litesync.
+        case SyncFileInstruction::UpdateMetadata: // We shouldn't receive an UpdateMetadata on linux, reserved instruction for
+                                                  // macOS and Windows for the litesync. Here for possible future litesync linux implem.
         case SyncFileInstruction::Update:
             return qtTrId("activityInstructionUpdateLabel");
         case SyncFileInstruction::Remove:

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -464,6 +464,10 @@ void ActivityListModel::resetProjection() {
     emit projectionChanged();
 }
 
+/**
+ * Schedules a projection reconciliation to run after a short delay, allowing multiple activity or error changes to be
+ * batched together. If a reconciliation is already scheduled, this call has no effect.
+ */
 void ActivityListModel::scheduleProjectionReconciliation() {
     if (!_projectionRefreshTimer.isActive()) {
         _projectionRefreshTimer.start();

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -20,16 +20,14 @@
 
 #include "libcommon/utility/types.h"
 
-#include <QCoreApplication>
 #include <QFontMetricsF>
-#include <QLoggingCategory>
 #include <QLocale>
+#include <QLoggingCategory>
 #include <QSet>
 
 #include <algorithm>
 #include <chrono>
 #include <qtimezone.h>
-#include <ranges>
 
 namespace KDC {
 
@@ -171,10 +169,13 @@ QString activityActionText(const ActivityEntry &activity) {
 
 QStringList ActivityListModel::timeTextSamples() {
     // Upper bound of every branch of formatRelativeTime(): the last value before each threshold rolls over.
-    QStringList samples{qtTrId("labelJustNow"), formatAgo(minute - second, second, "labelShortSecond"),
-                        formatAgo(hour - minute, minute, "labelShortMinute"),
-                        formatAgo(day - hour, hour, "labelShortHour"),
-                        formatAgo(relativeDateThreshold - day, day, "labelShortDay")};
+    QStringList samples{
+            qtTrId("labelJustNow"),
+            formatAgo(minute - second, second, "labelShortSecond"),
+            formatAgo(hour - minute, minute, "labelShortMinute"),
+            formatAgo(day - hour, hour, "labelShortHour"),
+            formatAgo(relativeDateThreshold - day, day, "labelShortDay"),
+    };
 
     // Past the relative threshold the cell shows a short date, whose width varies by month in locales that abbreviate
     // it, so every month is a candidate. Day 28 exists in all of them and is two digits wide.

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -131,16 +131,16 @@ ActivityListModel::Source toModelSource(const SyncDirection direction) {
 
 QString activityActionText(const ActivityEntry &activity) {
     switch (activity.instruction) {
+        case SyncFileInstruction::UpdateMetadata: // We can't receive an UpdateMetadata on linux, reserved instruction for macOS
+                                                  // and Windows for the litesync.
         case SyncFileInstruction::Update:
             return qtTrId("activityInstructionUpdateLabel");
-        case SyncFileInstruction::UpdateMetadata:
-            return qtTrId("activityInstructionUpdateMetadataLabel");
         case SyncFileInstruction::Remove:
             return qtTrId("activityInstructionRemoveLabel");
         case SyncFileInstruction::Move: {
             if (!activity.path.empty() && !activity.newPath.empty() &&
                 normalizedRelativePath(activity.path).parent_path() == normalizedRelativePath(activity.newPath).parent_path()) {
-                return qtTrId("activityInstructionUpdateMetadataLabel");
+                return qtTrId("activityInstructionRenameLabel");
             }
             return qtTrId("activityInstructionMoveLabel");
         }

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -21,6 +21,7 @@
 #include "libcommon/utility/types.h"
 
 #include <QCoreApplication>
+#include <QFontMetricsF>
 #include <QLoggingCategory>
 #include <QLocale>
 #include <QSet>
@@ -167,6 +168,43 @@ QString activityActionText(const ActivityEntry &activity) {
 }
 
 } // namespace
+
+QStringList ActivityListModel::timeTextSamples() {
+    // Upper bound of every branch of formatRelativeTime(): the last value before each threshold rolls over.
+    QStringList samples{qtTrId("labelJustNow"), formatAgo(minute - second, second, "labelShortSecond"),
+                        formatAgo(hour - minute, minute, "labelShortMinute"),
+                        formatAgo(day - hour, hour, "labelShortHour"),
+                        formatAgo(relativeDateThreshold - day, day, "labelShortDay")};
+
+    // Past the relative threshold the cell shows a short date, whose width varies by month in locales that abbreviate
+    // it, so every month is a candidate. Day 28 exists in all of them and is two digits wide.
+    const QLocale locale;
+    for (int month = 1; month <= 12; ++month) {
+        samples << locale.toString(QDate{2026, month, 28}, QLocale::ShortFormat);
+    }
+    return samples;
+}
+
+QStringList ActivityListModel::sizeTextSamples() {
+    // Widest value of each unit tier, capped at terabytes: drive quotas make larger files unreachable, and the Windows
+    // client stops there too.
+    QStringList samples{formatSize(NodeType::File, 999)};
+    int64_t unit = 1000;
+    for (int tier = 0; tier < 4; ++tier) {
+        samples << formatSize(NodeType::File, static_cast<int64_t>(999.9 * static_cast<double>(unit)));
+        unit *= 1000;
+    }
+    return samples;
+}
+
+qreal ActivityListModel::maxTextWidth(const QStringList &texts, const QFont &font) {
+    const QFontMetricsF metrics{font};
+    qreal widest = 0;
+    for (const QString &text: texts) {
+        widest = std::max(widest, metrics.horizontalAdvance(text));
+    }
+    return widest;
+}
 
 QString ActivityListModel::activityRowId(const GenericId localId) {
     return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -71,7 +71,7 @@ QString formatSize(const NodeType nodeType, const int64_t size) {
     // Drop the decimal part when it is zero, to match the macOS and Windows clients.
     const QString trailingZero = locale.decimalPoint() + locale.zeroDigit();
     if (const auto index = formatted.indexOf(trailingZero); index >= 0) {
-        formatted.remove(index, trailingZero.size());
+        (void) formatted.remove(index, trailingZero.size());
     }
     return formatted;
 }
@@ -178,8 +178,8 @@ QStringList ActivityListModel::timeTextSamples() {
 
     // Past the relative threshold the cell shows a short date, whose width varies by month in locales that abbreviate
     // it, so every month is a candidate. Day 28 exists in all of them and is two digits wide.
-    const QLocale locale;
-    for (int month = 1; month <= 12; ++month) {
+    for (uint8_t month = 1; month <= 12; ++month) {
+        const QLocale locale;
         samples << locale.toString(QDate{2026, month, 28}, QLocale::ShortFormat);
     }
     return samples;
@@ -190,7 +190,7 @@ QStringList ActivityListModel::sizeTextSamples() {
     // client stops there too.
     QStringList samples{formatSize(NodeType::File, 999)};
     int64_t unit = 1000;
-    for (int tier = 0; tier < 4; ++tier) {
+    for (uint8_t tier = 0; tier < 4; ++tier) {
         samples << formatSize(NodeType::File, static_cast<int64_t>(999.9 * static_cast<double>(unit)));
         unit *= 1000;
     }

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -23,6 +23,7 @@
 #include <QCoreApplication>
 #include <QLoggingCategory>
 #include <QLocale>
+#include <QSet>
 
 #include <algorithm>
 #include <chrono>
@@ -35,6 +36,7 @@ namespace {
 Q_LOGGING_CATEGORY(lcActivityListModel, "gui.v4.activitylistmodel", QtInfoMsg)
 
 constexpr auto relativeTimeRefreshInterval = std::chrono::minutes{1};
+constexpr auto projectionRefreshInterval = std::chrono::milliseconds{100};
 constexpr auto justNowThreshold = std::chrono::seconds{30};
 constexpr auto second = std::chrono::seconds{1};
 constexpr auto minute = std::chrono::minutes{1};
@@ -127,6 +129,34 @@ ActivityListModel::Source toModelSource(const SyncDirection direction) {
     return ActivityListModel::Source::Unknown;
 }
 
+QString activityActionText(const ActivityEntry &activity) {
+    switch (activity.instruction) {
+        case SyncFileInstruction::Update:
+            return qtTrId("activityInstructionUpdateLabel");
+        case SyncFileInstruction::UpdateMetadata:
+            return qtTrId("activityInstructionUpdateMetadataLabel");
+        case SyncFileInstruction::Remove:
+            return qtTrId("activityInstructionRemoveLabel");
+        case SyncFileInstruction::Move: {
+            if (!activity.path.empty() && !activity.newPath.empty() &&
+                normalizedRelativePath(activity.path).parent_path() == normalizedRelativePath(activity.newPath).parent_path()) {
+                return qtTrId("activityInstructionUpdateMetadataLabel");
+            }
+            return qtTrId("activityInstructionMoveLabel");
+        }
+        case SyncFileInstruction::Get:
+            return qtTrId("activityInstructionGetLabel");
+        case SyncFileInstruction::Put:
+            return qtTrId("activityInstructionPutLabel");
+        case SyncFileInstruction::Ignore:
+            return qtTrId("activityInstructionIgnoreLabel");
+        case SyncFileInstruction::None:
+        case SyncFileInstruction::EnumEnd:
+            return {};
+    }
+    return {};
+}
+
 } // namespace
 
 QString ActivityListModel::activityRowId(const GenericId localId) {
@@ -141,11 +171,19 @@ ActivityListModel::ActivityListModel(const ActivityStore &activityStore, const A
     _selectionStore(selectionStore) {
     (void) connect(&_activityStore, &ActivityStore::activitiesChanged, this, [this](const SyncDbId syncDbId) {
         if (syncDbId == static_cast<SyncDbId>(_selectionStore.currentSyncDbId())) {
-            reconcileProjection();
+            scheduleProjectionReconciliation();
         }
     });
-    (void) connect(&_appCache, &AppCache::syncErrorsChanged, this, &ActivityListModel::reconcileProjection);
-    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncDbIdChanged, this, &ActivityListModel::resetProjection);
+    (void) connect(&_appCache, &AppCache::syncErrorsChanged, this, &ActivityListModel::scheduleProjectionReconciliation);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncDbIdChanged, this, [this] {
+        // Keep the bounded icon cache scoped to the selected synchronization.
+        _fileIconResolver.clear();
+        resetProjection();
+    });
+
+    _projectionRefreshTimer.setInterval(projectionRefreshInterval);
+    _projectionRefreshTimer.setSingleShot(true);
+    (void) connect(&_projectionRefreshTimer, &QTimer::timeout, this, &ActivityListModel::reconcileProjection);
 
     _relativeTimeTimer.setInterval(relativeTimeRefreshInterval);
     (void) connect(&_relativeTimeTimer, &QTimer::timeout, this, &ActivityListModel::refreshRelativeTimes);
@@ -169,6 +207,10 @@ QVariant ActivityListModel::data(const QModelIndex &index, const int role) const
         case NameRole:
         case Qt::DisplayRole:
             return row.name;
+        case FileIconNameRole:
+            return row.fileIconName;
+        case ActionTextRole:
+            return row.actionText;
         case FolderRole:
             return row.folder;
         case TimeTextRole:
@@ -183,6 +225,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, const int role) const
             return QVariant::fromValue(row.source);
         case InstructionRole:
             return static_cast<int32_t>(row.instruction);
+        case IsDirectoryRole:
+            return row.nodeType == NodeType::Directory;
         case ProgressRole:
             return row.progress;
         case HasActiveErrorRole:
@@ -198,6 +242,8 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const {
     return {
             {RowIdRole, "rowId"},
             {NameRole, "name"},
+            {FileIconNameRole, "fileIconName"},
+            {ActionTextRole, "actionText"},
             {FolderRole, "folder"},
             {TimeTextRole, "timeText"},
             {SizeTextRole, "sizeText"},
@@ -205,6 +251,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const {
             {StatusRole, "status"},
             {SourceRole, "source"},
             {InstructionRole, "instruction"},
+            {IsDirectoryRole, "isDirectory"},
             {ProgressRole, "progress"},
             {HasActiveErrorRole, "hasActiveError"},
             {ActiveErrorCountRole, "activeErrorCount"},
@@ -264,7 +311,8 @@ std::vector<ActivityListModel::Row> ActivityListModel::activityRows(const SyncDb
     return rows;
 }
 
-void ActivityListModel::appendActiveErrors(const SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows) {
+void ActivityListModel::appendActiveErrors(const SyncDbId syncDbId, const std::vector<Error> &errors,
+                                           std::vector<Row> &rows) const {
     for (const auto &error: errors) {
         if (error.level() != ErrorLevel::Node) {
             continue;
@@ -273,7 +321,7 @@ void ActivityListModel::appendActiveErrors(const SyncDbId syncDbId, const std::v
     }
 }
 
-void ActivityListModel::appendActiveError(const SyncDbId syncDbId, const Error &error, std::vector<Row> &rows) {
+void ActivityListModel::appendActiveError(const SyncDbId syncDbId, const Error &error, std::vector<Row> &rows) const {
     if (auto *const matchingRow = findMatchingActivity(rows, error); matchingRow != nullptr) {
         matchingRow->activeErrorDbIds.push_back(error.dbId());
         return;
@@ -281,7 +329,7 @@ void ActivityListModel::appendActiveError(const SyncDbId syncDbId, const Error &
     rows.push_back(makeErrorRow(syncDbId, error));
 }
 
-ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbId, const ActivityEntry &activity) {
+ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbId, const ActivityEntry &activity) const {
     const SyncPath &currentPath =
             activity.instruction == SyncFileInstruction::Move && !activity.newPath.empty() ? activity.newPath : activity.path;
     const SyncPath relativePath = normalizedRelativePath(currentPath);
@@ -292,6 +340,8 @@ ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbI
     row.activityLocalId = activity.localId;
     row.syncDbId = syncDbId;
     row.name = itemName(relativePath);
+    row.fileIconName = _fileIconResolver.iconName(row.name, activity.nodeType);
+    row.actionText = activityActionText(activity);
     row.folder = parentFolder(relativePath);
     row.timeText = formatRelativeTime(activity.receivedAtUtc);
     row.sizeText = formatSize(activity.nodeType, activity.size);
@@ -310,7 +360,7 @@ ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbI
     return row;
 }
 
-ActivityListModel::Row ActivityListModel::makeErrorRow(const SyncDbId syncDbId, const Error &error) {
+ActivityListModel::Row ActivityListModel::makeErrorRow(const SyncDbId syncDbId, const Error &error) const {
     const SyncPath relativePath =
             normalizedRelativePath(error.destinationPath().empty() ? error.path() : error.destinationPath());
     const QDateTime timestampUtc = error.time() > 0 ? QDateTime::fromSecsSinceEpoch(error.time(), QTimeZone::UTC) : QDateTime{};
@@ -319,6 +369,7 @@ ActivityListModel::Row ActivityListModel::makeErrorRow(const SyncDbId syncDbId, 
     row.rowId = errorRowId(error.dbId());
     row.syncDbId = syncDbId;
     row.name = itemName(relativePath);
+    row.fileIconName = _fileIconResolver.iconName(row.name, error.nodeType());
     row.folder = parentFolder(relativePath);
     row.timeText = formatRelativeTime(timestampUtc);
     row.nodeType = error.nodeType();
@@ -335,7 +386,7 @@ ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row>
     Row *matchingRow = nullptr;
     MatchScore bestScore = noMatchScore;
     for (auto &row: rows) {
-        if (row.status != Status::Failed) {
+        if (row.status != Status::Failed && row.status != Status::InProgress) {
             continue;
         }
         if (const MatchScore score = errorMatchScore(row, error);
@@ -350,13 +401,21 @@ ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row>
 
 void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
     (void) std::erase_if(rows, [this](const Row &row) {
-        return row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
+        const bool resolvedFailure = row.status == Status::Failed && row.activeErrorDbIds.empty();
+        const bool filteredRemoteActivity =
+                row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
+        return resolvedFailure || filteredRemoteActivity;
     });
     (void) std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
         const bool lhsInProgress = lhs.status == Status::InProgress;
         const bool rhsInProgress = rhs.status == Status::InProgress;
         if (lhsInProgress != rhsInProgress) {
             return lhsInProgress;
+        }
+        const bool lhsHasActiveError = !lhs.activeErrorDbIds.empty();
+        const bool rhsHasActiveError = !rhs.activeErrorDbIds.empty();
+        if (lhsHasActiveError != rhsHasActiveError) {
+            return lhsHasActiveError;
         }
         if (lhs.timestampUtc != rhs.timestampUtc) {
             return lhs.timestampUtc > rhs.timestampUtc;
@@ -372,7 +431,8 @@ void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
  * Returns the strongest non-empty node identity shared by an activity row and an active node error.
  *
  * The comparisons mirror the server's `selectErrorByNodeInfo` lookup: local node id, remote node id, source path, then
- * destination path. A stronger match wins when several recent failed activities could represent the same error.
+ * destination path. A stronger match wins when several recent failed or in-progress activities could represent the same
+ * error.
  */
 ActivityListModel::MatchScore ActivityListModel::errorMatchScore(const Row &row, const Error &error) {
     if (!row.localNodeId.empty() && row.localNodeId == error.localNodeId()) {
@@ -391,6 +451,7 @@ ActivityListModel::MatchScore ActivityListModel::errorMatchScore(const Row &row,
 }
 
 void ActivityListModel::resetProjection() {
+    _projectionRefreshTimer.stop();
     auto nextRows = buildProjection();
     if (_rows == nextRows) {
         return;
@@ -399,6 +460,12 @@ void ActivityListModel::resetProjection() {
     _rows = std::move(nextRows);
     endResetModel();
     emit projectionChanged();
+}
+
+void ActivityListModel::scheduleProjectionReconciliation() {
+    if (!_projectionRefreshTimer.isActive()) {
+        _projectionRefreshTimer.start();
+    }
 }
 
 void ActivityListModel::reconcileProjection() {
@@ -411,12 +478,15 @@ void ActivityListModel::reconcileProjection() {
 }
 
 bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
+    QSet<QString> nextRowIds;
+    nextRowIds.reserve(static_cast<qsizetype>(nextRows.size()));
+    for (const auto &row: nextRows) {
+        (void) nextRowIds.insert(row.rowId);
+    }
+
     bool changed = false;
     for (qsizetype rowIndex = static_cast<qsizetype>(_rows.size()) - 1; rowIndex >= 0; --rowIndex) {
-        const auto rowExists = std::ranges::any_of(nextRows, [this, rowIndex](const Row &row) {
-            return row.rowId == _rows[static_cast<std::size_t>(rowIndex)].rowId;
-        });
-        if (rowExists) {
+        if (nextRowIds.contains(_rows[static_cast<std::size_t>(rowIndex)].rowId)) {
             continue;
         }
         beginRemoveRows({}, rowIndex, rowIndex);
@@ -482,10 +552,13 @@ bool ActivityListModel::updateRow(const qsizetype rowIndex, const Row &nextRow) 
         }
     };
     addRoleIf(row.name != nextRow.name, NameRole);
+    addRoleIf(row.fileIconName != nextRow.fileIconName, FileIconNameRole);
+    addRoleIf(row.actionText != nextRow.actionText, ActionTextRole);
     addRoleIf(row.folder != nextRow.folder, FolderRole);
     addRoleIf(row.timeText != nextRow.timeText, TimeTextRole);
     addRoleIf(row.sizeText != nextRow.sizeText, SizeTextRole);
     addRoleIf(row.nodeType != nextRow.nodeType, NodeTypeRole);
+    addRoleIf(row.nodeType != nextRow.nodeType, IsDirectoryRole);
     addRoleIf(row.status != nextRow.status, StatusRole);
     addRoleIf(row.source != nextRow.source, SourceRole);
     addRoleIf(row.instruction != nextRow.instruction, InstructionRole);

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -65,7 +65,14 @@ QString formatSize(const NodeType nodeType, const int64_t size) {
     if (nodeType == NodeType::Directory || size < 0) {
         return {};
     }
-    return QLocale().formattedDataSize(size);
+    const QLocale locale;
+    QString formatted = locale.formattedDataSize(size, 1, QLocale::DataSizeSIFormat);
+    // Drop the decimal part when it is zero, to match the macOS and Windows clients.
+    const QString trailingZero = locale.decimalPoint() + locale.zeroDigit();
+    if (const auto index = formatted.indexOf(trailingZero); index >= 0) {
+        formatted.remove(index, trailingZero.size());
+    }
+    return formatted;
 }
 
 QString formatAgo(const std::chrono::seconds elapsed, const std::chrono::seconds unit, const char *const unitTranslationId) {

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -449,9 +449,9 @@ ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row>
 void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
     (void) std::erase_if(rows, [this](const Row &row) {
         const bool resolvedFailure = row.status == Status::Failed && row.activeErrorDbIds.empty();
-        const bool filteredRemoteActivity =
+        const bool filteredOutRemoteActivity =
                 row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
-        return resolvedFailure || filteredRemoteActivity;
+        return resolvedFailure || filteredOutRemoteActivity;
     });
     (void) std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
         const bool lhsInProgress = lhs.status == Status::InProgress;

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -131,27 +131,29 @@ ActivityListModel::Source toModelSource(const SyncDirection direction) {
 
 QString activityActionText(const ActivityEntry &activity) {
     switch (activity.instruction) {
-        case SyncFileInstruction::UpdateMetadata: // We shouldn't receive an UpdateMetadata on linux, reserved instruction for
-                                                  // macOS and Windows for the litesync. Here for possible future litesync linux implem.
-        case SyncFileInstruction::Update:
+        using enum SyncFileInstruction;
+
+        case UpdateMetadata: // We shouldn't receive an UpdateMetadata on linux, reserved instruction for macOS and Windows for
+                             // the litesync. Here for possible future litesync linux implem.
+        case Update:
             return qtTrId("activityInstructionUpdateLabel");
-        case SyncFileInstruction::Remove:
+        case Remove:
             return qtTrId("activityInstructionRemoveLabel");
-        case SyncFileInstruction::Move: {
+        case Move: {
             if (!activity.path.empty() && !activity.newPath.empty() &&
                 normalizedRelativePath(activity.path).parent_path() == normalizedRelativePath(activity.newPath).parent_path()) {
                 return qtTrId("activityInstructionRenameLabel");
             }
             return qtTrId("activityInstructionMoveLabel");
         }
-        case SyncFileInstruction::Get:
+        case Get:
             return qtTrId("activityInstructionGetLabel");
-        case SyncFileInstruction::Put:
+        case Put:
             return qtTrId("activityInstructionPutLabel");
-        case SyncFileInstruction::Ignore:
+        case Ignore:
             return qtTrId("activityInstructionIgnoreLabel");
-        case SyncFileInstruction::None:
-        case SyncFileInstruction::EnumEnd:
+        case None:
+        case EnumEnd:
             return {};
     }
     return {};

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -522,14 +522,14 @@ void ActivityListModel::scheduleProjectionReconciliation() {
 
 void ActivityListModel::reconcileProjection() {
     const auto nextRows = buildProjection();
-    bool changed = removeMissingRows(nextRows);
+    bool changed = removeStaleRows(nextRows);
     changed = applyProjectionRows(nextRows) || changed;
     if (changed) {
         emit projectionChanged();
     }
 }
 
-bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
+bool ActivityListModel::removeStaleRows(const std::vector<Row> &nextRows) {
     QSet<QString> nextRowIds;
     nextRowIds.reserve(static_cast<qsizetype>(nextRows.size()));
     for (const auto &row: nextRows) {

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -21,6 +21,7 @@
 #include "app/cache/activitystore.h"
 #include "app/cache/appcache.h"
 #include "app/cache/mainselectionstore.h"
+#include "app/fileiconresolver.h"
 
 #include <QAbstractListModel>
 #include <QDateTime>
@@ -67,6 +68,8 @@ class ActivityListModel final : public QAbstractListModel {
         enum Role {
             RowIdRole = Qt::UserRole + 1,
             NameRole,
+            FileIconNameRole,
+            ActionTextRole,
             FolderRole,
             TimeTextRole,
             SizeTextRole,
@@ -74,6 +77,7 @@ class ActivityListModel final : public QAbstractListModel {
             StatusRole,
             SourceRole,
             InstructionRole,
+            IsDirectoryRole,
             ProgressRole,
             HasActiveErrorRole,
             ActiveErrorCountRole,
@@ -119,6 +123,8 @@ class ActivityListModel final : public QAbstractListModel {
                 GenericId activityLocalId{0};
                 SyncDbId syncDbId{0};
                 QString name;
+                QString fileIconName;
+                QString actionText;
                 QString folder;
                 QString timeText;
                 QString sizeText;
@@ -141,14 +147,15 @@ class ActivityListModel final : public QAbstractListModel {
 
         [[nodiscard]] std::vector<Row> buildProjection() const;
         [[nodiscard]] std::vector<Row> activityRows(SyncDbId syncDbId) const;
-        static void appendActiveErrors(SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows);
-        static void appendActiveError(SyncDbId syncDbId, const Error &error, std::vector<Row> &rows);
-        [[nodiscard]] static Row makeActivityRow(SyncDbId syncDbId, const ActivityEntry &activity);
-        [[nodiscard]] static Row makeErrorRow(SyncDbId syncDbId, const Error &error);
+        void appendActiveErrors(SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows) const;
+        void appendActiveError(SyncDbId syncDbId, const Error &error, std::vector<Row> &rows) const;
+        [[nodiscard]] Row makeActivityRow(SyncDbId syncDbId, const ActivityEntry &activity) const;
+        [[nodiscard]] Row makeErrorRow(SyncDbId syncDbId, const Error &error) const;
         [[nodiscard]] static Row *findMatchingActivity(std::vector<Row> &rows, const Error &error);
         [[nodiscard]] static MatchScore errorMatchScore(const Row &row, const Error &error);
         void finalizeProjection(std::vector<Row> &rows) const;
         void resetProjection();
+        void scheduleProjectionReconciliation();
         void reconcileProjection();
         [[nodiscard]] bool removeMissingRows(const std::vector<Row> &nextRows);
         [[nodiscard]] bool applyProjectionRows(const std::vector<Row> &nextRows);
@@ -160,6 +167,8 @@ class ActivityListModel final : public QAbstractListModel {
         MainSelectionStore &_selectionStore;
         std::vector<Row> _rows;
         Filter _filter{Filter::MyActivityOnly};
+        FileIconResolver _fileIconResolver;
+        QTimer _projectionRefreshTimer;
         QTimer _relativeTimeTimer;
 };
 

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -25,8 +25,10 @@
 
 #include <QAbstractListModel>
 #include <QDateTime>
+#include <QFont>
 #include <QList>
 #include <QString>
+#include <QStringList>
 #include <QTimer>
 
 #include <cstdint>
@@ -43,6 +45,8 @@ namespace KDC {
  */
 class ActivityListModel final : public QAbstractListModel {
         Q_OBJECT
+        Q_PROPERTY(QStringList timeTextSamples READ timeTextSamples CONSTANT)
+        Q_PROPERTY(QStringList sizeTextSamples READ sizeTextSamples CONSTANT)
 
     public:
         enum class Filter : uint8_t {
@@ -97,6 +101,19 @@ class ActivityListModel final : public QAbstractListModel {
 
         /** Returns the stable model row identifier for an activity. */
         [[nodiscard]] static QString activityRowId(GenericId localId);
+
+        /**
+         * Widest strings the time and size columns can ever render in the active locale.
+         *
+         * Both columns are fixed-width, so the view sizes them from these samples instead of a hard-coded constant that
+         * would truncate in the languages with the longest wordings. The values are the real per-tier maxima, not
+         * estimates. Constant because translations are installed once at startup and never swapped at runtime.
+         */
+        [[nodiscard]] static QStringList timeTextSamples();
+        [[nodiscard]] static QStringList sizeTextSamples();
+
+        /** Widest advance width of @p texts rendered with @p font. */
+        [[nodiscard]] Q_INVOKABLE static qreal maxTextWidth(const QStringList &texts, const QFont &font);
 
         [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
         [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -174,7 +174,7 @@ class ActivityListModel final : public QAbstractListModel {
         void resetProjection();
         void scheduleProjectionReconciliation();
         void reconcileProjection();
-        [[nodiscard]] bool removeMissingRows(const std::vector<Row> &nextRows);
+        [[nodiscard]] bool removeStaleRows(const std::vector<Row> &nextRows);
         [[nodiscard]] bool applyProjectionRows(const std::vector<Row> &nextRows);
         [[nodiscard]] bool updateRow(qsizetype rowIndex, const Row &nextRow);
         void refreshRelativeTimes();

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: da, Danish
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="da"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Flyttet til papirkurv</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Omdøbt</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Ændret</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Omdøbt</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: de, German
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="de"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>In den Papierkorb verschoben</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Umbenannt</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Geändert</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Umbenannt</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: el, Greek
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="el"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Μετακινήθηκε στα απορρίμματα</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Μετονομάστηκε</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Τροποποιημένο</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Μετονομάστηκε</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: en, English
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Moved to trash</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Renamed</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Modified</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Renamed</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: es, Spanish
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="es"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Movido a la papelera</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Cambiado de nombre</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Modificado</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Cambiado de nombre</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fi, Finnish
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:20 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fi"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Siirretty roskakoriin</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Nimetty uudelleen</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Muokattu</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Nimetty uudelleen</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fr, French
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fr"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Placé dans la corbeille</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Renommé</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Modifié</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Renommé</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: it, Italian
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:19 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="it"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Spostato nel cestino</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Rinominato</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Modificato</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Rinominato</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nb, Norwegian Bokmål
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:20 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nb"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Flyttet til papirkurven</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Omdøpt</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Endret</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Omdøpt</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nl, Dutch; Flemish
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:20 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nl"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Verplaatst naar prullenbak</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Hernoemd</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Gewijzigd</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Hernoemd</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pl, Polish
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:20 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pl"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Przeniesiono do kosza</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Zmieniono nazwę</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Zmodyfikowany</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Zmieniono nazwę</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pt, Portuguese
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:20 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pt"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Movido para o lixo</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Renomeado</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Modificado</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Renomeado</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: sv, Swedish
  Exported by: Romain Galland
- Exported at: Mon, 17 Aug 2026 11:05:11 +0200 
+ Exported at: Mon, 17 Aug 2026 14:29:20 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="sv"> 
     <context>
@@ -110,13 +110,13 @@
             <source>Moved to trash</source> 
             <translation>Flyttad till papperskorgen</translation> 
         </message> 
+        <message id="activityInstructionRenameLabel"> 
+            <source>Renamed</source> 
+            <translation>Bytt namn</translation> 
+        </message> 
         <message id="activityInstructionUpdateLabel"> 
             <source>Modified</source> 
             <translation>Ändrad</translation> 
-        </message> 
-        <message id="activityInstructionUpdateMetadataLabel"> 
-            <source>Renamed</source> 
-            <translation>Bytt namn</translation> 
         </message> 
         <message id="addAdvancedSyncDialogTitle"> 
             <source>Sync a folder with kDrive</source> 


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR complète la page Activities pour Linux v4 sur trois axes indépendants : le nettoyage des activités « en cours » lorsqu'une synchronisation devient inactive (pause, arrêt, erreur, inactivité), une action « ouvrir le dossier » distincte de l'ouverture de la cible elle-même, et l'enrichissement des lignes d'activité avec une icône de fichier et un libellé d'action. C'est également la branche où `FileIconResolver`, introduit sans appelant dans #2307, est enfin câblé dans `ActivityListModel`.

## Changements
- `ActivityStore::removeInProgress(syncDbId)` : supprime toutes les activités au statut « en cours » d'une synchronisation et émet `activitiesChanged` uniquement si une entrée a effectivement été retirée.
- `CachePipeline::reconcileInProgressActivities(syncDbId)` : nouveau gestionnaire connecté à `AppCache::syncStatusChanged`, qui appelle `ActivityStore::removeInProgress` dès que le statut runtime passe à `Idle`, `Paused`, `Stopped` ou `Error`. `routeActivity` applique désormais le même filtre en amont pour ignorer un item `Syncing` poussé alors que la synchronisation vient de basculer dans l'un de ces états.
- `ActivitiesController::openFolder(rowId)` : nouvelle action `Q_INVOKABLE` qui ouvre le dossier exact représenté par la colonne Folder, même si la cible de l'activité elle-même n'existe plus. `openLocal` et `openFolder` partagent désormais la même validation de chemin (résolution canonique, confinement dans la racine de synchronisation) via une méthode privée commune `openLocalPath(rowId, openDisplayedFolder)`.
- `ActivityListModel` expose deux nouveaux rôles, `FileIconNameRole` et `ActionTextRole`, ainsi que `IsDirectoryRole`. Chaque ligne construite dans `makeActivityRow`/`makeErrorRow` résout désormais son icône de fichier via un membre `FileIconResolver` détenu par le modèle, et `activityActionText` traduit l'instruction serveur (Update, Remove, Move, Get, Put, Ignore...) en libellé d'action affichable. Le cache d'icônes est vidé (`_fileIconResolver.clear()`) à chaque changement de synchronisation sélectionnée pour rester borné à la seule projection affichée.
- Rafraîchissements de projection groupés dans un timer à déclenchement unique de 100 ms (`scheduleProjectionReconciliation`) plutôt que reconciliés immédiatement à chaque signal, pour absorber les rafales d'invalidations du cache.
- Le tri de la projection place désormais les lignes ayant une erreur active juste après les transferts réellement en cours, et les activités en échec dont l'erreur a été résolue sont retirées de la projection. Le score de correspondance activité/erreur (`findMatchingActivity`) reconnaît aussi les lignes « en cours », pas seulement les échecs.
- `removeMissingRows` utilise désormais un `QSet<QString>` des identifiants de ligne suivants au lieu d'une recherche linéaire imbriquée.
- `formatSize()` : les tailles utilisent désormais `QLocale::DataSizeSIFormat` avec une décimale et suppression du zéro final (`5 Mo`, `137,4 Mo`), au lieu du format IEC à deux décimales systématiques (`5,00 Mio`). Aligne Linux sur les clients macOS et Windows, qui suppriment tous deux les zéros de fin.
- `ActivityListModel::timeTextSamples()` / `sizeTextSamples()` et `maxTextWidth(texts, font)` : exposent les chaînes les plus larges que les colonnes Temps et Taille peuvent rendre dans la locale active, et les mesurent via `QFontMetricsF`. Les bornes sont exactes (59 sec, 59 min, 23 h, 3 j ; 999 o puis 999,9 de chaque unité jusqu'au To), pas des estimations. La vue s'en sert pour dimensionner ces colonnes au lieu d'une constante, qui tronquait dans les langues aux formulations les plus longues.
- Mise à jour de `src/gui4/linux/AGENTS.md` : règles de préparation de PR pour la pile Activities, tri/matching des erreurs actives, action « ouvrir le dossier affiché », et documentation de `app/fileiconresolver.*` et des responsabilités élargies d'`ActivityListModel`/`ActivitiesController`.

</details>

---

## Summary
This PR rounds out the Linux v4 Activities page on three independent fronts: clearing in-progress activities once a synchronization goes inactive (paused, stopped, errored, idle), a dedicated "open folder" action distinct from opening the activity target itself, and enriching activity rows with a file icon and an action label. It is also the branch where `FileIconResolver`, introduced with no caller in #2307, finally gets wired into `ActivityListModel`.

## Changes
- `ActivityStore::removeInProgress(syncDbId)`: removes every in-progress activity owned by a synchronization and only emits `activitiesChanged` when an entry was actually removed.
- `CachePipeline::reconcileInProgressActivities(syncDbId)`: new handler connected to `AppCache::syncStatusChanged` that calls `ActivityStore::removeInProgress` as soon as the runtime status becomes `Idle`, `Paused`, `Stopped`, or `Error`. `routeActivity` applies the same guard upfront so a `Syncing` item pushed right after the sync flips into one of those states is dropped rather than ingested.
- `ActivitiesController::openFolder(rowId)`: new `Q_INVOKABLE` action that opens the exact folder represented by the Folder column, even when the activity target itself no longer exists. `openLocal` and `openFolder` now share the same path validation (canonical resolution, containment within the sync root) through a common private `openLocalPath(rowId, openDisplayedFolder)`.
- `ActivityListModel` exposes two new roles, `FileIconNameRole` and `ActionTextRole`, plus `IsDirectoryRole`. Every row built in `makeActivityRow`/`makeErrorRow` now resolves its file icon through a `FileIconResolver` member owned by the model, and `activityActionText` translates the server instruction (Update, Remove, Move, Get, Put, Ignore...) into a displayable action label. The icon cache is cleared (`_fileIconResolver.clear()`) on every selected-sync change so it stays scoped to the currently displayed projection.
- Projection refreshes are now coalesced through a single-shot 100ms timer (`scheduleProjectionReconciliation`) instead of reconciling immediately on every signal, absorbing bursts of cache invalidations.
- Projection sorting now places rows with an active error right after actually in-progress transfers, and failed activities whose error has been resolved are dropped from the projection. The activity/error match score (`findMatchingActivity`) now also recognizes in-progress rows, not only failed ones.
- `removeMissingRows` now uses a `QSet<QString>` of the next row ids instead of a nested linear search.
- `formatSize()`: sizes now use `QLocale::DataSizeSIFormat` with one decimal and the trailing zero stripped (`5 MB`, `137.4 MB`) instead of the IEC format with two always-printed decimals (`5.00 MiB`). This aligns Linux with the macOS and Windows clients, which both drop trailing zeros.
- `ActivityListModel::timeTextSamples()` / `sizeTextSamples()` and `maxTextWidth(texts, font)`: expose the widest strings the time and size columns can render in the active locale and measure them with `QFontMetricsF`. The bounds are exact (59 sec, 59 min, 23 h, 3 d; 999 bytes then 999.9 of each unit up to terabytes), not estimates. The view uses them to size those columns instead of a constant, which truncated in the languages with the longest wordings.
- Updated `src/gui4/linux/AGENTS.md`: PR-preparation rules for the Activities stack, active-error sort/matching behavior, the "open displayed folder" action, and documentation for `app/fileiconresolver.*` and the expanded responsibilities of `ActivityListModel`/`ActivitiesController`.

---

Depends on #2309
