### PR TITLE
fix: improve ServerCommService reliability and reduce log polution

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
@@ -87,7 +87,7 @@ namespace Infomaniak.kDrive.CustomControls
             Frame.Navigated += Frame_Navigated;
             if (LandingPageType is not null && LandingPageType.IsSubclassOf(typeof(Page)))
                 Frame.Navigate(LandingPageType);
-            else 
+            else
                 Frame.Navigate(typeof(Pages.HomePage));
 
             // Add an infobadge to SettingsItem
@@ -105,6 +105,8 @@ namespace Infomaniak.kDrive.CustomControls
                 Converter = new Converters.BooleanToVisibilityConverter(),
                 Mode = BindingMode.OneWay
             });
+
+            ApplyTemplate(); // Ensure the template is applied before accessing the SettingsItem
 
             NavigationViewItem? settingItem = SettingsItem as NavigationViewItem;
             if (settingItem is null)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1986,7 +1986,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
             else
             {
-                Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs.");
+                Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs, ErrorInfo: {signalData[JsonKeys.ErrorInfo] ?? "null"}");
             }
         }
         public async Task HandleErrorRemovedAsync(object? sender, SignalEventArgs args)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -134,8 +134,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        private static bool CheckJobResultAndLogIfError(CommData? data, JsonObject? jobInput = null, [CallerMemberName] string callerName = "")
+        private static bool CheckJobResultAndLogIfError(CommData? data, CancellationToken cancellationToken, JsonObject? jobInput = null, [CallerMemberName] string callerName = "")
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Logger.Log(Logger.Level.Info, $"Job cancelled at {callerName} with input {jobInput}.");
+                return false;
+            }
+
             if (data is null)
             {
                 Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, CommData is null.");

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1741,19 +1741,19 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             });
         }
-        public Task HandleSyncProgressInfo(object? sender, SignalEventArgs args)
+        public async Task HandleSyncProgressInfo(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
 
             if (signalData == null || !signalData.ContainsKey(JsonKeys.SyncDbId))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.SyncDbId} not found in parameters.");
-                return Task.CompletedTask;
+                return;
             }
             if (signalData == null || !signalData.ContainsKey(JsonKeys.SyncStatus))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.SyncStatus} not found in parameters.");
-                return Task.CompletedTask;
+                return;
             }
 
             DbId? syncDbID = signalData[JsonKeys.SyncDbId]?.AsValue().GetValue<DbId>();
@@ -1762,22 +1762,23 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             if (syncDbID is null)
             {
                 Logger.Log(Logger.Level.Error, "syncDbID is null.");
-                return Task.CompletedTask;
+                return;
             }
             if (syncStatus is null)
             {
                 Logger.Log(Logger.Level.Error, "syncStatus is null.");
-                return Task.CompletedTask;
+                return;
             }
 
-            Sync? updatedSync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID);
+            Sync? updatedSync = null;
+            await Utility.RunOnUIThread(() => updatedSync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID));
             if (updatedSync == null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with dbID {syncDbID} not found in the model.");
-                return Task.CompletedTask;
+                return;
             }
             updatedSync.SyncStatus = syncStatus ?? SyncStatus.Undefined;
-            return Task.CompletedTask;
+            return;
         }
 
         public async Task HandleSyncCompletedItem(object? sender, SignalEventArgs args)
@@ -2007,7 +2008,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         ++_errorCount;
                     }
 
-                   await _viewModel.AddErrorAsync(error);
+                    await _viewModel.AddErrorAsync(error);
                 }
                 else
                 {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -214,7 +214,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         Logger.Log(Logger.Level.Info, $"AddOrRelogUser: User with DbId {userDbId} already exists in the application.");
                         return;
                     }
-                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(100, cancellationToken);
                     --maxRetries;
                 } while (!cancellationToken.IsCancellationRequested && maxRetries > 0);
                 Logger.Log(Logger.Level.Error, $"AddOrRelogUser: Timeout waiting for user with DbId {userDbId} to be added to the application.");
@@ -590,7 +590,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> SetSyncType(DbId syncDbId, SyncType type, CancellationToken cancellationToken)
         {
             Sync? sync = null;
-            await Utility.RunOnUIThread(() => _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId));
+            await Utility.RunOnUIThread(() => sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId));
             if (sync is null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with DbId {syncDbId} not found in model.");
@@ -1984,34 +1984,36 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Error, $"Failed to deserialize errorInfo from {signalData[JsonKeys.ErrorInfo]}.");
                 return;
             }
