### PR TITLE
fix(comm): make IPC shutdown graceful and idempotent on quit

### DIFF
--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -149,7 +149,7 @@ void AppClientLinux::setupSignalConnections() {
                    &SystemTrayController::handleUpdateStateChanged);
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
-    (void) connect(&_serverCommService, &CommService::quit, this, &AppClientLinux::quitOnServerDisconnection);
+    (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::openOnboardingWindowRequested, &_systemTrayController,
                    &SystemTrayController::showMainWindow);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -48,6 +48,11 @@ namespace KDC {
 
 Q_LOGGING_CATEGORY(lcAppClientLinux, "gui.v4.app", QtInfoMsg)
 
+namespace {
+// Upper bound on how long the client waits for the server to close the IPC connection before quitting on its own.
+constexpr int32_t serverDisconnectionTimeoutMs = 5000;
+} // namespace
+
 AppClientLinux::AppClientLinux(int &argc, char **argv) :
     QApplication(argc, argv) {
     setupLogging();
@@ -144,7 +149,7 @@ void AppClientLinux::setupSignalConnections() {
                    &SystemTrayController::handleUpdateStateChanged);
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
-    (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
+    (void) connect(&_serverCommService, &CommService::quit, this, &AppClientLinux::quitOnServerDisconnection);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::openOnboardingWindowRequested, &_systemTrayController,
                    &SystemTrayController::showMainWindow);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,
@@ -188,8 +193,13 @@ void AppClientLinux::setupIpcConnection() {
 }
 
 void AppClientLinux::handleIpcDisconnection() {
-    // Normal UTILITY_QUIT paths stop the application before the server closes the socket. This cleanup therefore runs only
-    // when an established IPC connection is lost unexpectedly.
+    if (_quitPending) {
+        // The server closed the socket because it is shutting down, as awaited by quitOnServerDisconnection(). Resetting
+        // the UI and the caches at this point would only make the closing application flicker.
+        return;
+    }
+
+    // This cleanup therefore runs only when an established IPC connection is lost unexpectedly.
     _systemTrayController.setProductStateInitialized(false);
     _appRouter.hideMainWindow();
     _appCache.clearAll();
@@ -245,7 +255,7 @@ void AppClientLinux::updateLoggerMinLevel() const {
                              << QString::fromStdString(toString(parametersInfo->logLevel()));
 }
 
-void AppClientLinux::requestQuit() const {
+void AppClientLinux::requestQuit() {
     qCInfo(lcAppClientLinux) << "Quit requested from system tray";
     if (!_ipcClient.isConnected()) {
         qCWarning(lcAppClientLinux) << "IPC is not connected, quitting application directly";
@@ -253,11 +263,42 @@ void AppClientLinux::requestQuit() const {
         return;
     }
 
-    _serverCommService.requestQuit([](const auto &exitInfo) {
+    _serverCommService.requestQuit([this](const auto &exitInfo) {
         if (!exitInfo) {
-            qCWarning(lcAppClientLinux) << "Server quit request failed";
+            qCWarning(lcAppClientLinux) << "Server quit request failed, quitting application directly";
+            quit();
+            return;
         }
+
+        quitOnServerDisconnection();
+    });
+}
+
+/**
+ * Keeps the application alive until the server closes the IPC connection during its own shutdown.
+ * Tearing the socket down from here instead would leave the server reading a connection dropped mid-TLS-session and
+ * logging shutdown errors. Quits anyway after serverDisconnectionTimeoutMs if the server never closes.
+ */
+void AppClientLinux::quitOnServerDisconnection() {
+    if (_quitPending) {
+        return;
+    }
+    _quitPending = true;
+
+    if (!_ipcClient.isConnected()) {
         quit();
+        return;
+    }
+
+    _ipcClient.expectDisconnection();
+    (void) connect(&_ipcClient, &IpcClient::disconnected, this, [] {
+        qCInfo(lcAppClientLinux) << "Server closed the IPC connection, quitting";
+        QCoreApplication::quit();
+    });
+    QTimer::singleShot(serverDisconnectionTimeoutMs, this, [] {
+        qCWarning(lcAppClientLinux) << "Server did not close the IPC connection within" << serverDisconnectionTimeoutMs
+                                    << "ms, quitting anyway";
+        QCoreApplication::quit();
     });
 }
 

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -110,7 +110,8 @@ class AppClientLinux : public QApplication {
         void handleBootstrapCompletion();
         void refreshUpdaterState();
         void updateLoggerMinLevel() const;
-        void requestQuit() const;
+        void requestQuit();
+        void quitOnServerDisconnection();
         void openMainWindow();
         void openOnboardingFromHome();
         void handleConfiguredSyncsChanged();
@@ -152,6 +153,7 @@ class AppClientLinux : public QApplication {
         bool _mainWindowDismissedDuringBootstrap{false};
         bool _preferSetupHomeWhenUnconfigured{false};
         bool _hadConfiguredSync{false};
+        bool _quitPending{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/communicationlayer/ipcclient.cpp
+++ b/src/gui4/linux/communicationlayer/ipcclient.cpp
@@ -253,13 +253,21 @@ void IpcClient::onConnected() {
 /**
  * Handles socket disconnection.
  * Before the first successful connection: schedules a reconnection retry (server may not be ready yet).
- * After the first successful connection: considered fatal — emits disconnected() and calls exit(EXIT_FAILURE).
+ * During a shutdown (see expectDisconnection()): the expected end of the session, only disconnected() is emitted.
+ * Otherwise: considered fatal — emits disconnected() and calls exit(EXIT_FAILURE).
  */
 void IpcClient::onDisconnected() {
     if (!_hasConnectedOnce) {
         scheduleInitialConnectionRetry("Socket disconnected before the first successful connection");
         return;
     }
+
+    if (_disconnectionExpected) {
+        qCInfo(lcIpcClient) << "Socket closed by the server during shutdown";
+        emit disconnected();
+        return;
+    }
+
     qCWarning(lcIpcClient) << "Socket disconnected";
     emit disconnected();
     SentryService::reportFatalAndExit("IPC disconnected after connection", "Socket disconnected after initial connection.");
@@ -268,12 +276,24 @@ void IpcClient::onDisconnected() {
 /**
  * Handles socket errors.
  * Before the first successful connection: schedules a retry (e.g. server not started yet, port not bound).
- * After the first successful connection: considered fatal — logs the error and calls exit(EXIT_FAILURE).
+ * During a shutdown (see expectDisconnection()): the server closing the TLS session surfaces as
+ * RemoteHostClosedError, which is the awaited outcome and not an error.
+ * Otherwise: considered fatal — logs the error and calls exit(EXIT_FAILURE).
  * @param socketError The socket error code (see QAbstractSocket::SocketError).
  */
 void IpcClient::onErrorOccurred(const QAbstractSocket::SocketError socketError) {
     if (!_hasConnectedOnce) {
         scheduleInitialConnectionRetry(QString("Socket error %1 - %2").arg(toInt(socketError)).arg(_socket->errorString()));
+        return;
+    }
+
+    if (_disconnectionExpected) {
+        // The server closing the TLS session surfaces as RemoteHostClosedError twice, once for the TLS layer and once for
+        // the underlying socket. onDisconnected() already traces the closure, only an unexpected error is worth a line.
+        if (socketError != QAbstractSocket::RemoteHostClosedError) {
+            qCWarning(lcIpcClient) << "Socket error while waiting for the server to close:" << socketError << "-"
+                                   << _socket->errorString();
+        }
         return;
     }
 

--- a/src/gui4/linux/communicationlayer/ipcclient.h
+++ b/src/gui4/linux/communicationlayer/ipcclient.h
@@ -51,6 +51,13 @@ class IpcClient : public QObject {
         [[nodiscard]] bool isConnected() const { return _socket->state() == QAbstractSocket::ConnectedState; }
         void sendRequest(RequestNum num, const Poco::DynamicStruct &params = {}, ResponseCallback callback = nullptr);
 
+        /**
+         * Declares that the server is about to close the connection as part of a shutdown.
+         * Until then, losing the connection is fatal; afterwards it is the expected end of the session and only
+         * disconnected() is emitted.
+         */
+        void expectDisconnection() { _disconnectionExpected = true; }
+
     signals:
         void connected();
         void disconnected();
@@ -82,6 +89,7 @@ class IpcClient : public QObject {
         int32_t _nextId{0};
         QHash<int32_t, ResponseCallback> _pendingCallbacks;
         bool _hasConnectedOnce{false};
+        bool _disconnectionExpected{false};
         uint32_t _initialConnectionAttemptCount{0};
         quint16 _configuredPort{0};
         QSslCertificate _pinnedCert;

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -266,11 +266,16 @@ void SocketCommServer::close() {
 
         // Close the established channels here rather than leaving it to ~SocketCommServer: the peer is waiting for this
         // shutdown to quit, and the destructor only runs at the very end of the server cleanup.
+        // Copy the list first: close() blocks on the channel's socket mutex, which a pending receiveBytes() can hold for
+        // up to channelReceiveTimeoutSec, and _channelsMutex must not be held that long.
+        // create a copy to avoid hold the lock for up to channelReceiveTimeoutSec
+        std::list<std::shared_ptr<AbstractCommChannel>> channels;
         {
             const std::scoped_lock lock(_channelsMutex);
-            for (const auto &channel: _channels) {
-                channel->close();
-            }
+            channels = _channels;
+        }
+        for (const auto &channel: channels) {
+            channel->close();
         }
 
         LOG_DEBUG(Log::instance()->getLogger(), name() << " stopped");

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -264,11 +264,9 @@ void SocketCommServer::close() {
             _serverSocketThread->join();
         }
 
-        // Close the established channels here rather than leaving it to ~SocketCommServer: the peer is waiting for this
-        // shutdown to quit, and the destructor only runs at the very end of the server cleanup.
-        // Copy the list first: close() blocks on the channel's socket mutex, which a pending receiveBytes() can hold for
-        // up to channelReceiveTimeoutSec, and _channelsMutex must not be held that long.
-        // create a copy to avoid hold the lock for up to channelReceiveTimeoutSec
+        // Close here and not in ~SocketCommServer: the peer linux waits for this shutdown to quit, and the destructor only
+        // runs at the end of the cleanup. Copy the list first, close() can block on the channel's socket mutex.
+        // windows peer doesn't wait for the server to quit.
         std::list<std::shared_ptr<AbstractCommChannel>> channels;
         {
             const std::scoped_lock lock(_channelsMutex);

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -82,8 +82,7 @@ uint64_t SocketCommChannel::readData(CommChar *data, uint64_t maxlen) {
         return 0;
     } catch (Poco::Exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::receiveBytes: " << ex.displayText());
-        _isClosing = true;
-        lostConnectionCbk();
+        if (!_isClosing.exchange(true)) lostConnectionCbk();
         close();
         _pendingRead = false;
         return 0;
@@ -92,8 +91,9 @@ uint64_t SocketCommChannel::readData(CommChar *data, uint64_t maxlen) {
     if (lenReceived <= 0) {
         LOG_DEBUG(Log::instance()->getLogger(),
                   (lenReceived == 0 ? "Socket connection closed by peer" : "Socket connection error"));
-        _isClosing = true;
-        lostConnectionCbk();
+        // Only report a lost connection when the channel was still open: a read racing with a deliberate close()
+        // reaches this point too.
+        if (!_isClosing.exchange(true)) lostConnectionCbk();
         close();
         _pendingRead = false;
         return 0;
@@ -109,6 +109,13 @@ uint64_t SocketCommChannel::writeData(const CommChar *data, uint64_t len) {
     if (len > std::numeric_limits<int>::max() / sizeof(CommChar)) {
 #pragma pop_macro("max")
         LOG_ERROR(Log::instance()->getLogger(), "Socket writeData error: data length too large");
+        return 0;
+    }
+
+    if (_isClosing) {
+        // The channel is being torn down (server stopping or connection lost): the socket is already shut down, sending
+        // would only raise an exception.
+        LOG_DEBUG(Log::instance()->getLogger(), "Channel is closing, outgoing data discarded");
         return 0;
     }
 
@@ -151,6 +158,8 @@ void SocketCommChannel::callbackHandler() {
             break;
         }
 
+        if (_isClosing) break; // Closed while polling: this is a deliberate shutdown, not a lost connection
+
         _pendingRead = true;
         readyReadCbk();
         while (!_isClosing && _pendingRead) { // Wait until readData is called before polling again
@@ -190,6 +199,11 @@ bool SocketCommChannel::isReadable() const {
 }
 
 void SocketCommChannel::close() {
+    _isClosing = true;
+    // The lost-connection path and ~SocketCommChannel both close the channel: shutdown() must run only once, a second
+    // one always throws on an already closed TLS session.
+    if (_closed.exchange(true)) return;
+
     try {
         std::lock_guard lock(_socketMutex);
         _socket.shutdown();
@@ -248,6 +262,15 @@ void SocketCommServer::close() {
 
         if (_serverSocketThread && _serverSocketThread->joinable()) {
             _serverSocketThread->join();
+        }
+
+        // Close the established channels here rather than leaving it to ~SocketCommServer: the peer is waiting for this
+        // shutdown to quit, and the destructor only runs at the very end of the server cleanup.
+        {
+            const std::scoped_lock lock(_channelsMutex);
+            for (const auto &channel: _channels) {
+                channel->close();
+            }
         }
 
         LOG_DEBUG(Log::instance()->getLogger(), name() << " stopped");

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -54,6 +54,7 @@ class SocketCommChannel : public AbstractCommChannel {
 
     private:
         std::atomic<bool> _isClosing{false};
+        std::atomic<bool> _closed{false};
         std::atomic<bool> _pendingRead{false};
         std::unique_ptr<StdLoggingThread> _callbackThread{nullptr};
         Poco::Net::StreamSocket _socket;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
À chaque quit du client, le serveur logguait deux fois la même erreur TLS (`Exception in StreamSocket::shutdown`) suivie d'un `Failed to join callback thread`. En cause : le client coupait la socket dès réception de la réponse à `UTILITY_QUIT`, sans `close_notify` TLS, ce qui faisait appeler `SocketCommChannel::close()` deux fois sur le même canal depuis deux threads différents (le thread `callbackHandler` via `readData()`, et le thread `postponedLostConnectionCbk` via le destructeur du canal), chacun retentant un `_socket.shutdown()` sur une session déjà morte. Cette PR rend la fermeture idempotente côté serveur et inverse l'ordre de fermeture : désormais c'est le serveur qui ferme la connexion IPC en premier, et le client attend ce signal avant de quitter.

## Changements
Côté serveur (`socketcommserver.h`/`.cpp`) :
- `SocketCommChannel::close()` devient idempotent grâce à un nouveau flag atomique `_closed` ; un second appel ne refait plus de `_socket.shutdown()`.
- `close()` pose aussi `_isClosing`, pour que toute fermeture (volontaire ou non) mette le canal dans le même état cohérent.
- `writeData()` sort immédiatement si `_isClosing` au lieu de tenter un `sendBytes` voué à l'échec.
- `callbackHandler()` sort de sa boucle de poll dès que `_isClosing` est posé.
- `readData()` : `if (!_isClosing.exchange(true)) lostConnectionCbk();` referme la fenêtre de course où un `read` était déjà en vol au moment d'un `close()` externe.
- `SocketCommServer::close()` ferme désormais explicitement tous les canaux établis (`_channels`), au lieu de laisser cela au destructeur `~SocketCommServer`, qui ne s'exécute qu'à la toute fin de `AppServer::cleanup()` (après `stopAllSyncPals()`, potentiellement plusieurs secondes plus tard). La fermeture arrive donc désormais dès `CommManager::stop()`, en tête du cleanup serveur.

Côté client (`ipcclient.h`/`.cpp`, `appclientlinux.h`/`.cpp`) :
- Nouvelle méthode `IpcClient::expectDisconnection()` qui bascule la connexion en mode « fin de session attendue ».
- `onDisconnected()` : quand une déconnexion est attendue, elle n'est plus traitée comme fatale (plus de `SentryService::reportFatalAndExit()`) ; seul le signal `disconnected()` est émis.
- `onErrorOccurred()` : en mode attendu, le `RemoteHostClosedError` que Qt émet deux fois (couche TLS puis socket sous-jacente) à la réception du `close_notify` est silencieux ; tout autre code d'erreur passe en `qCWarning` au lieu d'être fatal.
- Nouvelle méthode `AppClientLinux::quitOnServerDisconnection()` : appelle `expectDisconnection()`, attend le signal `disconnected()` de l'IPC, et quitte quand même après un timeout de 5 s (`serverDisconnectionTimeoutMs`) si le serveur ne ferme jamais la connexion.
- Elle est branchée sur le seul chemin de sortie existant sur Linux : la réponse à la requête `UTILITY_QUIT`, déclenchée depuis le system tray. Le signal `UTILITY_QUIT` initié par le serveur n'est pas concerné : `AppServer::sendQuit()` n'est câblé que sur macOS (callback de relaunch Sparkle), il ne peut donc pas parvenir au client Linux.
- `AppClientLinux::requestQuit()` n'est plus `const` (elle modifie désormais l'état `_quitPending`) et quitte directement si l'IPC n'est pas connectée ou si la requête `UTILITY_QUIT` échoue côté serveur.
- `handleIpcDisconnection()` sort immédiatement si `_quitPending` est vrai : inutile de vider les caches et de cacher la fenêtre principale sur une application déjà en cours de fermeture.

</details>

---

## Summary
On every client quit, the server was logging the same TLS error twice (`Exception in StreamSocket::shutdown`), followed by a `Failed to join callback thread`. The root cause: the client tore down the socket as soon as it received the `UTILITY_QUIT` response, without a TLS `close_notify`, which made `SocketCommChannel::close()` get called twice on the same channel from two different threads (the `callbackHandler` thread via `readData()`, and the `postponedLostConnectionCbk` thread via the channel's destructor), each retrying `_socket.shutdown()` on an already-dead session. This PR makes the close path idempotent on the server side and inverts the shutdown order: the server now closes the IPC connection first, and the client waits for that signal before quitting.

## Changes
Server side (`socketcommserver.h`/`.cpp`):
- `SocketCommChannel::close()` becomes idempotent via a new atomic `_closed` flag; a second call no longer retries `_socket.shutdown()`.
- `close()` also sets `_isClosing`, so any closure (deliberate or not) puts the channel in the same consistent state.
- `writeData()` returns immediately when `_isClosing` instead of attempting a `sendBytes` that would fail.
- `callbackHandler()` breaks out of its poll loop as soon as `_isClosing` is set.
- `readData()`: `if (!_isClosing.exchange(true)) lostConnectionCbk();` closes the race window where a read was already in flight when an external `close()` happened.
- `SocketCommServer::close()` now explicitly closes all established channels (`_channels`), instead of leaving that to `~SocketCommServer`, which only runs at the very end of `AppServer::cleanup()` (after `stopAllSyncPals()`, potentially several seconds later). Closing now happens as early as `CommManager::stop()`, at the top of the server cleanup.

Client side (`ipcclient.h`/`.cpp`, `appclientlinux.h`/`.cpp`):
- New `IpcClient::expectDisconnection()` method that switches the connection into an "expected end of session" mode.
- `onDisconnected()`: when a disconnection is expected, it is no longer treated as fatal (no more `SentryService::reportFatalAndExit()`); only the `disconnected()` signal is emitted.
- `onErrorOccurred()`: in expected mode, the `RemoteHostClosedError` that Qt raises twice (TLS layer, then the underlying socket) when the `close_notify` is received is silenced; any other error code is now a `qCWarning` instead of fatal.
- New `AppClientLinux::quitOnServerDisconnection()` method: calls `expectDisconnection()`, waits for the IPC `disconnected()` signal, and quits anyway after a 5s timeout (`serverDisconnectionTimeoutMs`) if the server never closes the connection.
- It is wired into the only exit path that exists on Linux: the response to the `UTILITY_QUIT` request, triggered from the system tray. The server-initiated `UTILITY_QUIT` signal is out of scope: `AppServer::sendQuit()` is only wired on macOS (Sparkle relaunch callback), so it can never reach the Linux client.
- `AppClientLinux::requestQuit()` is no longer `const` (it now updates the `_quitPending` state) and quits directly if the IPC is not connected or if the server-side `UTILITY_QUIT` request fails.
- `handleIpcDisconnection()` returns immediately when `_quitPending` is true: there is no point clearing caches and hiding the main window on an application that is already shutting down.