### PR TITLE
fix(ui): reapply window input region on every exposure

### DIFF
--- a/src/gui4/linux/ui/chrome/windowdecorationcontroller.cpp
+++ b/src/gui4/linux/ui/chrome/windowdecorationcontroller.cpp
@@ -317,12 +317,12 @@ void WindowDecorationController::updateWindowDecoration(QWindow *const window, c
         window->installEventFilter(this);
         // The hash keeps a raw pointer, so drop the entry with the window rather than leaving a dangling key that a
         // later window could reuse.
-        connect(window, &QObject::destroyed, this, [this, window] { _decorationRequests.remove(window); });
+        (void) connect(window, &QObject::destroyed, this, [this, window] { (void) _decorationRequests.remove(window); });
     }
 
     const DecorationRequest request{
             .customFrameEnabled = customFrameEnabled, .frameMargin = frameMargin, .resizeHandleThickness = resizeHandleThickness};
-    _decorationRequests.insert(window, request);
+    (void) _decorationRequests.insert(window, request);
     applyDecoration(window, request);
 }
 

--- a/src/gui4/linux/ui/chrome/windowdecorationcontroller.cpp
+++ b/src/gui4/linux/ui/chrome/windowdecorationcontroller.cpp
@@ -19,6 +19,7 @@
 #include "windowdecorationcontroller.h"
 
 #include <QByteArray>
+#include <QEvent>
 #include <QGuiApplication>
 #include <QRegion>
 #include <QWindow>
@@ -31,6 +32,9 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/shape.h>
 #include <xcb/xcb.h>
+// Xlib defines Expose as the numeric X11 event type, which would rewrite QEvent::Expose into a numeric constant. The
+// X11 spelling is unused here, so drop it rather than qualifying every Qt enumerator that collides with it.
+#undef Expose
 #endif
 
 namespace KDC {
@@ -292,20 +296,45 @@ bool WindowDecorationController::customShadowsSupported() const {
     return _customShadowsSupported;
 }
 
+void WindowDecorationController::applyDecoration(QWindow *const window, const DecorationRequest &request) {
+    // Keep the resize handles interactive by excluding only the outer part of the shadow margin. A maximized window
+    // passes a zero frameMargin, so clamping the subtraction restores the full-window input region.
+    const auto interactiveMargin = qMax<int32_t>(0, qRound(request.frameMargin - request.resizeHandleThickness));
+    const auto interactiveWidth = qMax<int32_t>(0, window->width() - (2 * interactiveMargin));
+    const auto interactiveHeight = qMax<int32_t>(0, window->height() - (2 * interactiveMargin));
+    const QRect inputRect{interactiveMargin, interactiveMargin, interactiveWidth, interactiveHeight};
+    applyInputRegion(window, inputRect, request.customFrameEnabled);
+    applyFrameExtents(window, request.customFrameEnabled, request.frameMargin);
+}
+
 void WindowDecorationController::updateWindowDecoration(QWindow *const window, const bool customFrameEnabled,
                                                         const qreal frameMargin, const qreal resizeHandleThickness) {
     if (window == nullptr) {
         return;
     }
 
-    // Keep the resize handles interactive by excluding only the outer part of the shadow margin. A maximized window
-    // passes a zero frameMargin, so clamping the subtraction restores the full-window input region.
-    const auto interactiveMargin = qMax<int32_t>(0, qRound(frameMargin - resizeHandleThickness));
-    const auto interactiveWidth = qMax<int32_t>(0, window->width() - (2 * interactiveMargin));
-    const auto interactiveHeight = qMax<int32_t>(0, window->height() - (2 * interactiveMargin));
-    const QRect inputRect{interactiveMargin, interactiveMargin, interactiveWidth, interactiveHeight};
-    applyInputRegion(window, inputRect, customFrameEnabled);
-    applyFrameExtents(window, customFrameEnabled, frameMargin);
+    if (!_decorationRequests.contains(window)) {
+        window->installEventFilter(this);
+        // The hash keeps a raw pointer, so drop the entry with the window rather than leaving a dangling key that a
+        // later window could reuse.
+        connect(window, &QObject::destroyed, this, [this, window] { _decorationRequests.remove(window); });
+    }
+
+    const DecorationRequest request{
+            .customFrameEnabled = customFrameEnabled, .frameMargin = frameMargin, .resizeHandleThickness = resizeHandleThickness};
+    _decorationRequests.insert(window, request);
+    applyDecoration(window, request);
+}
+
+bool WindowDecorationController::eventFilter(QObject *const watched, QEvent *const event) {
+    if (event->type() == QEvent::Expose) {
+        if (auto *const window = qobject_cast<QWindow *>(watched); window != nullptr && window->isExposed()) {
+            if (const auto request = _decorationRequests.constFind(window); request != _decorationRequests.cend()) {
+                applyDecoration(window, *request);
+            }
+        }
+    }
+    return QObject::eventFilter(watched, event);
 }
 
 } // namespace KDC