-
-            if (errorInfo.Level == ErrorLevel.Server)
+            await Utility.RunOnUIThread(async () =>
             {
-                lock (_errorLock)
+                if (errorInfo.Level == ErrorLevel.Server)
                 {
-                    ++_errorCount;
-                }
-                Error error = new(errorInfo);
-                await Utility.RunOnUIThread(async () => await _viewModel.AddErrorAsync(error).ConfigureAwait(false));
+                    lock (_errorLock)
+                    {
+                        ++_errorCount;
+                    }
+                    Error error = new(errorInfo);
+                    await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
 
-                return;
-            }
-
-            var sync = App.ServiceProvider.GetRequiredService<AppModel>().AllSyncs.FirstOrDefault(s => s.DbId == errorInfo.SyncDbId);
-            if (sync is not null)
-            {
-                Error error = new(sync, errorInfo);
-                lock (_errorLock)
-                {
-                    ++_errorCount;
+                    return;
                 }
 
-                await Utility.RunOnUIThread(async () => await _viewModel.AddErrorAsync(error).ConfigureAwait(false));
-            }
-            else
-            {
-                Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs, ErrorInfo: {signalData[JsonKeys.ErrorInfo] ?? "null"}");
-            }
+                var sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == errorInfo.SyncDbId);
+                if (sync is not null)
+                {
+                    Error error = new(sync, errorInfo);
+                    lock (_errorLock)
+                    {
+                        ++_errorCount;
+                    }
+
+                   await _viewModel.AddErrorAsync(error);
+                }
+                else
+                {
+                    Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs, ErrorInfo: {signalData[JsonKeys.ErrorInfo] ?? "null"}");
+                }
+            });
         }
         public async Task HandleErrorRemovedAsync(object? sender, SignalEventArgs args)
         {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -184,7 +184,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.LOGIN_REQUESTTOKEN, parms, cancellationToken).ConfigureAwait(false);
 
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.UserDbId))
@@ -201,13 +201,15 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return null;
             }
 
+            User? user = null;
             await Utility.RunOnUIThread(async () =>
             {
                 // The server should send a signal user_added that will add the user to the model, we wait here for max 10s for that to happen
                 int maxRetries = 100;
                 do
                 {
-                    if (_viewModel.Users.Any(u => u.DbId == userDbId))
+                    user = _viewModel.Users.FirstOrDefault(u => u?.DbId == userDbId, null);
+                    if (user != null)
                     {
                         Logger.Log(Logger.Level.Info, $"AddOrRelogUser: User with DbId {userDbId} already exists in the application.");
                         return;
@@ -217,14 +219,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 } while (!cancellationToken.IsCancellationRequested && maxRetries > 0);
                 Logger.Log(Logger.Level.Error, $"AddOrRelogUser: Timeout waiting for user with DbId {userDbId} to be added to the application.");
             }).ConfigureAwait(false);
-            return _viewModel.Users.FirstOrDefault(u => u?.DbId == userDbId, null);
+            return user;
         }
 
         public async Task<bool> RefreshUsers(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, [], cancellationToken).ConfigureAwait(false);
 
-            if (!CheckJobResultAndLogIfError(data, []))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, []))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.UserInfoList))
@@ -286,13 +288,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return true;
             }
 
-            return CheckJobResultAndLogIfError(commData, parms);
+            return CheckJobResultAndLogIfError(commData, cancellationToken, parms);
         }
 
         public async Task<bool> RefreshAccounts(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.ACCOUNT_INFOLIST, [], cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.AccountInfoList))
@@ -324,16 +326,16 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             // Remove accounts that are no longer present
             var accountDbIds = accountInfos.Where(a => a.DbId != null).Select(a => a.DbId).ToHashSet();
 
-            // Find accounts to remove in all users
-            var accountsToRemove = new List<Account>();
-            foreach (var user in _viewModel.Users)
-            {
-                var userAccountsToRemove = user.Accounts.Where(a => !accountDbIds.Contains(a.DbId)).ToList();
-                accountsToRemove.AddRange(userAccountsToRemove);
-            }
-
             await Utility.RunOnUIThread(() =>
             {
+                // Find accounts to remove in all users
+                var accountsToRemove = new List<Account>();
+                foreach (var user in _viewModel.Users)
+                {
+                    var userAccountsToRemove = user.Accounts.Where(a => !accountDbIds.Contains(a.DbId)).ToList();
+                    accountsToRemove.AddRange(userAccountsToRemove);
+                }
+
                 foreach (var account in accountsToRemove)
                 {
                     var parentUser = account.User;
@@ -350,7 +352,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> RefreshDrives(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_INFOLIST, [], cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.DriveInfoList))
@@ -383,16 +385,16 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             // Remove drives that are no longer present
             var driveDbIds = driveInfos.Where(d => d.DbId != null).Select(d => d.DbId).ToHashSet();
 
-            // Find drives to remove in all users
-            var drivesToRemove = new List<Drive>();
-            foreach (var user in _viewModel.Users)
-            {
-                var userDrivesToRemove = user.Drives.Where(d => !driveDbIds.Contains(d.DbId)).ToList();
-                drivesToRemove.AddRange(userDrivesToRemove);
-            }
-
             await Utility.RunOnUIThread(() =>
             {
+                // Find drives to remove in all users
+                var drivesToRemove = new List<Drive>();
+                foreach (var user in _viewModel.Users)
+                {
+                    var userDrivesToRemove = user.Drives.Where(d => !driveDbIds.Contains(d.DbId)).ToList();
+                    drivesToRemove.AddRange(userDrivesToRemove);
+                }
+
                 foreach (var drive in drivesToRemove)
                 {
                     var parentAccount = drive.Account;
@@ -413,7 +415,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.UserDbId] = userDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_AVAILABLEDRIVES, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.DriveAvailableInfoList))
@@ -433,7 +435,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
 
 
-            User? user = _viewModel.Users.FirstOrDefault<User>(u => u.DbId == userDbId);
+            User? user = null;
+            await Utility.RunOnUIThread(() => user = _viewModel.Users.FirstOrDefault<User>(u => u.DbId == userDbId));
             if (user is null)
             {
                 Logger.Log(Logger.Level.Error, $"User not found with dbID {userDbId}.");
@@ -499,7 +502,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> RefreshSyncs(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_INFOLIST, [], cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.SyncInfoList))
@@ -531,17 +534,17 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             // Remove syncs that are no longer present
             var syncDbIds = syncInfos.Where(d => d.DbId != null).Select(d => d.DbId).ToHashSet();
 
-            // Find sync to remove in all users
-            var syncsToRemove = new List<Sync>();
-            foreach (var drive in _viewModel.AllDrives)
-            {
-                var driveSyncsToRemove = drive.Syncs.Where(s => !syncDbIds.Contains(s.DbId)).ToList();
-                syncsToRemove.AddRange(driveSyncsToRemove);
-
-            }
-
             await Utility.RunOnUIThread(() =>
             {
+                // Find sync to remove in all users
+                var syncsToRemove = new List<Sync>();
+                foreach (var drive in _viewModel.AllDrives)
+                {
+                    var driveSyncsToRemove = drive.Syncs.Where(s => !syncDbIds.Contains(s.DbId)).ToList();
+                    syncsToRemove.AddRange(driveSyncsToRemove);
+
+                }
+
                 foreach (var sync in syncsToRemove)
                 {
                     var parentDrive = sync.Drive;
@@ -574,7 +577,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.BlackList] = JsonSerializer.SerializeToNode(newSync.ExcludedNodeIds, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() } })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_ADD, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.SyncInfo))
@@ -586,7 +589,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> SetSyncType(DbId syncDbId, SyncType type, CancellationToken cancellationToken)
         {
-            Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId);
+            Sync? sync = null;
+            await Utility.RunOnUIThread(() => _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId));
             if (sync is null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with DbId {syncDbId} not found in model.");
@@ -611,7 +615,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_SETSUPPORTSVIRTUALFILES, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return false;
 
             return true;
@@ -639,7 +643,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return true;
             }
 
