### PR TITLE
fix(activities): address PR 2313 review feedback

### DIFF
--- a/src/gui4/linux/ui/components/IKToolTip.qml
+++ b/src/gui4/linux/ui/components/IKToolTip.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import QtQuick

--- a/src/gui4/linux/ui/tokens/IKActivities.qml
+++ b/src/gui4/linux/ui/tokens/IKActivities.qml
@@ -47,8 +47,8 @@ QtObject {
     readonly property real actionMenuIconSlotSize: 16
     readonly property real actionMenuSeparatorHeight: 11
     readonly property real progressStrokeWidth: 2
-    readonly property real emptyIllustrationWidth: 183
-    readonly property real emptyIllustrationHeight: 120.094
+    readonly property real noActivityIllustrationWidth: 183
+    readonly property real noActivityIllustrationHeight: 120.094
     readonly property real emptyContentSpacing: IKSpacing.s32
     readonly property real emptyTextSpacing: IKSpacing.s8
     readonly property real emptyTitleSize: 15

--- a/src/gui4/linux/ui/tokens/IKActivities.qml
+++ b/src/gui4/linux/ui/tokens/IKActivities.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma Singleton

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -170,8 +170,6 @@ QtObject {
     readonly property color homeSyncingForeground: darkMode ? _p.kDriveLight : _p.blue600
     readonly property color homeSyncingSurface: darkMode ? _p.kDriveDark : _p.bluePale
     readonly property color activitiesFilterSurface: surfaceSecondary
-    readonly property color activitiesFilterSelectedSurface: actionPrimary
-    readonly property color activitiesFilterSelectedText: actionOnPrimary
     readonly property color activitiesRowAlternateSurface: surfaceSecondary
     readonly property color activitiesDivider: surfaceTertiary
     readonly property color activitiesFileIcon: textTertiary

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesEmptyState.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesEmptyState.qml
@@ -28,8 +28,8 @@ Item {
 
         Image {
             anchors.horizontalCenter: parent.horizontalCenter
-            width: IKActivities.emptyIllustrationWidth
-            height: IKActivities.emptyIllustrationHeight
+            width: IKActivities.noActivityIllustrationWidth
+            height: IKActivities.noActivityIllustrationHeight
             source: ThemeMode.isDark ? "qrc:/assets/main/activities/empty-dark.svg" : "qrc:/assets/main/activities/empty.svg"
             fillMode: Image.PreserveAspectFit
             sourceSize.width: width

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesEmptyState.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesEmptyState.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import QtQuick

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesFilterMenu.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesFilterMenu.qml
@@ -85,7 +85,7 @@ Popup {
             required property int index
 
             readonly property bool selected: root.controller.filter === modelData.filter
-            readonly property color foregroundColor: selected ? IKColors.activitiesFilterSelectedText : IKColors.textPrimary
+            readonly property color surfaceColor: hovered || down || visualFocus ? IKColors.surfaceTertiary : "transparent"
 
             width: optionsList.width
             height: IKActivities.filterMenuOptionHeight
@@ -106,14 +106,14 @@ Popup {
                     width: IKActivities.filterIconSize
                     height: IKActivities.filterIconSize
                     source: option.modelData.icon
-                    color: option.foregroundColor
+                    color: IKColors.textPrimary
                 }
 
                 Text {
                     width: Math.max(0, parent.width - x)
                     anchors.verticalCenter: parent.verticalCenter
                     text: option.modelData.label
-                    color: option.foregroundColor
+                    color: IKColors.textPrimary
                     font.pixelSize: IKFonts.bodySize
                     font.weight: IKFonts.emphasized
                     elide: Text.ElideRight
@@ -122,7 +122,7 @@ Popup {
 
             background: Rectangle {
                 radius: IKRadius.r8
-                color: option.selected ? IKColors.activitiesFilterSelectedSurface : option.hovered || option.visualFocus ? IKColors.surfaceTertiary : "transparent"
+                color: option.surfaceColor
                 border.width: option.visualFocus ? 2 : 0
                 border.color: IKColors.accentPrimary
             }

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesFilterMenu.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesFilterMenu.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesHeader.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesHeader.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesTable.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesTable.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesTableHeader.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesTableHeader.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivitiesView.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitiesView.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivityFileIcon.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivityFileIcon.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import QtQuick

--- a/src/gui4/linux/ui/windows/main/activities/ActivityOptionsMenu.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivityOptionsMenu.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivityProgressRing.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivityProgressRing.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import QtQuick

--- a/src/gui4/linux/ui/windows/main/activities/ActivityRow.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivityRow.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound

--- a/src/gui4/linux/ui/windows/main/activities/ActivitySourceIcon.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivitySourceIcon.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import QtQuick

--- a/src/gui4/linux/ui/windows/main/activities/ActivityStatusIcon.qml
+++ b/src/gui4/linux/ui/windows/main/activities/ActivityStatusIcon.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import QtQuick

--- a/src/gui4/linux/ui/windows/main/sidebar/SidebarNotification.qml
+++ b/src/gui4/linux/ui/windows/main/sidebar/SidebarNotification.qml
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 pragma ComponentBehavior: Bound


### PR DESCRIPTION
## Summary
This follow-up addresses the review feedback left by @luc-guyot-infomaniak on PR #2313. It completes the GPL headers in the affected Linux v4 QML files, clarifies the empty-state illustration tokens, and simplifies the Activities filter menu states.

## Changes
- Completed the standard GPL notice in the affected Linux v4 QML files after auditing `src/gui4/linux` for truncated headers.
- Renamed the generic empty illustration dimensions to `noActivityIllustrationWidth` and `noActivityIllustrationHeight`, including their `ActivitiesEmptyState` consumers.
- Simplified `ActivitiesFilterMenu` state styling through a dedicated `surfaceColor` property.
- Removed the persistent selected-option color from the filter menu so options remain neutral until hovered, pressed, or keyboard-focused.
- Removed the selection color tokens that are no longer used.

----

## PR #2313 Review Feedback

### Empty-state illustration naming

> `readonly property real noActivitesIllustrationWidth: 183`

[Review response thread](https://github.com/Infomaniak/desktop-kDrive/pull/2313#discussion_r3821511633)

The dimensions are now named `noActivityIllustrationWidth` and `noActivityIllustrationHeight`. The singular `Activity` wording avoids the typo in the suggestion while keeping both properties explicit and consistent. The token rename is implemented by [`01fe5098c`](https://github.com/Infomaniak/desktop-kDrive/commit/01fe5098c04163e8866288db36a34a4b9b331420), and the `ActivitiesEmptyState` references are updated by [`ae906ae1a`](https://github.com/Infomaniak/desktop-kDrive/commit/ae906ae1ad3aa8f80359d6286269edc753f2a642).

### Complete license header

> The header is smaller than the usual ones, see e.g., `src/gui/aboutdialog.h`.

[Review response thread](https://github.com/Infomaniak/desktop-kDrive/pull/2313#discussion_r3821527074)

The missing GPL warranty and license-copy paragraphs were restored. The correction was applied consistently to every affected QML file found by the `src/gui4/linux` header audit in [`161035f2d`](https://github.com/Infomaniak/desktop-kDrive/commit/161035f2da701c6335dc395b0d9771f9a7d2ab56).

### Filter menu background expression

> Difficult to parse.

[Review response thread](https://github.com/Infomaniak/desktop-kDrive/pull/2313#discussion_r3821560882)

The nested inline condition was replaced with the named `surfaceColor` property in [`08f09ac0e`](https://github.com/Infomaniak/desktop-kDrive/commit/08f09ac0ebebc0c556d91edc0675dd1bf695a99b). The same commit makes the default option background neutral and applies `surfaceTertiary` only while the option is hovered, pressed, or keyboard-focused.

### Filter button interaction state

> Just to be sure: is the logic correct?

[Review response thread](https://github.com/Infomaniak/desktop-kDrive/pull/2313#discussion_r3821573535)

The existing `filterButton.hovered || filterButton.down` condition was verified and is intentional: `hovered` covers pointer hover, while `down` keeps the pressed interaction visible. Keyboard focus remains represented independently by the `visualFocus` border. No code change or commit was required for this comment.
