### PR TITLE
fix(local-file-system-observer): Avoids appending _pendingFileEvents …to itself, which can happen when the local live snapshot is invalid

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -109,17 +109,10 @@ ExitInfo LocalFileSystemObserverWorker::handleDeleteOp(const SyncPath &absoluteP
     return ExitCode::Ok;
 }
 
-ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<SyncPath, OperationType>> &changes) {
+ExitInfo LocalFileSystemObserverWorker::localChangesDetected(const std::list<std::pair<SyncPath, OperationType>> &changes) {
     const std::scoped_lock lock(_recursiveMutex);
 
-    // Warning: OperationType retrieved from FSEvent (macOS) seems to be unreliable in some cases. One event might contain
-    // several operations. Only Delete event seems to be 100% reliable Move event from outside the synced dir to inside it will
-    // be considered by the OS as move while must be considered by the synchronizer as Create.
-    if (!_liveSnapshot.isValid()) {
-        // Snapshot generation is ongoing, queue the events and process them later
-        _pendingFileEvents.insert(_pendingFileEvents.end(), changes.begin(), changes.end());
-        return ExitCode::Ok;
-    }
+    if (!_liveSnapshot.isValid()) return ExitCode::Ok;
 
     auto tmpChanges = changes;
     for (auto changeIt = tmpChanges.begin(); changeIt != tmpChanges.end(); ++changeIt) {
@@ -298,10 +291,10 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
 
         if (const bool itemExistsInSnapshot = _liveSnapshot.exists(nodeId); !itemExistsInSnapshot) {
             if (opTypeFromOS == OperationType::Delete) {
-                // The node ID of the deleted item is different from `nodeId`. The latter is the identifier of an item with the
-                // same path as the deleted item and that exists on the file system at the time of the last check. This situation
-                // happens for instance if a file is deleted while another file with the same path is created shortly
-                // afterward. Typically, editors of the MS suite (xlsx, docx) or Adobe suite (pdf) perform a
+                // The node ID of the deleted item is different from `nodeId`. The latter is the identifier of an item with
+                // the same path as the deleted item and that exists on the file system at the time of the last check. This
+                // situation happens for instance if a file is deleted while another file with the same path is created
+                // shortly afterward. Typically, editors of the MS suite (xlsx, docx) or Adobe suite (pdf) perform a
                 // Delete-followed-by-Create operation during a single edit.
                 NodeId itemId;
                 if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); !exitInfo) {
@@ -330,9 +323,9 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
 
             NodeId previousItemId;
             if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, previousItemId); exitInfo) {
-                // If an item with the same path already exists, remove it from snapshot because its ID might have changed (i.e.
-                // the file has been downloaded in the tmp folder then moved to override the existing one). The item will be
-                // inserted below anyway.
+                // If an item with the same path already exists, remove it from snapshot because its ID might have changed
+                // (i.e. the file has been downloaded in the tmp folder then moved to override the existing one). The item
+                // will be inserted below anyway.
                 if (!previousItemId.empty()) {
                     if (!_liveSnapshot.removeItem(previousItemId)) {
                         LOGW_SYNCPAL_WARN(_logger, L"Failed to delete item: " << Utility::formatSyncPath(absolutePath) << L" ("
@@ -379,7 +372,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
 
             if (nodeType == NodeType::Directory) {
                 // A new directory must be explored
-                // NB: When a directory is moved while staying inside the sync directory, it is deleted & added to the snapshot
+                // NB: When a directory is moved while staying inside the sync directory, it is deleted & added to the
+                // snapshot
                 if (absolutePath.native().length() > CommonUtility::maxPathLength()) {
                     LOGW_SYNCPAL_WARN(_logger, L"Ignore item: " << Utility::formatSyncPath(absolutePath) << L" because size > "
                                                                 << CommonUtility::maxPathLength());
@@ -442,9 +436,9 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
                     return ExitCode::DbError;
                 }
                 if (found) {
-                    // The update operation can lead to the replacement of an existing item in the snapshot (for example when a
-                    // file is replaced by another one with the same name). If the removed item is still in the DB, we raise a
-                    // Move operation to force the update of the snapshot.
+                    // The update operation can lead to the replacement of an existing item in the snapshot (for example when
+                    // a file is replaced by another one with the same name). If the removed item is still in the DB, we raise
+                    // a Move operation to force the update of the snapshot.
                     LOGW_SYNCPAL_DEBUG(_logger, L"Raise a Move operation for item: "
                                                         << Utility::formatSyncPath(removedPath) << L" ("
                                                         << CommonUtility::s2ws(removedNodeId) << L")");
@@ -459,6 +453,22 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
     }
 
     return ExitCode::Ok;
+}
+
+
+ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<SyncPath, OperationType>> &changes) {
+    const std::scoped_lock lock(_recursiveMutex);
+
+    // Warning: OperationType retrieved from FSEvent (macOS) seems to be unreliable in some cases. One event might contain
+    // several operations. Only Delete event seems to be 100% reliable Move event from outside the synced dir to inside it
+    // will be considered by the OS as move while must be considered by the synchronizer as Create.
+    if (!_liveSnapshot.isValid()) {
+        // Snapshot generation is ongoing, queue the events and process them later
+        _pendingFileEvents.insert(_pendingFileEvents.end(), changes.begin(), changes.end());
+        return ExitCode::Ok;
+    }
+
+    return localChangesDetected(changes);
 }
 
 void LocalFileSystemObserverWorker::forceUpdate() {
@@ -578,7 +588,7 @@ ExitInfo LocalFileSystemObserverWorker::generateInitialSnapshot() {
     const std::scoped_lock lock(_recursiveMutex);
     if (!_pendingFileEvents.empty()) {
         LOG_SYNCPAL_DEBUG(_logger, "Processing pending file events");
-        if (const auto exitInfo = changesDetected(_pendingFileEvents); !exitInfo) {
+        if (const auto exitInfo = localChangesDetected(_pendingFileEvents); !exitInfo) {
             LOG_SYNCPAL_WARN(_logger, "Error in LocalFileSystemObserverWorker::changesDetected: " << exitInfo);
             mainExitInfo.merge(exitInfo, {ExitCode::SystemError, ExitCode::DataError});
         }

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -109,7 +109,7 @@ ExitInfo LocalFileSystemObserverWorker::handleDeleteOp(const SyncPath &absoluteP
     return ExitCode::Ok;
 }
 
-ExitInfo LocalFileSystemObserverWorker::localChangesDetected(const std::list<std::pair<SyncPath, OperationType>> &changes) {
+ExitInfo LocalFileSystemObserverWorker::processDetectedChanges(const std::list<std::pair<SyncPath, OperationType>> &changes) {
     const std::scoped_lock lock(_recursiveMutex);
 
     if (!_liveSnapshot.isValid()) return ExitCode::Ok;
@@ -468,7 +468,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
         return ExitCode::Ok;
     }
 
-    return localChangesDetected(changes);
+    return processDetectedChanges(changes);
 }
 
 void LocalFileSystemObserverWorker::forceUpdate() {
@@ -588,7 +588,7 @@ ExitInfo LocalFileSystemObserverWorker::generateInitialSnapshot() {
     const std::scoped_lock lock(_recursiveMutex);
     if (!_pendingFileEvents.empty()) {
         LOG_SYNCPAL_DEBUG(_logger, "Processing pending file events");
-        if (const auto exitInfo = localChangesDetected(_pendingFileEvents); !exitInfo) {
+        if (const auto exitInfo = processDetectedChanges(_pendingFileEvents); !exitInfo) {
             LOG_SYNCPAL_WARN(_logger, "Error in LocalFileSystemObserverWorker::changesDetected: " << exitInfo);
             mainExitInfo.merge(exitInfo, {ExitCode::SystemError, ExitCode::DataError});
         }

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
@@ -66,6 +66,8 @@ class LocalFileSystemObserverWorker : public FileSystemObserverWorker {
         // Returns true if the execute() loop should break.
         bool checkAndClearUpdateDelay(ExitInfo &exitInfo);
 
+        ExitInfo localChangesDetected(const std::list<std::pair<SyncPath, OperationType>> &changes);
+
         std::chrono::steady_clock::time_point _needUpdateTimerStart = std::chrono::steady_clock::now();
         bool _useExtendedDelay = false;
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
@@ -66,7 +66,7 @@ class LocalFileSystemObserverWorker : public FileSystemObserverWorker {
         // Returns true if the execute() loop should break.
         bool checkAndClearUpdateDelay(ExitInfo &exitInfo);
 
-        ExitInfo localChangesDetected(const std::list<std::pair<SyncPath, OperationType>> &changes);
+        ExitInfo processDetectedChanges(const std::list<std::pair<SyncPath, OperationType>> &changes);
 
         std::chrono::steady_clock::time_point _needUpdateTimerStart = std::chrono::steady_clock::now();
         bool _useExtendedDelay = false;

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -771,7 +771,7 @@ void TestLocalFileSystemObserverWorker::populatePendingFiles(const Count fileCou
     // Populate _pendingFileEvents with a few events.
     for (Count i = 0; i < fileCount; ++i) {
         const auto filename = "pending_file_" + std::to_string(i) + ".txt";
-        localFSO->_pendingFileEvents.emplace_back(_rootFolderPath / filename, OperationType::Create);
+        (void) localFSO->_pendingFileEvents.emplace_back(_rootFolderPath / filename, OperationType::Create);
     }
 
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(fileCount), localFSO->_pendingFileEvents.size());

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -249,6 +249,22 @@ void TestLocalFileSystemObserverWorker::testLFSOWithFiles() {
     LOGW_DEBUG(_logger, L"Tests for files successful!");
 }
 
+void MockLocalFileSystemObserverWorker::waitForUpdate(SnapshotRevision previousRevision,
+                                                      const std::chrono::milliseconds timeoutMs) const {
+    using namespace std::chrono;
+    const auto start = system_clock::now();
+    while (previousRevision == liveSnapshot().revision() &&
+           duration_cast<milliseconds>(system_clock::now() - start) < timeoutMs) {
+        Utility::msleep(10);
+    }
+    CPPUNIT_ASSERT_LESS(timeoutMs.count(), duration_cast<milliseconds>(system_clock::now() - start).count());
+    while (_updating && duration_cast<milliseconds>(system_clock::now() - start) < timeoutMs) {
+        Utility::msleep(10);
+    }
+    CPPUNIT_ASSERT_LESS(timeoutMs.count(), duration_cast<milliseconds>(system_clock::now() - start).count());
+}
+
+
 void TestLocalFileSystemObserverWorker::testLFSOWithDuplicateFileNames() {
     // Create two files with the same name, up to encoding (NFC vs NFD).
     // On Windows and Linux systems, we expect to find two distinct items. But we will only consider one in the local snapshot and
@@ -710,8 +726,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         testhelpers::generateOrEditTestFile(filePath);
 
         // Wait until _updating becomes true (change detected)
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, changeDetectionTimeout,
-                                              loopPollInterval));
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, changeDetectionTimeout, loopPollInterval));
         CPPUNIT_ASSERT(!localFSO->_useExtendedDelay);
 
         // Measure how long until _updating goes back to false (sync allowed)
@@ -732,8 +747,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         testhelpers::generateOrEditTestFile(filePath);
 
         // Wait until _updating becomes true (change detected)
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, changeDetectionTimeout,
-                                              loopPollInterval));
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, changeDetectionTimeout, loopPollInterval));
         CPPUNIT_ASSERT(localFSO->_useExtendedDelay);
 
         // Measure how long until _updating goes back to false (sync allowed)
@@ -748,19 +762,89 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
     }
 }
 
-void MockLocalFileSystemObserverWorker::waitForUpdate(SnapshotRevision previousRevision,
-                                                      const std::chrono::milliseconds timeoutMs) const {
-    using namespace std::chrono;
-    const auto start = system_clock::now();
-    while (previousRevision == liveSnapshot().revision() &&
-           duration_cast<milliseconds>(system_clock::now() - start) < timeoutMs) {
-        Utility::msleep(10);
+void TestLocalFileSystemObserverWorker::populatePendingFiles(const Count fileCount) {
+    auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
+    CPPUNIT_ASSERT(localFSO);
+
+    localFSO->_pendingFileEvents.clear();
+
+    // Populate _pendingFileEvents with a few events.
+    for (Count i = 0; i < fileCount; ++i) {
+        const auto filename = "pending_file_" + std::to_string(i) + ".txt";
+        localFSO->_pendingFileEvents.emplace_back(_rootFolderPath / filename, OperationType::Create);
     }
-    CPPUNIT_ASSERT_LESS(timeoutMs.count(), duration_cast<milliseconds>(system_clock::now() - start).count());
-    while (_updating && duration_cast<milliseconds>(system_clock::now() - start) < timeoutMs) {
-        Utility::msleep(10);
-    }
-    CPPUNIT_ASSERT_LESS(timeoutMs.count(), duration_cast<milliseconds>(system_clock::now() - start).count());
+
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(fileCount), localFSO->_pendingFileEvents.size());
+}
+
+void TestLocalFileSystemObserverWorker::testLocalChangesDetectedDoesNotAppendPendingEventsToItself() {
+    // Regression test for the fix that splits changesDetected() using localChangesDetected().
+    // Before the fix, generateInitialSnapshot() called changesDetected(_pendingFileEvents), which — when the
+    // snapshot was still invalid — executed `_pendingFileEvents.insert(_pendingFileEvents.end(),
+    // _pendingFileEvents.begin(), _pendingFileEvents.end())`, inserting a std::list into itself (undefined behaviour).
+    //
+    // This test verifies that localChangesDetected(), when the live snapshot is invalid, returns Ok without modifying
+    // _pendingFileEvents (no self-append).
+
+    auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
+    CPPUNIT_ASSERT(localFSO);
+
+    // Ensure the worker thread is stopped, so that we can safely manipulate internal state.
+    _syncPal->_localFSObserverWorker->stop();
+    _syncPal->_localFSObserverWorker->waitForExit();
+
+    // Make the snapshot invalid, reproducing the state in which generateInitialSnapshot() processes pending events.
+    localFSO->invalidateSnapshot();
+    CPPUNIT_ASSERT(!localFSO->_liveSnapshot.isValid());
+
+    // Clear and populate _pendingFileEvents with a few events.
+    const size_t sizeBefore = 3;
+    populatePendingFiles(Count{3});
+
+    // Call localChangesDetected with _pendingFileEvents — the exact call made by generateInitialSnapshot().
+    const auto exitInfo = localFSO->localChangesDetected(localFSO->_pendingFileEvents);
+
+    // Must return Ok (the snapshot is invalid, so it returns early without processing).
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
+
+    // _pendingFileEvents must be unchanged — no self-append occurred.
+    CPPUNIT_ASSERT_EQUAL(sizeBefore, localFSO->_pendingFileEvents.size());
+}
+
+void TestLocalFileSystemObserverWorker::testGenerateInitialSnapshotWithInvalidSnapshotAndPendingEvents() {
+    // Regression test for the fix that splits changesDetected() using localChangesDetected().
+    // This test exercises the full generateInitialSnapshot() code path when the snapshot cannot become valid (because
+    // the sync directory is missing). With the old code, pending events would be appended to themselves (UB); with
+    // the fix, localChangesDetected() is called instead, which returns early without self-appending.
+    //
+    // The test verifies that generateInitialSnapshot() does not crash nor hang and clears the pending events afterward.
+
+    auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
+    CPPUNIT_ASSERT(localFSO);
+
+    // Ensure the worker thread is stopped so that we can safely manipulate internal state.
+    _syncPal->_localFSObserverWorker->stop();
+    _syncPal->_localFSObserverWorker->waitForExit();
+
+    // Delete the root folder so that exploreDir() in generateInitialSnapshot() fails and the snapshot stays invalid.
+    auto ioError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::deleteItem(_rootFolderPath, ioError));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+
+    localFSO->invalidateSnapshot();
+    CPPUNIT_ASSERT(!localFSO->_liveSnapshot.isValid());
+
+    // Clear and populate _pendingFileEvents with a few events.
+    populatePendingFiles(3);
+
+    // Call generateInitialSnapshot() — with the old code this would append _pendingFileEvents to itself (UB).
+    const auto exitInfo = localFSO->generateInitialSnapshot();
+
+    // exploreDir() should have failed because the root folder no longer exists.
+    CPPUNIT_ASSERT(!exitInfo);
+
+    // _pendingFileEvents must have been cleared after processing, regardless of the snapshot validity.
+    CPPUNIT_ASSERT(localFSO->_pendingFileEvents.empty());
 }
 
 } // namespace KDC

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -778,12 +778,12 @@ void TestLocalFileSystemObserverWorker::populatePendingFiles(const Count fileCou
 }
 
 void TestLocalFileSystemObserverWorker::testLocalChangesDetectedDoesNotAppendPendingEventsToItself() {
-    // Regression test for the fix that splits changesDetected() using localChangesDetected().
+    // Regression test for the fix that splits changesDetected() using processDetectedChanges().
     // Before the fix, generateInitialSnapshot() called changesDetected(_pendingFileEvents), which — when the
     // snapshot was still invalid — executed `_pendingFileEvents.insert(_pendingFileEvents.end(),
     // _pendingFileEvents.begin(), _pendingFileEvents.end())`, inserting a std::list into itself (undefined behaviour).
     //
-    // This test verifies that localChangesDetected(), when the live snapshot is invalid, returns Ok without modifying
+    // This test verifies that processDetectedChanges(), when the live snapshot is invalid, returns Ok without modifying
     // _pendingFileEvents (no self-append).
 
     auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
@@ -801,8 +801,8 @@ void TestLocalFileSystemObserverWorker::testLocalChangesDetectedDoesNotAppendPen
     const size_t sizeBefore = 3;
     populatePendingFiles(Count{3});
 
-    // Call localChangesDetected with _pendingFileEvents — the exact call made by generateInitialSnapshot().
-    const auto exitInfo = localFSO->localChangesDetected(localFSO->_pendingFileEvents);
+    // Call processDetectedChanges with _pendingFileEvents — the exact call made by generateInitialSnapshot().
+    const auto exitInfo = localFSO->processDetectedChanges(localFSO->_pendingFileEvents);
 
     // Must return Ok (the snapshot is invalid, so it returns early without processing).
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
@@ -812,10 +812,10 @@ void TestLocalFileSystemObserverWorker::testLocalChangesDetectedDoesNotAppendPen
 }
 
 void TestLocalFileSystemObserverWorker::testGenerateInitialSnapshotWithInvalidSnapshotAndPendingEvents() {
-    // Regression test for the fix that splits changesDetected() using localChangesDetected().
+    // Regression test for the fix that splits changesDetected() using processDetectedChanges().
     // This test exercises the full generateInitialSnapshot() code path when the snapshot cannot become valid (because
     // the sync directory is missing). With the old code, pending events would be appended to themselves (UB); with
-    // the fix, localChangesDetected() is called instead, which returns early without self-appending.
+    // the fix, processDetectedChanges() is called instead, which returns early without self-appending.
     //
     // The test verifies that generateInitialSnapshot() does not crash nor hang and clears the pending events afterward.
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
@@ -79,6 +79,8 @@ class TestLocalFileSystemObserverWorker final : public CppUnit::TestFixture, pub
         CPPUNIT_TEST(testInvalidateCounter);
         CPPUNIT_TEST(testInvalidateSnapshot);
         CPPUNIT_TEST(testSlowWritingExtensionDelay);
+        CPPUNIT_TEST(testLocalChangesDetectedDoesNotAppendPendingEventsToItself);
+        CPPUNIT_TEST(testGenerateInitialSnapshotWithInvalidSnapshotAndPendingEvents);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -108,10 +110,14 @@ class TestLocalFileSystemObserverWorker final : public CppUnit::TestFixture, pub
         void testInvalidateCounter();
         void testInvalidateSnapshot();
         void testSlowWritingExtensionDelay();
+        void testLocalChangesDetectedDoesNotAppendPendingEventsToItself();
+        void testGenerateInitialSnapshotWithInvalidSnapshotAndPendingEvents();
         void testSyncDirChange();
         static bool vfsStatus(int, const SyncPath &, bool &, bool &, bool &, int &) { return true; }
         static bool vfsPinState(int, const SyncPath &, PinState &) { return true; }
         static bool vfsFileStatusChanged(int, const SyncPath &, SyncFileStatus) { return true; }
+
+        void populatePendingFiles(Count fileCount);
 };
 
 } // namespace KDC


### PR DESCRIPTION
These changes prevent an undefined behaviour in `LocalFileSystemObserverWorker::changesDetected` when called with the argument `_pendingFileEvents` at line 591 while `_liveSnapshot.isValid()` is `false`.

In this case, the method appends (a `const` reference to) the `std::list` variable named `_pendingFileEvents` to itself, which leads to undefined behaviour. 