-            if (!CheckJobResultAndLogIfError(commData, parms))
+            if (!CheckJobResultAndLogIfError(commData, cancellationToken, parms))
                 return false;
 
             // Rely on signal to remove the sync from the model
@@ -648,7 +652,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> StartSync(DbId syncDbId, CancellationToken cancellationToken)
         {
-            Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId);
+            Sync? sync = null;
+            await Utility.RunOnUIThread(() => sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId));
             if (sync is null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with DbId {syncDbId} not found in model.");
@@ -662,7 +667,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_START, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
             {
                 sync.SyncStatus = previousStatus;
                 return false;
@@ -673,7 +678,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> PauseSync(DbId syncDbId, CancellationToken cancellationToken)
         {
-            Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId);
+            Sync? sync = null;
+            await Utility.RunOnUIThread(() => sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId));
             if (sync is null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with DbId {syncDbId} not found in model.");
@@ -687,7 +693,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_STOP, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
             {
                 sync.SyncStatus = previousStatus;
                 return false;
@@ -703,7 +709,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_BESTVFSAVAILABLEMODE, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.BestMode))
@@ -727,7 +733,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_FINDGOODPATHFORNEWSYNC, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.GoodPath) || !HasRequiredParam(data, JsonKeys.ErrorMessage))
@@ -759,7 +765,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ISPATHVALIDFORNEWSYNC, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.IsValid))
@@ -790,7 +796,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_SEARCH, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.SearchInfoList))
@@ -841,7 +847,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_OFFLINE_FILES_SIZE, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.Size))
@@ -867,7 +873,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.WithPath] = true
             };
             CommData data = await _getSubFolderQueue.SendRequestAsync(RequestNum.NODE_SUBFOLDERS, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeSubFolderInfoList))
@@ -902,7 +908,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.WithPath] = true
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_INFO, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return new GetNodeInfoResult(data.Cause, null);
 
             if (!HasRequiredParam(data, JsonKeys.NodeInfo))
@@ -932,7 +938,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.NodeId] = Utility.ToBase64String(nodeId),
             };
             CommData data = await _getFolderSizeQueue.SendRequestAsync(RequestNum.NODE_FOLDER_SIZE, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.FolderSize))
@@ -955,7 +961,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId,
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.BLACKLISTED_NODE_LIST, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeIdList))
@@ -983,7 +989,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.NodeIdList] = JsonSerializer.SerializeToNode(idList, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() } })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.BLACKLISTED_NODE_SETLIST, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<NodeId?> CreateMissingDirectories(IDrive drive, NodeId parentNodeId, string path, CancellationToken cancellationToken)
@@ -1000,7 +1006,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_CREATEMISSINGFOLDERS, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeId))
@@ -1026,7 +1032,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.NodeId] = Utility.ToBase64String(nodeId)
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_GETPUBLICLINKURL, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.LinkUrl))
@@ -1061,7 +1067,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.ReplicaSide] = (int)replicaSide
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_CONFLICT_INFO, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeConflictInfo))
@@ -1087,7 +1093,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> StartUpdate(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_START_INSTALLER, [], cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> SkipVersion(CancellationToken cancellationToken)
@@ -1105,7 +1111,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_SKIP_VERSION, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> RefreshUpdaterVersionInfo(UpdateState? updateState, CancellationToken cancellationToken)
@@ -1114,7 +1120,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             if (updateState is null)
             {
                 CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_STATE, [], cancellationToken);
-                if (!CheckJobResultAndLogIfError(data))
+                if (!CheckJobResultAndLogIfError(data, cancellationToken))
                     return false;
 
                 if (!HasRequiredParam(data, JsonKeys.UpdateState))
@@ -1173,7 +1179,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.UpdateChannel] = (int)channel
             };
             CommData data2 = await _commClient.SendRequestAsync(RequestNum.UPDATER_VERSION_INFO, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data2, parms))