--- a/src/gui4/linux/ui/chrome/windowdecorationcontroller.h
+++ b/src/gui4/linux/ui/chrome/windowdecorationcontroller.h
@@ -59,7 +59,7 @@ class WindowDecorationController final : public QObject {
         Q_INVOKABLE void updateWindowDecoration(QWindow *window, bool customFrameEnabled, qreal frameMargin,
                                                 qreal resizeHandleThickness);
 
-    protected:
+    private:
         /**
          * Replays the last decoration request whenever a tracked window becomes exposed.
          *
@@ -73,7 +73,6 @@ class WindowDecorationController final : public QObject {
          */
         bool eventFilter(QObject *watched, QEvent *event) override;
 
-    private:
         struct DecorationRequest {
                 bool customFrameEnabled = false;
                 qreal frameMargin = 0;

--- a/src/gui4/linux/ui/chrome/windowdecorationcontroller.h
+++ b/src/gui4/linux/ui/chrome/windowdecorationcontroller.h
@@ -18,8 +18,10 @@
 
 #pragma once
 
+#include <QHash>
 #include <QObject>
 
+class QEvent;
 class QWindow;
 
 namespace KDC {
@@ -51,12 +53,38 @@ class WindowDecorationController final : public QObject {
          *
          * QML passes logical-pixel measurements. The platform implementation performs any required conversion before
          * updating the native window.
+         *
+         * The request is remembered so that it can be replayed on every later exposure of @p window. See eventFilter().
          */
-        Q_INVOKABLE static void updateWindowDecoration(QWindow *window, bool customFrameEnabled, qreal frameMargin,
-                                                       qreal resizeHandleThickness);
+        Q_INVOKABLE void updateWindowDecoration(QWindow *window, bool customFrameEnabled, qreal frameMargin,
+                                                qreal resizeHandleThickness);
+
+    protected:
+        /**
+         * Replays the last decoration request whenever a tracked window becomes exposed.
+         *
+         * The input region is expressed in logical pixels but consumed in surface coordinates, and the two only agree
+         * once the native surface is mapped with its final scale. An application-wide scale factor makes them differ by
+         * that factor until then, which leaves a painted but click-through band along the right and bottom edges.
+         * Applying the region once, when QML computes it, is therefore not enough: a window that is hidden and shown
+         * again never recomputes it and keeps the mismatched region for the rest of its life. Exposure is the earliest
+         * point where the surface is guaranteed to be mapped, so the region is reapplied there, for every window and
+         * every code path that shows one.
+         */
+        bool eventFilter(QObject *watched, QEvent *event) override;
 
     private:
+        struct DecorationRequest {
+                bool customFrameEnabled = false;
+                qreal frameMargin = 0;
+                qreal resizeHandleThickness = 0;
+        };
+
+        /** Applies @p request to @p window without touching the stored requests. */
+        static void applyDecoration(QWindow *window, const DecorationRequest &request);
+
         bool _customShadowsSupported = false;
+        QHash<const QWindow *, DecorationRequest> _decorationRequests;
 };
 
 } // namespace KDC


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Sous Wayland natif, `WindowDecorationController` définit la région d'entrée de la fenêtre via `QWindow::setMask()` (le chemin XShape/`_GTK_FRAME_EXTENTS` est du code mort hors X11). Le rectangle est calculé en pixels logiques `QWindow`, mais le compositeur l'interprète en coordonnées de surface : lorsqu'un facteur d'échelle applicatif est actif (`QT_SCALE_FACTOR`), les deux espaces diffèrent de ce facteur, ce qui laisse une bande de la fenêtre peinte mais traversante aux clics sur la droite et en bas (clic transmis à la fenêtre du dessous, kDrive passe au second plan). Le bug était masqué au premier affichage : l'événement `wp_fractional_scale_v1.preferred_scale` changeait alors le `devicePixelRatio`, ce qui recalculait la région et la corrigeait par effet de bord. Au réaffichage (masquer/rouvrir), l'échelle est déjà connue, aucun signal ne se déclenche, et la région erronée restait en place pour toute la vie de la fenêtre. Le correctif est entièrement côté C++ ; le QML est inchangé, ce qui le rend valable pour n'importe quelle fenêtre et n'importe quel chemin d'affichage (tray, appel programmatique, restauration après minimisation, ré-exposition), sans avoir à câbler un `onVisibleChanged` dans chaque composant QML.

## Changements
- Ajout d'une struct `DecorationRequest` mémorisant `customFrameEnabled`, `frameMargin` et `resizeHandleThickness` par fenêtre dans `_decorationRequests` (`QHash`), au lieu d'appliquer la requête puis de l'oublier.
- `updateWindowDecoration()` installe un filtre d'événements sur la fenêtre au premier appel pour celle-ci.
- `eventFilter()` rejoue la requête mémorisée à chaque `QEvent::Expose` où la fenêtre est exposée (`window->isExposed()`) : l'exposition est le premier moment où la surface native est garantie montée avec son échelle définitive.
- L'entrée de hash est retirée via `QObject::destroyed`, pour ne pas laisser de clé pendante qu'une fenêtre ultérieure pourrait réutiliser à la même adresse.
- Extraction du calcul de géométrie dans une méthode privée `applyDecoration()`, partagée entre le site d'appel QML et le rejeu déclenché par le filtre d'événements.
- `updateWindowDecoration()` passe de méthode statique à méthode d'instance (`Q_INVOKABLE`) ; le site d'appel QML reste identique.
- Ajout d'un `#undef Expose` après les includes X11 : Xlib définit `Expose` comme macro numérique (`#define Expose 12`), ce qui réécrivait silencieusement `QEvent::Expose` en `QEvent::12` et cassait la compilation dès que `QT_CONFIG(xcb)` est actif. Le symbole X11 `Expose` n'est pas utilisé dans ce fichier.

## Tests
Pas de captures d'écran : la preuve est protocolaire, capturée via `WAYLAND_DEBUG=1`.

Commande :

    QT_SCALE_FACTOR=1.3 WAYLAND_DEBUG=1 ./kdrive_qml 2>&1 | grep -E "wl_region#[0-9]+\.add"

Avant le correctif, surface de 1336x1009, région émise `(56, 56, 916, 664)` au lieu de `(73, 73, 1190, 863)` : 3 appels `set_input_region` sur toute la session, celui du réaffichage restant bloqué sur la valeur non convertie.

    wl_region#47.add(56, 56, 916, 664)     <- création, non converti
    wp_fractional_scale_v1#43.preferred_scale(150)
    wl_region#47.add(73, 73, 1191, 863)    <- corrigé par effet de bord
    wl_region#46.add(56, 56, 916, 664)     <- réaffichage, jamais corrigé

Après le correctif, la valeur initiale est corrigée en 21 ms, puis les 53 appels suivants restent tous à la marge 73, y compris après une pause d'inactivité d'environ 10 secondes et à travers une session complète de redimensionnement interactif (largeurs de 1191 à 2496 px, hauteurs de 759 à 1217 px).

    wl_region#47.add(56, 56, 916, 664)
    wl_region#47.add(73, 73, 1191, 863)
    wl_region#50.add(73, 73, 1191, 866)
    ...
    wl_region#53.add(73, 73, 2370, 1081)

Critère de validation : pour une surface `set_destination(W, H)`, une région `add(m, m, w, h)` est correcte si `w == W - 2m` et `h == H - 2m`. Exemple : `1191 + 2 x 73 = 1337`, à comparer à la largeur de surface de 1336.

## Notes
- Portée limitée : le bug ne se manifeste que lorsqu'un facteur d'échelle applicatif est actif (`QT_SCALE_FACTOR`). En configuration par défaut, l'espace logique et l'espace de surface coïncident et la région était déjà correcte ; la variable était positionnée manuellement pour les besoins du test, ce n'est pas une configuration par défaut du produit. À considérer comme un défaut de robustesse réel, pas comme un plantage généralisé pour tous les utilisateurs.
- Pas encore compilé dans le projet : seulement vérifié en syntaxe isolée (`g++ -fsyntax-only` contre le Qt système). Le `moc` doit être régénéré puisque le `Q_INVOKABLE` passe de méthode statique à méthode d'instance.
- Environnement de reproduction : Ubuntu 26.04, GNOME, Wayland natif, Qt 6.11.1.

</details>

---

## Summary
On native Wayland, `WindowDecorationController` sets the window's input region via `QWindow::setMask()` (the XShape/`_GTK_FRAME_EXTENTS` path is dead code outside X11). The rectangle is computed in `QWindow` logical pixels, but the compositor interprets it in surface coordinates: when an application-wide scale factor is active (`QT_SCALE_FACTOR`), the two spaces differ by that factor, leaving a band of the window painted but click-through along the right and bottom edges (the click is forwarded to the window underneath, and kDrive drops to the background). The bug was masked on first show: the `wp_fractional_scale_v1.preferred_scale` event changed `devicePixelRatio` at that point, which recomputed the region and fixed it as a side effect. On re-show (hide/reopen), the scale is already known, nothing triggers a recompute, and the wrong region stays in place for the rest of the window's life. The fix is entirely on the C++ side; QML is unchanged, which makes it valid for any window and any display path (tray, programmatic call, restore from minimized, re-exposure) without wiring an `onVisibleChanged` into every QML component.

## Changes
- Add a `DecorationRequest` struct that remembers `customFrameEnabled`, `frameMargin`, and `resizeHandleThickness` per window in `_decorationRequests` (`QHash`), instead of applying the request and forgetting it.
- `updateWindowDecoration()` installs an event filter on the window the first time it is called for that window.
- `eventFilter()` replays the stored request on every `QEvent::Expose` where the window is exposed (`window->isExposed()`): exposure is the earliest point where the native surface is guaranteed to be mapped with its final scale.
- The hash entry is removed via `QObject::destroyed`, so a dangling key that a later window could reuse at the same address is never left behind.
- Extract the geometry computation into a private `applyDecoration()` method, shared between the QML call site and the replay triggered by the event filter.
- `updateWindowDecoration()` changes from a static method to an instance method (`Q_INVOKABLE`); the QML call site is unchanged.
- Add `#undef Expose` after the X11 includes: Xlib defines `Expose` as a numeric macro (`#define Expose 12`), which was silently rewriting `QEvent::Expose` into `QEvent::12` and breaking the build whenever `QT_CONFIG(xcb)` is active. The X11 symbol `Expose` is not used in this file.

## Testing
No screenshots: the evidence is protocol-level, captured via `WAYLAND_DEBUG=1`.

Command:

    QT_SCALE_FACTOR=1.3 WAYLAND_DEBUG=1 ./kdrive_qml 2>&1 | grep -E "wl_region#[0-9]+\.add"

Before the fix, on a 1336x1009 surface, the emitted region was `(56, 56, 916, 664)` instead of `(73, 73, 1190, 863)`: 3 `set_input_region` calls over the whole session, with the re-show one stuck on the unconverted value.

    wl_region#47.add(56, 56, 916, 664)     <- initial, unconverted
    wp_fractional_scale_v1#43.preferred_scale(150)
    wl_region#47.add(73, 73, 1191, 863)    <- fixed as a side effect
    wl_region#46.add(56, 56, 916, 664)     <- re-show, never fixed

After the fix, the initial value is corrected within 21ms, and all 53 subsequent calls stay at the 73 margin, including after an idle pause of about 10 seconds and across a full interactive resize session (widths from 1191 to 2496px, heights from 759 to 1217px).

    wl_region#47.add(56, 56, 916, 664)
    wl_region#47.add(73, 73, 1191, 863)
    wl_region#50.add(73, 73, 1191, 866)
    ...
    wl_region#53.add(73, 73, 2370, 1081)

Validation criterion: for a surface with `set_destination(W, H)`, a region `add(m, m, w, h)` is correct if `w == W - 2m` and `h == H - 2m`. Example: `1191 + 2 x 73 = 1337`, matching the surface width of 1336.

## Notes
- Limited scope: the bug only manifests when an application-wide scale factor is active (`QT_SCALE_FACTOR`). In the default configuration, logical space and surface space coincide and the region was already correct; the variable was set manually for testing purposes, it is not a default product configuration. This should be read as a real robustness gap, not a crash affecting users generally.
- Not yet compiled in the project: only checked with isolated syntax (`g++ -fsyntax-only` against the system Qt). `moc` needs to be regenerated since the `Q_INVOKABLE` method changes from static to instance.
- Reproduction environment: Ubuntu 26.04, GNOME, native Wayland, Qt 6.11.1.