+            if (!CheckJobResultAndLogIfError(data2, cancellationToken, parms))
                 return false;
 
             if (!HasRequiredParam(data2, JsonKeys.VersionInfo))
@@ -1206,19 +1212,19 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.IncludeArchivedLogs] = includeArchivedLogs
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_SEND_LOG_TO_SUPPORT, parms, cancellationToken);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<bool> CancelLogUpload(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_CANCEL_LOG_TO_SUPPORT, [], cancellationToken);
-            return CheckJobResultAndLogIfError(data);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> RefreshSettings(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.PARAMETERS_INFO, [], cancellationToken);
-            if (!CheckJobResultAndLogIfError(data))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.ParmsInfo))
@@ -1242,7 +1248,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> ActivateLoadInfo(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ACTIVATELOADINFO, [], cancellationToken);
-            return CheckJobResultAndLogIfError(data);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> SetAppState(AppStateKey key, string value, CancellationToken cancellationToken)
@@ -1253,7 +1259,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Value] = Utility.ToBase64String(value)
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_SET_APPSTATE, parms, cancellationToken);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<string?> GetAppState(AppStateKey key, CancellationToken cancellationToken)
@@ -1263,7 +1269,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Key] = (int)key
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_GET_APPSTATE, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.Value))
@@ -1308,7 +1314,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.PARAMETERS_UPDATE, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return false;
 
             return true;
@@ -1325,7 +1331,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     [JsonKeys.Default] = def
                 };
                 CommData data = await _commClient.SendRequestAsync(RequestNum.EXCLTEMPL_GETLIST, parms, cancellationToken).ConfigureAwait(false);
-                if (!CheckJobResultAndLogIfError(data, parms))
+                if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                     return null;
 
                 if (!HasRequiredParam(data, JsonKeys.ExclusionTemplatesList))
@@ -1357,7 +1363,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.ExclusionTemplatesList] = JsonSerializer.SerializeToNode(templates, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() }, PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.EXCLTEMPL_SETUSERLIST, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<bool> RefreshErrors(CancellationToken cancellationToken)
@@ -1367,7 +1373,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Limit] = _maxErrorLimit
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_INFOLIST, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.ErrorInfoList))
@@ -1390,33 +1396,37 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 _hasMoreError = errorInfos.Count == _maxErrorLimit;
                 _errorCount = errorInfos.Count;
             }
-            await _viewModel.ClearAllErrorsAsync().ConfigureAwait(false);
-            foreach (var errorInfo in errorInfos)
+            await Utility.RunOnUIThread(async () =>
             {
-                if (errorInfo.Level == ErrorLevel.Server)
+                await _viewModel.ClearAllErrorsAsync();
+                foreach (var errorInfo in errorInfos)
                 {
-                    Error error = new(errorInfo);
-                    await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
-                }
-                else if (errorInfo.SyncDbId is not null)
-                {
-                    var sync = App.ServiceProvider.GetRequiredService<AppModel>().AllSyncs.FirstOrDefault(s => s.DbId == errorInfo.SyncDbId);
-
-                    if (sync is not null)
+                    if (errorInfo.Level == ErrorLevel.Server)
                     {
-                        Error error = new(sync, errorInfo);
-                        await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
+                        Error error = new(errorInfo);
+                        await _viewModel.AddErrorAsync(error);
+                    }
+                    else if (errorInfo.SyncDbId is not null)
+                    {
+                        var sync = App.ServiceProvider.GetRequiredService<AppModel>().AllSyncs.FirstOrDefault(s => s.DbId == errorInfo.SyncDbId);
+
+                        if (sync is not null)
+                        {
+                            Error error = new(sync, errorInfo);
+                            await _viewModel.AddErrorAsync(error);
+                        }
+                        else
+                        {
+                            Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs.");
+                        }
                     }
                     else
                     {
-                        Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs.");
+                        Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} has invalid SyncDbId {errorInfo.SyncDbId}.");
                     }
                 }
-                else
-                {
-                    Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} has invalid SyncDbId {errorInfo.SyncDbId}.");
-                }
-            }
+            });
+
             return true;
         }
 
@@ -1432,7 +1442,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Info, $"Error with DbId {errorDbId} cannot be deleted as it is kept by the server.");
                 return false;
             }
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<bool> RefreshSyncErrors(DbId syncDbId, CancellationToken cancellationToken)
@@ -1442,7 +1452,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_SYNC_REFRESH, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<bool> ResolveConflicts(List<DbId> keepLocalErrorDbIds, List<DbId> keepRemoteErrorDbIds, CancellationToken cancellationToken)
@@ -1453,7 +1463,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.KeepRemoteErrorDbIdList] = JsonSerializer.SerializeToNode(keepRemoteErrorDbIds)
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_RESOLVE_CONFLICTS, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         public async Task<bool> ResolveConflictsQuick(List<DbId> errorDbIds, ConflictResolutionStrategy strategy, CancellationToken cancellationToken)
@@ -1464,7 +1474,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Strategy] = (int)strategy
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_RESOLVE_CONFLICTS_QUICK, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
         }
 
         // Signals
@@ -1607,13 +1617,16 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
 
-            Account? deletedAccount = _viewModel.Users.SelectMany(u => u.Accounts).FirstOrDefault(a => a.DbId == accountDbId);
-            if (deletedAccount == null)
+            await Utility.RunOnUIThread(() =>
             {
-                Logger.Log(Logger.Level.Error, $"Account with dbID {accountDbId} not found in the model.");
-                return;
-            }
-            await Utility.RunOnUIThread(() => { deletedAccount.User.Accounts.Remove(deletedAccount); });
+                Account? deletedAccount = _viewModel.Users.SelectMany(u => u.Accounts).FirstOrDefault(a => a.DbId == accountDbId);
+                if (deletedAccount == null)
+                {
+                    Logger.Log(Logger.Level.Error, $"Account with dbID {accountDbId} not found in the model.");
+                    return;
+                }
+                deletedAccount.User.Accounts.Remove(deletedAccount);
+            });
         }
         public async Task HandleDriveUpdatedOrAddedAsync(object? sender, SignalEventArgs args)
         {
@@ -1658,13 +1671,16 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
 
-            Drive? deletedDrive = _viewModel.AllDrives.FirstOrDefault(d => d.DbId == driveDbId);
-            if (deletedDrive == null)
+            await Utility.RunOnUIThread(() =>
             {
-                Logger.Log(Logger.Level.Error, $"Drive with dbID {driveDbId} not found in the model.");
-                return;
-            }
-            await Utility.RunOnUIThread(() => { deletedDrive.Account.Drives.Remove(deletedDrive); });
+                Drive? deletedDrive = _viewModel.AllDrives.FirstOrDefault(d => d.DbId == driveDbId);
+                if (deletedDrive == null)
+                {
+                    Logger.Log(Logger.Level.Error, $"Drive with dbID {driveDbId} not found in the model.");
+                    return;
+                }
+                deletedDrive.Account.Drives.Remove(deletedDrive);
+            });
         }
 
         public async Task HandleSyncUpdatedOrAddedAsync(object? sender, SignalEventArgs args)
@@ -1692,7 +1708,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             await AddOrUpdateSyncInModel(syncInfo);
 
             if (args.SignalNum == SignalNum.SYNC_ADDED)
-                _viewModel.SelectedSync = _viewModel.AllSyncs.FirstOrDefault(s => s?.DbId == syncInfo.DbId, _viewModel.SelectedSync);
+                await Utility.RunOnUIThread(() => _viewModel.SelectedSync = _viewModel.AllSyncs.FirstOrDefault(s => s?.DbId == syncInfo.DbId, _viewModel.SelectedSync));
         }
 
         public async Task HandleSyncRemovedAsync(object? sender, SignalEventArgs args)
@@ -1713,13 +1729,17 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
 
-            Sync? deletedSync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID);
-            if (deletedSync == null)
+            await Utility.RunOnUIThread(() =>
             {
-                Logger.Log(Logger.Level.Error, $"Sync with dbID {syncDbID} not found in the model.");
-                return;
-            }
-            await Utility.RunOnUIThread(() => { deletedSync.Drive.Syncs.Remove(deletedSync); });
+                Sync? deletedSync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID);
+                if (deletedSync == null)
+                {
+                    Logger.Log(Logger.Level.Error, $"Sync with dbID {syncDbID} not found in the model.");
+                    return;
+                }
+                deletedSync.Drive.Syncs.Remove(deletedSync);
+
+            });
         }
         public Task HandleSyncProgressInfo(object? sender, SignalEventArgs args)
         {
@@ -1793,15 +1813,15 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
 
-            Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID);
-            if (sync == null)
-            {
-                Logger.Log(Logger.Level.Error, $"Sync with dbID {syncDbID} not found in the model.");
-                return;
-            }
-
             await Utility.RunOnUIThread(() =>
             {
+                Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID);
+                if (sync == null)
+                {
+                    Logger.Log(Logger.Level.Error, $"Sync with dbID {syncDbID} not found in the model.");
+                    return;
+                }
+
                 const int MaxActivities = 500;
 
                 var activities = sync.SyncActivities;
@@ -1929,14 +1949,16 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
             DbId dbId = signalData[JsonKeys.UserDbId]?.GetValue<DbId>() ?? -1;
-
-            User? user = _viewModel.Users.FirstOrDefault(u => u.DbId == dbId);
-            if (user == null)
+            await Utility.RunOnUIThread(async () =>
             {
-                Logger.Log(Logger.Level.Error, $"User with dbId {dbId} not found");
-                return;
-            }
-            await Utility.RunOnUIThread(() => { _viewModel.Users.Remove(user); });
+                User? user = _viewModel.Users.FirstOrDefault(u => u.DbId == dbId);
+                if (user == null)
+                {
+                    Logger.Log(Logger.Level.Error, $"User with dbId {dbId} not found");
+                    return;
+                }
+                _viewModel.Users.Remove(user);
+            });
             return;
         }
 
@@ -1970,7 +1992,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     ++_errorCount;
                 }
                 Error error = new(errorInfo);
-                await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
+                await Utility.RunOnUIThread(async () => await _viewModel.AddErrorAsync(error).ConfigureAwait(false));
+
                 return;
             }
 
@@ -1982,7 +2005,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 {
                     ++_errorCount;
                 }
-                await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
+
+                await Utility.RunOnUIThread(async () => await _viewModel.AddErrorAsync(error).ConfigureAwait(false));
             }
             else
             {
@@ -2024,7 +2048,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Error, "errorDbId is null.");
                 return;
             }
-            await _viewModel.RemoveErrorByDbIdAsync(errorDbId.Value);
+            await Utility.RunOnUIThread(async () =>
+            await _viewModel.RemoveErrorByDbIdAsync(errorDbId.Value));
             lock (_errorLock)
             {
                 _errorCount = Math.Max(0, _errorCount - 1);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -134,29 +134,29 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        private static bool CheckJobResultAndLogIfError(CommData? data, CancellationToken cancellationToken, JsonObject? jobInput = null, [CallerMemberName] string callerName = "")
+        private static bool CheckJobResultAndLogIfError(CommData? data, CancellationToken cancellationToken, [CallerMemberName] string callerName = "")
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                Logger.Log(Logger.Level.Info, $"Job cancelled at {callerName} with input {jobInput}.");
+                Logger.Log(Logger.Level.Info, $"Job cancelled at {callerName}.");
                 return false;
             }
 
             if (data is null)
             {
-                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, CommData is null.");
+                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName}, CommData is null.");
                 return false;
             }
 
             if (data.Params is null)
             {
-                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, Params is null.");
+                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName}, Params is null.");
                 return false;
             }
 
             if (data.Code != ExitCode.Ok)
             {
-                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, exit code: {data.Code}, exit cause: {data.Cause}.");
+                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName}, exit code: {data.Code}, exit cause: {data.Cause}.");
                 return false;
             }
             return true;
@@ -184,7 +184,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.LOGIN_REQUESTTOKEN, parms, cancellationToken).ConfigureAwait(false);
 
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.UserDbId))
@@ -226,7 +226,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, [], cancellationToken).ConfigureAwait(false);
 
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, []))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.UserInfoList))
@@ -288,7 +288,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return true;
             }
 
-            return CheckJobResultAndLogIfError(commData, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(commData, cancellationToken);
         }
 
         public async Task<bool> RefreshAccounts(CancellationToken cancellationToken)
@@ -415,7 +415,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.UserDbId] = userDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_AVAILABLEDRIVES, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.DriveAvailableInfoList))
@@ -577,7 +577,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.BlackList] = JsonSerializer.SerializeToNode(newSync.ExcludedNodeIds, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() } })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_ADD, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.SyncInfo))
@@ -615,7 +615,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_SETSUPPORTSVIRTUALFILES, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             return true;
@@ -643,7 +643,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return true;
             }
 
-            if (!CheckJobResultAndLogIfError(commData, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(commData, cancellationToken))
                 return false;
 
             // Rely on signal to remove the sync from the model
@@ -667,7 +667,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_START, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
             {
                 sync.SyncStatus = previousStatus;
                 return false;
@@ -693,7 +693,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_STOP, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
             {
                 sync.SyncStatus = previousStatus;
                 return false;
@@ -709,7 +709,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_BESTVFSAVAILABLEMODE, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.BestMode))
@@ -733,7 +733,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_FINDGOODPATHFORNEWSYNC, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.GoodPath) || !HasRequiredParam(data, JsonKeys.ErrorMessage))
@@ -765,7 +765,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ISPATHVALIDFORNEWSYNC, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.IsValid))
@@ -796,7 +796,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_SEARCH, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.SearchInfoList))
@@ -847,7 +847,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_OFFLINE_FILES_SIZE, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.Size))
@@ -873,7 +873,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.WithPath] = true
             };
             CommData data = await _getSubFolderQueue.SendRequestAsync(RequestNum.NODE_SUBFOLDERS, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeSubFolderInfoList))
@@ -908,7 +908,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.WithPath] = true
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_INFO, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return new GetNodeInfoResult(data.Cause, null);
 
             if (!HasRequiredParam(data, JsonKeys.NodeInfo))
@@ -938,7 +938,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.NodeId] = Utility.ToBase64String(nodeId),
             };
             CommData data = await _getFolderSizeQueue.SendRequestAsync(RequestNum.NODE_FOLDER_SIZE, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.FolderSize))
@@ -961,7 +961,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId,
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.BLACKLISTED_NODE_LIST, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeIdList))
@@ -989,7 +989,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.NodeIdList] = JsonSerializer.SerializeToNode(idList, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() } })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.BLACKLISTED_NODE_SETLIST, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<NodeId?> CreateMissingDirectories(IDrive drive, NodeId parentNodeId, string path, CancellationToken cancellationToken)
@@ -1006,7 +1006,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_CREATEMISSINGFOLDERS, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeId))
@@ -1032,7 +1032,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.NodeId] = Utility.ToBase64String(nodeId)
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_GETPUBLICLINKURL, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.LinkUrl))
@@ -1067,7 +1067,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.ReplicaSide] = (int)replicaSide
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_CONFLICT_INFO, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.NodeConflictInfo))
@@ -1179,7 +1179,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.UpdateChannel] = (int)channel
             };
             CommData data2 = await _commClient.SendRequestAsync(RequestNum.UPDATER_VERSION_INFO, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data2, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data2, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data2, JsonKeys.VersionInfo))
@@ -1212,7 +1212,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.IncludeArchivedLogs] = includeArchivedLogs
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_SEND_LOG_TO_SUPPORT, parms, cancellationToken);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> CancelLogUpload(CancellationToken cancellationToken)
@@ -1259,7 +1259,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Value] = Utility.ToBase64String(value)
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_SET_APPSTATE, parms, cancellationToken);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<string?> GetAppState(AppStateKey key, CancellationToken cancellationToken)
@@ -1269,7 +1269,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Key] = (int)key
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_GET_APPSTATE, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return null;
 
             if (!HasRequiredParam(data, JsonKeys.Value))
@@ -1314,7 +1314,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.PARAMETERS_UPDATE, parms, cancellationToken);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             return true;
@@ -1331,7 +1331,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     [JsonKeys.Default] = def
                 };
                 CommData data = await _commClient.SendRequestAsync(RequestNum.EXCLTEMPL_GETLIST, parms, cancellationToken).ConfigureAwait(false);
-                if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+                if (!CheckJobResultAndLogIfError(data, cancellationToken))
                     return null;
 
                 if (!HasRequiredParam(data, JsonKeys.ExclusionTemplatesList))
@@ -1363,7 +1363,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.ExclusionTemplatesList] = JsonSerializer.SerializeToNode(templates, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() }, PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.EXCLTEMPL_SETUSERLIST, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> RefreshErrors(CancellationToken cancellationToken)
@@ -1373,7 +1373,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Limit] = _maxErrorLimit
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_INFOLIST, parms, cancellationToken).ConfigureAwait(false);
-            if (!CheckJobResultAndLogIfError(data, cancellationToken, parms))
+            if (!CheckJobResultAndLogIfError(data, cancellationToken))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.ErrorInfoList))
@@ -1442,7 +1442,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Info, $"Error with DbId {errorDbId} cannot be deleted as it is kept by the server.");
                 return false;
             }
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> RefreshSyncErrors(DbId syncDbId, CancellationToken cancellationToken)
@@ -1452,7 +1452,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_SYNC_REFRESH, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> ResolveConflicts(List<DbId> keepLocalErrorDbIds, List<DbId> keepRemoteErrorDbIds, CancellationToken cancellationToken)
@@ -1463,7 +1463,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.KeepRemoteErrorDbIdList] = JsonSerializer.SerializeToNode(keepRemoteErrorDbIds)
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_RESOLVE_CONFLICTS, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         public async Task<bool> ResolveConflictsQuick(List<DbId> errorDbIds, ConflictResolutionStrategy strategy, CancellationToken cancellationToken)
@@ -1474,7 +1474,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Strategy] = (int)strategy
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_RESOLVE_CONFLICTS_QUICK, parms, cancellationToken).ConfigureAwait(false);
-            return CheckJobResultAndLogIfError(data, cancellationToken, parms);
+            return CheckJobResultAndLogIfError(data, cancellationToken);
         }
 
         // Signals

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
@@ -69,7 +69,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public event EventHandler<SignalEventArgs> SignalReceived = delegate { };
         public event EventHandler ConnectionLost = delegate { };
 
-        public TcpServerCommClient() {}
+        public TcpServerCommClient() { }
 
         ~TcpServerCommClient()
         {
@@ -248,9 +248,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     await Task.Delay(100, cancellationToken).ConfigureAwait(false);
                 }
 
-                _pendingRequests[requestId] = new TaskCompletionSource<CommData>(
-                    TaskCreationOptions.RunContinuationsAsynchronously);
-
+                var replySource = new TaskCompletionSource<CommData>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _pendingRequests[requestId] = replySource;
                 // Create the JSON object
                 var requestObj = new JsonObject
                 {
@@ -274,7 +273,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 }
                 Logger.Log(Logger.Level.Info, $"Sent request: {jsonString}");
                 cancellationToken.ThrowIfCancellationRequested();
-                CommData reply = await WaitForReplyAsync(requestId, cancellationToken).ConfigureAwait(false);
+                CommData reply = await WaitForReplyAsync(requestId, replySource, cancellationToken).ConfigureAwait(false);
                 if (reply.RequestNum == RequestNum.Unknown)
                 {
                     Logger.Log(Logger.Level.Debug, "Request not implemented server-side");
@@ -297,15 +296,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return new CommData();
             }
         }
-        private Task<CommData> WaitForReplyAsync(long requestId, CancellationToken ct = default)
+        private Task<CommData> WaitForReplyAsync(long requestId, TaskCompletionSource<CommData> tcs, CancellationToken ct = default)
         {
-
-            if (!_pendingRequests.TryGetValue(requestId, out var tcs))
-            {
-                Logger.Log(Logger.Level.Error, $"RequestId {requestId} not found in pending requests.");
-                return Task.FromResult(new CommData());
-            }
-
             // Tie cancellation to the task
             if (ct.CanBeCanceled)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/NotificationManager.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/NotificationManager.cs
@@ -16,12 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.Diagnostics.Utilities;
-using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.Windows.AppNotifications;
 using Microsoft.Windows.AppNotifications.Builder;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Windows.System;
 
@@ -59,7 +56,7 @@ namespace Infomaniak.kDrive
         {
             if (Availability != AppNotificationAvailability.Available)
             {
-                Logger.Log(Logger.Level.Warning, $"App notifications are not available: {Availability}");
+                Logger.Log(Logger.Level.Warning, $"App notifications are not available: {Availability} ({AppNotificationManager.Default.Setting})");
                 return;
             }
 
@@ -109,7 +106,7 @@ namespace Infomaniak.kDrive
                 Init(); // The Notifications might have been enabled after the app start in system settings
                 if (!m_isRegistered)
                 {
-                    Logger.Log(Logger.Level.Warning, "Attempted to show a notification while not registered. Call Init() first.");
+                    Logger.Log(Logger.Level.Info, "Attempted to show a notification while not registered. Call Init() first.");
                     return 0;
                 }
             }

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -351,17 +351,19 @@ namespace Infomaniak.kDrive.ViewModels
                 return;
             }
 
-            foreach (var sync in AllSyncs)
+            await Utility.RunOnUIThread(async () =>
             {
-                var syncError = sync.SyncErrors.FirstOrDefault(e => e.DbId == errorDbId);
-                if (syncError != null)
+                Sync? sync = AllSyncs.FirstOrDefault(s => s.SyncErrors.Any(e => e.DbId == errorDbId));
+                Error? syncError = sync?.SyncErrors.FirstOrDefault(e => e.DbId == errorDbId);
+
+                if (sync is null || syncError is null)
                 {
-                    await sync.RemoveErrorAsync(syncError);
+                    Logger.Log(Logger.Level.Warning, $"AppModel: Could not find error with DbId {errorDbId} to remove, Sync: {sync?.DbId ?? -1}, SyncError: {syncError?.DbId ?? -1}");
                     return;
                 }
-            }
 
-            Logger.Log(Logger.Level.Warning, $"AppModel: Could not find error with DbId {errorDbId} to remove.");
+                await sync.RemoveErrorAsync(syncError);
+            });
         }
 
         public async Task ClearAllErrorsAsync()

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Error.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Error.cs
@@ -94,6 +94,11 @@ namespace Infomaniak.kDrive.ViewModels
             _autoResolved = errorInfo.AutoResolved ?? _autoResolved;
         }
 
+        public override string ToString()
+        {
+            return $"Error: DbId={DbId}, Timestamp={Timestamp}, ErrorLevel={ErrorLevel}, ExitCode={ExitCode}, ExitCause={ExitCause}, NodeType={NodeType}, Path={Path}, DestinationPath={DestinationPath}, LocalNodeId={LocalNodeId}, RemoteNodeId={RemoteNodeId}, ConflictType={ConflictType}, InconsistencyType={InconsistencyType}, CancelType={CancelType}, AutoResolved={AutoResolved}";
+        }
+
         public DbId DbId
         {
             get => _DbId;


### PR DESCRIPTION
This pull request introduces several improvements to the `ServerCommService` in the kDrive client, focusing on better handling of cancellation tokens, ensuring UI thread safety when accessing or modifying view model collections, and improving consistency in error checking for server communication tasks. The changes enhance application stability, responsiveness, and maintainability.

**Cancellation and Error Handling Improvements**
- All calls to `CheckJobResultAndLogIfError` now pass the `CancellationToken`, and the method itself has been updated to log and handle cancellation requests gracefully, preventing unnecessary operations if a task is cancelled. [[1]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL137-R144) [[2]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL181-R187) [[3]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL214-R229) [[4]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL283-R297) [[5]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL347-R355) [[6]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL410-R418) [[7]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL496-R505) [[8]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL571-R580) [[9]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL608-R618) [[10]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL636-R646) [[11]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL659-R670) [[12]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL684-R696) [[13]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL700-R712) [[14]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL724-R736) [[15]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL756-R768)

**Thread Safety and UI Access**
- Accesses to view model collections (`_viewModel.Users`, `_viewModel.AllSyncs`, etc.) that could affect the UI are now wrapped in `Utility.RunOnUIThread` to ensure thread safety, especially when searching for or updating users, accounts, drives, and syncs. [[1]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cR204-R212) [[2]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL430-R439) [[3]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL583-R593) [[4]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL645-R656) [[5]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL670-R682)

**Refactoring of UI Updates**
- Refactored code that removes accounts, drives, and syncs so that the entire block for finding and removing items is executed on the UI thread, consolidating and simplifying UI updates. [[1]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cR329-R330) [[2]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL329-L330) [[3]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cR388-R389) [[4]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL388-L389) [[5]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cR537-R538) [[6]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL537-L538)

**Miscellaneous Fixes**
- Fixed logic to ensure that the correct user or sync object is returned or modified after UI-threaded operations, improving reliability in user and sync management. [[1]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cR204-R212) [[2]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL430-R439) [[3]](diffhunk://#diff-6a6efe604119a6c091a084c636f10960ab420071eb864d1edbb5f313c5310c4cL583-R593)
- Ensured that the control template is applied before accessing `SettingsItem` in `AppNavigationView`, which can prevent potential null reference issues.