### PR TITLE
feat(ui): wire Storage QML view to StorageController

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -234,6 +234,13 @@
   independent Home banner instead of replacing the central state.
 - `app/mainwindow/networkstatusobserver.*`: process-long `QNetworkInformation` adapter. Only explicit disconnected
   reachability is treated as offline; unavailable or unknown backends preserve the cache-derived state.
+- `app/mainwindow/storagecontroller.*`: QML-facing Storage lifecycle and process-local per-sync snapshot cache. It
+  starts cancellable local scans only while Storage is visible, keeps the last resolved presentation during refresh, and
+  refreshes once an active synchronization leaves `Starting`, `Running`, `PauseAsked`, or `StopAsked` for any non-active
+  status.
+- `app/mainwindow/storagescanner.*`: Linux local-volume scanner using `QStorageInfo` plus an explicit Qt directory
+  stack. It stays on the synchronization root device, skips links and special files, deduplicates hard links, and sums
+  allocated blocks so sparse files reflect their physical footprint.
 - `app/navigation/approuter.*`: minimal main-window router. It owns only `mainWindowActive` and the selected main tab;
   it must not read `AppCache`, call backend services, or decide whether onboarding is required.
 - `app/navigation/mainwindowactivationdecision.*`: pure post-bootstrap choice between onboarding, the unconfigured Home,

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -15,6 +15,7 @@
 
 - In versioned documentation, use repo-relative paths, not hardcoded absolute paths.
 - Do not add links to `.md` files that are not versioned in git.
+- Use Swiss German orthography for German Linux v4 translations: write `ss` instead of `ß`.
 - Never launch a build unless explicitly asked by the user.
 - For the Activities PR stack, preparing a PR means isolating and staging its changes only. Leave commit, push, and PR
   creation to the user unless they explicitly ask Codex to publish them.
@@ -29,6 +30,8 @@
 - Do not duplicate method documentation between headers and implementation files. Document public API contracts in
   headers, private helpers in `.cpp` files, and keep implementation-specific comments next to the relevant code.
 - Do not introduce raw `int` in new code when a fixed-width type fits (`uint8_t`, `int32_t`, ...).
+- In new Linux v4 C++ code, import `Qt::StringLiterals` in the implementation and use `u"..."_s` instead of
+  `QStringLiteral(...)`.
 - Use the domain aliases from `libcommon/utility/types.h` whenever they match the represented concept. Keep `int` and Qt
   numeric types when required by an overridden Qt API or a QML boundary, and make that constraint explicit when unclear.
 - Do not run `clang-format` on `CMakeLists.txt` in this repository.
@@ -103,6 +106,17 @@
   component generic, non-modal, and independent from the activity row lifetime.
 - Automated tests for the current Activities milestone are deferred. Do not add an Activities-specific test target or
   files under `test/gui4/linux/` until the user explicitly reopens that scope.
+- Keep Linux Storage usage local to the GUI: use `QStorageInfo`/Qt filesystem tools where they expose the required
+  semantics, supplement them with POSIX metadata only for device identity and allocated blocks, never descend onto a
+  different `st_dev`, and count sparse files by their physically allocated blocks rather than logical size.
+- Disable the Activities and Storage sidebar entries when no selected synchronization root exists; the unconfigured
+  route remains on Home.
+- Let Storage inherit the shared main-page surface, and use the same card surface as Home Quick Access. Keep the 12 px
+  clipped card radius, 24 px horizontal page margins, and 32 px top margin.
+- Mask the complete Storage graph with one rounded shape instead of rounding individual segments: `Rectangle.clip` is
+  rectangular in Qt Quick, and segment-level rounding breaks when the leading segment is zero or subpixel-sized.
+- Keep the synchronization and other-files Storage segments visible with a nominal 1% minimum, but let free space reach
+  a true zero width. Normalize the displayed widths inside the single rounded graph mask.
 - Main-sidebar selection changes only the row background; it must not recolor the icon or increase the label weight.
 - Keep shared color primitives aligned with the macOS design-token assets; notably, `NeutralBlue200` is `#DCE3F0` and
   `NeutralBlue600` is `#1F242E`.

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -169,8 +169,9 @@ set(GUI_QML_FILES # .qml files for the app
         ui/windows/main/BlockingErrorPlaceholder.qml
         ui/windows/main/MainToolbar.qml
         ui/windows/main/MainWindowView.qml
-        ui/windows/main/StoragePlaceholder.qml
+        ui/windows/main/storage/StorageErrorState.qml
         ui/windows/main/storage/StorageUsageCard.qml
+        ui/windows/main/storage/StorageView.qml
         ui/windows/main/activities/ActivitiesEmptyState.qml
         ui/windows/main/activities/ActivitiesFilterMenu.qml
         ui/windows/main/activities/ActivitiesHeader.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -170,6 +170,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/windows/main/MainToolbar.qml
         ui/windows/main/MainWindowView.qml
         ui/windows/main/StoragePlaceholder.qml
+        ui/windows/main/storage/StorageUsageCard.qml
         ui/windows/main/activities/ActivitiesEmptyState.qml
         ui/windows/main/activities/ActivitiesFilterMenu.qml
         ui/windows/main/activities/ActivitiesHeader.qml

--- a/src/gui4/linux/app/mainwindow/storagecontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/storagecontroller.cpp
@@ -28,6 +28,10 @@ Q_LOGGING_CATEGORY(lcStorageController, "gui.v4.storagecontroller", QtInfoMsg)
 
 namespace KDC {
 
+namespace {
+constexpr int32_t minimumRetryIndicatorDurationMs = 300;
+}
+
 StorageController::StorageController(MainSelectionStore &selectionStore, QObject *const parent) :
     QObject(parent),
     _selectionStore(selectionStore) {
@@ -38,6 +42,14 @@ StorageController::StorageController(MainSelectionStore &selectionStore, QObject
     (void) connect(&_selectionStore, &MainSelectionStore::currentSyncStatusChanged, this,
                    &StorageController::handleSyncStatusChanged);
     (void) connect(&_scanWatcher, &QFutureWatcher<StorageScanResult>::finished, this, &StorageController::handleScanFinished);
+    _minimumRetryTimer.setInterval(minimumRetryIndicatorDurationMs);
+    _minimumRetryTimer.setSingleShot(true);
+    (void) connect(&_minimumRetryTimer, &QTimer::timeout, this, [this] {
+        if (_retryCompletionPending) {
+            _retryCompletionPending = false;
+            handleScanFinished();
+        }
+    });
     refreshSelectedContext();
 }
 
@@ -99,10 +111,10 @@ void StorageController::setViewActive(const bool active) {
 }
 
 void StorageController::retry() {
-    if (!_viewActive || _selectedSyncDbId == 0) {
+    if (!_viewActive || _selectedSyncDbId == 0 || _retrying || _scanWatcher.isRunning()) {
         return;
     }
-    startScan();
+    startScan(ScanTrigger::Retry);
 }
 
 void StorageController::refreshSelectedContext() {
@@ -172,19 +184,24 @@ void StorageController::presentSnapshot(const StorageSnapshot &snapshot) {
     emit storageChanged();
 }
 
-void StorageController::startScan() {
+void StorageController::startScan(const ScanTrigger trigger) {
     if (!_viewActive || _selectedSyncDbId == 0 || _selectedSyncRoot.empty()) {
         return;
     }
 
     cancelScan();
+    if (trigger == ScanTrigger::Retry) {
+        setRetrying(true);
+        _minimumRetryTimer.start();
+    }
 
     const SyncDbId requestedSyncDbId = _selectedSyncDbId;
     const SyncPath requestedSyncRoot = _selectedSyncRoot;
     _scanCancellation = std::make_shared<std::atomic_bool>(false);
     const auto cancellation = _scanCancellation;
     qCInfo(lcStorageController) << "Starting local Storage scan | syncDbId:" << requestedSyncDbId
-                                << "| root:" << Path2QStr(requestedSyncRoot);
+                                << "| root:" << Path2QStr(requestedSyncRoot)
+                                << "| trigger:" << (trigger == ScanTrigger::Retry ? "retry" : "automatic");
     (void) _scanWatcher.setProperty("syncDbId", QVariant::fromValue<qint64>(requestedSyncDbId));
     (void) _scanWatcher.setProperty("syncRoot", Path2QStr(requestedSyncRoot));
     _scanWatcher.setFuture(QtConcurrent::run([requestedSyncRoot, cancellation] {
@@ -193,12 +210,19 @@ void StorageController::startScan() {
 }
 
 void StorageController::cancelScan() {
+    _minimumRetryTimer.stop();
+    _retryCompletionPending = false;
+    setRetrying(false);
     if (_scanCancellation) {
         _scanCancellation->store(true, std::memory_order_relaxed);
         _scanCancellation.reset();
     }
 }
 
+/**
+ * Applies the current scan result, deferring a fast retry result until the retry indicator has been visible for its
+ * minimum duration.
+ */
 void StorageController::handleScanFinished() {
     const auto result = _scanWatcher.result();
     const auto requestedSyncDbId = static_cast<SyncDbId>(_scanWatcher.property("syncDbId").toLongLong());
@@ -207,6 +231,13 @@ void StorageController::handleScanFinished() {
         result.error == StorageScanError::Canceled) {
         return;
     }
+    if (_retrying && _minimumRetryTimer.isActive()) {
+        _retryCompletionPending = true;
+        return;
+    }
+
+    _retryCompletionPending = false;
+    setRetrying(false);
 
     if (result.succeeded()) {
         _cache[requestedSyncDbId] = CachedSnapshot{.syncRoot = requestedSyncRoot, .snapshot = *result.snapshot};
@@ -230,6 +261,15 @@ void StorageController::handleScanFinished() {
 
 void StorageController::setState(const State state) {
     _state = state;
+}
+
+void StorageController::setRetrying(const bool retrying) {
+    if (_retrying == retrying) {
+        return;
+    }
+
+    _retrying = retrying;
+    emit retryingChanged();
 }
 
 std::optional<SyncStatus> StorageController::currentStatus() const {

--- a/src/gui4/linux/app/mainwindow/storagecontroller.h
+++ b/src/gui4/linux/app/mainwindow/storagecontroller.h
@@ -25,6 +25,7 @@
 #include <QLoggingCategory>
 #include <QObject>
 #include <QString>
+#include <QTimer>
 
 #include <atomic>
 #include <cstdint>
@@ -47,6 +48,7 @@ namespace KDC {
 class StorageController final : public QObject {
         Q_OBJECT
         Q_PROPERTY(State state READ state NOTIFY storageChanged)
+        Q_PROPERTY(bool retrying READ retrying NOTIFY retryingChanged)
         Q_PROPERTY(QString volumeName READ volumeName NOTIFY storageChanged)
         Q_PROPERTY(QString usageText READ usageText NOTIFY storageChanged)
         Q_PROPERTY(QString syncSizeText READ syncSizeText NOTIFY storageChanged)
@@ -68,6 +70,7 @@ class StorageController final : public QObject {
         ~StorageController() override;
 
         [[nodiscard]] State state() const { return _state; }
+        [[nodiscard]] bool retrying() const { return _retrying; }
         [[nodiscard]] QString volumeName() const;
         [[nodiscard]] QString usageText() const;
         [[nodiscard]] QString syncSizeText() const;
@@ -81,8 +84,14 @@ class StorageController final : public QObject {
 
     signals:
         void storageChanged();
+        void retryingChanged();
 
     private:
+        enum class ScanTrigger : uint8_t {
+            Automatic = 0,
+            Retry,
+        };
+
         struct CachedSnapshot {
                 SyncPath syncRoot;
                 StorageSnapshot snapshot;
@@ -92,10 +101,11 @@ class StorageController final : public QObject {
         void handleSyncStatusChanged();
         void presentSelectedCache();
         void presentSnapshot(const StorageSnapshot &snapshot);
-        void startScan();
+        void startScan(ScanTrigger trigger = ScanTrigger::Automatic);
         void cancelScan();
         void handleScanFinished();
         void setState(State state);
+        void setRetrying(bool retrying);
         [[nodiscard]] std::optional<SyncStatus> currentStatus() const;
         [[nodiscard]] uint64_t usedBytes() const;
         [[nodiscard]] uint64_t otherBytes() const;
@@ -105,6 +115,7 @@ class StorageController final : public QObject {
 
         MainSelectionStore &_selectionStore;
         QFutureWatcher<StorageScanResult> _scanWatcher;
+        QTimer _minimumRetryTimer;
         std::shared_ptr<std::atomic_bool> _scanCancellation;
         std::unordered_map<SyncDbId, CachedSnapshot> _cache;
         std::unordered_set<SyncDbId> _dirtySyncs;
@@ -114,6 +125,8 @@ class StorageController final : public QObject {
         SyncPath _selectedSyncRoot;
         State _state{State::Loading};
         bool _viewActive{false};
+        bool _retrying{false};
+        bool _retryCompletionPending{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/mainwindow/storagescanner.cpp
+++ b/src/gui4/linux/app/mainwindow/storagescanner.cpp
@@ -79,17 +79,22 @@ void logFilesystemError(const char *operation, const SyncPath &path, const int e
                                 << "| error:" << QString::fromLocal8Bit(errorMessage.c_str()) << "| errno:" << errorNumber;
 }
 
+[[nodiscard]] QString titleWithDevice(const QString &title, const QString &device) {
+    return device.isEmpty() || device == title ? title : u"%1 (%2)"_s.arg(title, device);
+}
+
 [[nodiscard]] QString volumeName(const QStorageInfo &storage) {
-    QString label = storage.displayName();
-    if (label.isEmpty()) {
-        label = storage.name();
+    const QString label = storage.name();
+    const QString device = QDir::toNativeSeparators(QString::fromLocal8Bit(storage.device()));
+    if (!label.isEmpty()) {
+        return titleWithDevice(label, device);
     }
 
-    const QString device = QDir::toNativeSeparators(QString::fromLocal8Bit(storage.device()));
-    if (label.isEmpty()) {
-        return device.isEmpty() ? QDir::toNativeSeparators(storage.rootPath()) : device;
+    if (storage.isRoot()) {
+        return qtTrId("storageThisComputer");
     }
-    return device.isEmpty() || device == label ? label : u"%1 (%2)"_s.arg(label, device);
+
+    return titleWithDevice(QDir::toNativeSeparators(storage.rootPath()), device);
 }
 
 void addAllocatedBytes(const struct stat &fileStat, uint64_t &total) {

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: da, Danish
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="da"> 
     <context>
@@ -2266,6 +2266,11 @@ oplåst og tilgængeligt fra din computer.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synkronisering</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Denne computer</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: de, German
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="de"> 
     <context>
@@ -2265,6 +2265,11 @@ entsperrt ist und von Ihrem Computer aus darauf zugegriffen werden kann.</transl
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synchronisierung</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Dieser Computer</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: el, Greek
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="el"> 
     <context>
@@ -2266,6 +2266,11 @@ unlocked and accessible from your computer.</source>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Συγχρονισμός</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Αυτός ο υπολογιστής</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: en, English
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en"> 
     <context>
@@ -2266,6 +2266,11 @@ unlocked and accessible from your computer.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Sync</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>This computer</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: es, Spanish
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="es"> 
     <context>
@@ -2266,6 +2266,11 @@ desbloqueado y accesible desde su ordenador.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Sincronización</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Este ordenador</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fi, Finnish
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fi"> 
     <context>
@@ -2266,6 +2266,11 @@ lukitsematon ja tietokoneeltasi käytettävissä.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synkronointi</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Tämä tietokone</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fr, French
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fr"> 
     <context>
@@ -2266,6 +2266,11 @@ déverrouillé et accessible depuis votre ordinateur.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synchronisation</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Cet ordinateur</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: it, Italian
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="it"> 
     <context>
@@ -2266,6 +2266,11 @@ sbloccato e accessibile dal computer.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Sincronizzazione</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Questo computer</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nb, Norwegian Bokmål
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nb"> 
     <context>
@@ -2266,6 +2266,11 @@ låst opp og tilgjengelig fra datamaskinen din.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synkronisering</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Denne datamaskinen</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nl, Dutch; Flemish
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nl"> 
     <context>
@@ -2266,6 +2266,11 @@ ontgrendeld en toegankelijk is vanaf uw computer.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synchronisatie</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Deze computer</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pl, Polish
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pl"> 
     <context>
@@ -2270,6 +2270,11 @@ odblokowany i dostępny z Twojego komputera.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synchronizacja</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Ten komputer</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pt, Portuguese
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pt"> 
     <context>
@@ -2266,6 +2266,11 @@ desbloqueado e acessível no seu computador.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Sincronização</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Este computador</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: sv, Swedish
  Exported by: Romain Galland
- Exported at: Mon, 24 Aug 2026 10:21:44 +0200 
+ Exported at: Tue, 25 Aug 2026 14:05:49 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="sv"> 
     <context>
@@ -2266,6 +2266,11 @@ olåst och tillgänglig från din dator.</translation>
         <message id="storageSyncBlockTitle"> 
             <source>Sync</source> 
             <translation>Synkronisering</translation> 
+        </message> 
+        <message id="storageThisComputer"> 
+            <source>This computer</source> 
+            <extracomment>Title shown for the main system volume when it has no filesystem label.</extracomment> 
+            <translation>Den här datorn</translation> 
         </message> 
         <message id="storageThisComputerTitle"> 
             <source>This PC - %1 - %2</source> 

--- a/src/gui4/linux/ui/tokens/IKStorage.qml
+++ b/src/gui4/linux/ui/tokens/IKStorage.qml
@@ -36,7 +36,6 @@ QtObject {
     readonly property real errorTextMaxWidth: 440
     readonly property real errorTitleSize: 15
     readonly property real errorLineHeight: 20
-    readonly property real retryHeight: 20
     readonly property real loadingSpinnerSize: 16
     readonly property real loadingPlaceholderWidth: 64
     readonly property real loadingPlaceholderHeight: 12

--- a/src/gui4/linux/ui/windows/main/MainWindowView.qml
+++ b/src/gui4/linux/ui/windows/main/MainWindowView.qml
@@ -29,6 +29,7 @@ Item {
     required property var activitiesController
     required property var homeController
     required property var mainSidebarController
+    required property var storageController
 
     readonly property int tabHome: AppRouter.Home
     readonly property int tabActivities: AppRouter.Activities
@@ -73,9 +74,10 @@ Item {
                     sourceComponent: activitiesViewComponent
                 }
 
-                StoragePlaceholder {
+                Loader {
                     anchors.fill: parent
-                    visible: root.currentTab === root.tabStorage
+                    active: root.currentTab === root.tabStorage && root.windowVisible
+                    sourceComponent: storageViewComponent
                 }
 
                 BlockingErrorPlaceholder {
@@ -115,6 +117,14 @@ Item {
 
         ActivitiesView {
             controller: root.activitiesController
+        }
+    }
+
+    Component {
+        id: storageViewComponent
+
+        StorageView {
+            controller: root.storageController
         }
     }
 }

--- a/src/gui4/linux/ui/windows/main/storage/StorageErrorState.qml
+++ b/src/gui4/linux/ui/windows/main/storage/StorageErrorState.qml
@@ -73,23 +73,37 @@ Item {
                 width: parent.width
                 wrapMode: Text.WordWrap
             }
-            Button {
-                id: retryButton
-
+            Item {
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTrId("buttonRetry")
-                flat: true
-                focusPolicy: Qt.StrongFocus
+                height: retryButton.implicitHeight
+                width: retryButton.implicitWidth
 
-                contentItem: Text {
-                    color: IKColors.actionPrimary
-                    font.pixelSize: IKFonts.bodySize
-                    horizontalAlignment: Text.AlignHCenter
-                    text: retryButton.text
-                    verticalAlignment: Text.AlignVCenter
+                Button {
+                    id: retryButton
+
+                    anchors.fill: parent
+                    flat: true
+                    focusPolicy: Qt.StrongFocus
+                    text: qsTrId("buttonRetry")
+                    visible: !root.controller.retrying
+
+                    contentItem: Text {
+                        color: IKColors.actionPrimary
+                        font.pixelSize: IKFonts.bodySize
+                        horizontalAlignment: Text.AlignHCenter
+                        text: retryButton.text
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    onClicked: root.controller.retry()
                 }
-
-                onClicked: root.controller.retry()
+                IKLoadingSpinner {
+                    Accessible.name: qsTrId("storageLoadingHint")
+                    anchors.centerIn: parent
+                    height: IKStorage.loadingSpinnerSize
+                    visible: root.controller.retrying
+                    width: IKStorage.loadingSpinnerSize
+                }
             }
         }
     }

--- a/src/gui4/linux/ui/windows/main/storage/StorageErrorState.qml
+++ b/src/gui4/linux/ui/windows/main/storage/StorageErrorState.qml
@@ -77,12 +77,10 @@ Item {
                 id: retryButton
 
                 anchors.horizontalCenter: parent.horizontalCenter
-                height: IKStorage.retryHeight
-                padding: 0
                 text: qsTrId("buttonRetry")
+                flat: true
+                focusPolicy: Qt.StrongFocus
 
-                background: Item {
-                }
                 contentItem: Text {
                     color: IKColors.actionPrimary
                     font.pixelSize: IKFonts.bodySize

--- a/src/gui4/linux/ui/windows/main/storage/StorageErrorState.qml
+++ b/src/gui4/linux/ui/windows/main/storage/StorageErrorState.qml
@@ -1,0 +1,98 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+Item {
+    id: root
+
+    required property var controller
+
+    Column {
+        anchors.centerIn: parent
+        spacing: IKStorage.errorContentSpacing
+
+        Item {
+            anchors.horizontalCenter: parent.horizontalCenter
+            height: IKStorage.illustrationSize
+            width: IKStorage.illustrationSize
+
+            Image {
+                anchors.centerIn: parent
+                fillMode: Image.PreserveAspectFit
+                height: IKStorage.illustrationGraphicHeight
+                smooth: true
+                source: "qrc:/assets/main/storage/unavailable.svg"
+                sourceSize.height: height
+                sourceSize.width: width
+                width: IKStorage.illustrationGraphicWidth
+            }
+        }
+        Column {
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: IKStorage.errorTextSpacing
+            width: Math.min(IKStorage.errorTextMaxWidth, root.width - IKSpacing.s48)
+
+            Text {
+                color: IKColors.textPrimary
+                font.pixelSize: IKStorage.errorTitleSize
+                font.weight: IKFonts.emphasized
+                horizontalAlignment: Text.AlignHCenter
+                lineHeight: IKStorage.errorLineHeight
+                lineHeightMode: Text.FixedHeight
+                text: qsTrId("linuxStorageLocationUnavailableTitle")
+                width: parent.width
+                wrapMode: Text.WordWrap
+            }
+            Text {
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.bodySize
+                horizontalAlignment: Text.AlignHCenter
+                lineHeight: IKStorage.errorLineHeight
+                lineHeightMode: Text.FixedHeight
+                text: qsTrId("linuxStorageLocationUnavailableDescription")
+                width: parent.width
+                wrapMode: Text.WordWrap
+            }
+            Button {
+                id: retryButton
+
+                anchors.horizontalCenter: parent.horizontalCenter
+                height: IKStorage.retryHeight
+                padding: 0
+                text: qsTrId("buttonRetry")
+
+                background: Item {
+                }
+                contentItem: Text {
+                    color: IKColors.actionPrimary
+                    font.pixelSize: IKFonts.bodySize
+                    horizontalAlignment: Text.AlignHCenter
+                    text: retryButton.text
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                onClicked: root.controller.retry()
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/windows/main/storage/StorageUsageCard.qml
+++ b/src/gui4/linux/ui/windows/main/storage/StorageUsageCard.qml
@@ -1,0 +1,240 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Effects
+import kDrive.UI
+
+Rectangle {
+    id: root
+
+    required property var controller
+    required property bool loading
+
+    clip: true
+    color: IKColors.storageSurface
+    height: IKStorage.cardHeight
+    radius: IKRadius.r12
+
+    Item {
+        id: header
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: IKStorage.headerHeight
+
+        Text {
+            anchors.left: parent.left
+            anchors.leftMargin: IKStorage.cardHorizontalPadding
+            anchors.right: root.loading ? loadingIndicator.left : usageText.left
+            anchors.rightMargin: IKSpacing.s16
+            color: IKColors.textPrimary
+            elide: Text.ElideRight
+            font.pixelSize: IKFonts.bodySize
+            font.weight: IKFonts.medium
+            text: root.controller.volumeName
+            visible: !root.loading
+            y: IKSpacing.s16
+        }
+        Text {
+            id: usageText
+
+            anchors.right: parent.right
+            anchors.rightMargin: IKStorage.cardHorizontalPadding
+            color: IKColors.textSecondary
+            font.pixelSize: IKFonts.bodySize
+            font.weight: IKFonts.medium
+            text: root.controller.usageText
+            visible: !root.loading
+            y: IKSpacing.s16
+        }
+        IKLoadingSpinner {
+            id: loadingIndicator
+
+            Accessible.name: qsTrId("storageLoadingHint")
+            anchors.right: parent.right
+            anchors.rightMargin: IKStorage.cardHorizontalPadding
+            height: IKStorage.loadingSpinnerSize
+            visible: root.loading
+            width: IKStorage.loadingSpinnerSize
+            y: IKSpacing.s16
+        }
+        Rectangle {
+            id: storageBar
+
+            readonly property real displayedRatioTotal: rawSyncRatio + rawOtherRatio + rawAvailableRatio
+            readonly property real otherWidth: width * rawOtherRatio / displayedRatioTotal
+            readonly property real rawAvailableRatio: root.controller.availableRatio
+            readonly property real rawOtherRatio: Math.max(root.controller.otherRatio, IKStorage.minimumSegmentRatio)
+            readonly property real rawSyncRatio: Math.max(root.controller.syncRatio, IKStorage.minimumSegmentRatio)
+            readonly property real syncWidth: width * rawSyncRatio / displayedRatioTotal
+
+            anchors.left: parent.left
+            anchors.leftMargin: IKStorage.cardHorizontalPadding
+            anchors.right: parent.right
+            anchors.rightMargin: IKStorage.cardHorizontalPadding
+            clip: true
+            color: root.loading ? IKColors.surfaceTertiary : IKColors.storageFree
+            height: IKStorage.storageBarHeight
+            layer.enabled: true
+            radius: IKStorage.storageBarRadius
+            y: IKSpacing.s16 + IKFonts.bodySize + IKSpacing.s12
+
+            layer.effect: MultiEffect {
+                maskEnabled: true
+                maskSource: storageBarMask
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                color: IKColors.storageBarSync
+                height: parent.height
+                width: root.loading ? 0 : storageBar.syncWidth
+            }
+            Rectangle {
+                color: IKColors.storageBarOther
+                height: parent.height
+                width: root.loading ? 0 : storageBar.otherWidth
+                x: storageBar.syncWidth
+            }
+            Rectangle {
+                color: IKColors.storageBarSeparator
+                height: parent.height
+                visible: !root.loading
+                width: 1
+                x: Math.max(0, storageBar.syncWidth - width)
+            }
+            Rectangle {
+                color: IKColors.storageBarSeparator
+                height: parent.height
+                visible: !root.loading && root.controller.availableRatio > 0
+                width: 1
+                x: Math.max(0, storageBar.syncWidth + storageBar.otherWidth - width)
+            }
+        }
+        Rectangle {
+            id: storageBarMask
+
+            color: IKColors.storageFree
+            height: storageBar.height
+            layer.enabled: true
+            radius: IKStorage.storageBarRadius
+            visible: false
+            width: storageBar.width
+        }
+    }
+    Column {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: header.bottom
+
+        LegendRow {
+            dotColor: IKColors.storageLegendSync
+            height: IKStorage.rowHeight
+            label: qsTrId("storageComputerUsedByKDrive")
+            loading: root.loading
+            value: root.controller.syncSizeText
+            width: parent.width
+        }
+        LegendRow {
+            dotColor: IKColors.storageLegendOther
+            height: IKStorage.rowHeight
+            label: qsTrId("storageComputerUsedByOther")
+            loading: root.loading
+            value: root.controller.otherSizeText
+            width: parent.width
+        }
+        LegendRow {
+            dotColor: IKColors.storageFree
+            height: IKStorage.rowHeight
+            label: qsTrId("storageComputerFreeSpace")
+            loading: root.loading
+            value: root.controller.availableSizeText
+            width: parent.width
+        }
+    }
+
+    component LegendRow: Item {
+        id: legendRow
+
+        required property color dotColor
+        required property string label
+        required property bool loading
+        required property string value
+
+        Rectangle {
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            color: IKColors.storageDivider
+            height: 1
+        }
+        Rectangle {
+            anchors.left: parent.left
+            anchors.leftMargin: IKStorage.cardHorizontalPadding
+            anchors.verticalCenter: parent.verticalCenter
+            color: legendRow.dotColor
+            height: IKStorage.legendDotSize
+            radius: width / 2
+            width: IKStorage.legendDotSize
+        }
+        Text {
+            anchors.left: parent.left
+            anchors.leftMargin: IKStorage.cardHorizontalPadding + IKStorage.legendDotSize + IKSpacing.s8
+            anchors.right: valueLoader.left
+            anchors.rightMargin: IKSpacing.s16
+            anchors.verticalCenter: parent.verticalCenter
+            color: IKColors.textPrimary
+            elide: Text.ElideRight
+            font.pixelSize: IKFonts.bodySize
+            font.weight: IKFonts.medium
+            text: legendRow.label
+        }
+        Item {
+            id: valueLoader
+
+            anchors.right: parent.right
+            anchors.rightMargin: IKStorage.cardHorizontalPadding
+            anchors.verticalCenter: parent.verticalCenter
+            height: IKFonts.bodySize + IKSpacing.s4
+            width: legendRow.loading ? IKStorage.loadingPlaceholderWidth : valueText.implicitWidth
+
+            Rectangle {
+                anchors.centerIn: parent
+                color: IKColors.surfaceTertiary
+                height: IKStorage.loadingPlaceholderHeight
+                radius: IKRadius.r4
+                visible: legendRow.loading
+                width: IKStorage.loadingPlaceholderWidth
+            }
+            Text {
+                id: valueText
+
+                anchors.centerIn: parent
+                color: IKColors.textSecondary
+                font.pixelSize: IKFonts.bodySize
+                font.weight: IKFonts.medium
+                text: legendRow.value
+                visible: !legendRow.loading
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/windows/main/storage/StorageView.qml
+++ b/src/gui4/linux/ui/windows/main/storage/StorageView.qml
@@ -22,10 +22,28 @@ import QtQuick
 import kDrive.UI
 
 Item {
-    Text {
-        anchors.centerIn: parent
-        text: qsTrId("tabTitleStorage")
-        color: IKColors.textSecondary
-        font.pixelSize: IKFonts.bodySize
+    id: root
+
+    required property var controller
+
+    Component.onCompleted: controller.setViewActive(true)
+    Component.onDestruction: controller.setViewActive(false)
+
+    StorageUsageCard {
+        anchors.left: parent.left
+        anchors.leftMargin: IKSpacing.page
+        anchors.right: parent.right
+        anchors.rightMargin: IKSpacing.page
+        anchors.top: parent.top
+        anchors.topMargin: IKSpacing.s32
+        visible: root.controller.state !== StorageController.Unavailable
+        controller: root.controller
+        loading: root.controller.state === StorageController.Loading
+    }
+
+    StorageErrorState {
+        anchors.fill: parent
+        visible: root.controller.state === StorageController.Unavailable
+        controller: root.controller
     }
 }


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR relie l'interface QML de l'onglet Storage au `StorageController` existant (implémenté dans la branche de base `linux-v4/storage-scanner-and-controller`), en remplaçant le placeholder statique par une vue fonctionnelle avec état de chargement, barre d'utilisation segmentée et état d'erreur.

## Changements
- Ajout de `StorageUsageCard.qml` : carte affichant le nom du volume, l'utilisation totale, une barre segmentée (synchronisation / autres fichiers / espace libre) avec masque arrondi unique, ainsi qu'un état de chargement avec placeholders.
- Ajout de `StorageErrorState.qml` : état d'erreur avec illustration, titre et description localisés, et bouton "Réessayer" appelant `controller.retry()`.
- Renommage de `StoragePlaceholder.qml` en `storage/StorageView.qml`, désormais lié au `StorageController` : affiche `StorageUsageCard` ou `StorageErrorState` selon `controller.state`, et notifie le contrôleur de sa visibilité via `setViewActive(true/false)`.
- `MainWindowView.qml` : remplacement de l'instanciation directe du placeholder par un `Loader` paresseux, actif uniquement lorsque l'onglet Storage est sélectionné et la fenêtre visible, et ajout de la propriété requise `storageController`.
- Mise à jour de `CMakeLists.txt` pour référencer les fichiers QML ajoutés et renommés.
- Documentation (`AGENTS.md`) enrichie avec les conventions Linux v4 : orthographe suisse-allemande (`ss` au lieu de `ß`) pour les traductions allemandes, usage de `Qt::StringLiterals` (`u"..."_s`) au lieu de `QStringLiteral`, règles de mise en page et de masquage du graphe Storage, et description des composants `storagecontroller.*` / `storagescanner.*`.

## Détails techniques
- Le masquage du graphe de la barre de stockage utilise `MultiEffect` avec un `maskSource` rectangulaire arrondi unique plutôt qu'un arrondi par segment, car `Rectangle.clip` est rectangulaire dans Qt Quick et l'arrondi par segment casse lorsque le premier segment est nul ou infra-pixel.
- Les segments "synchronisation" et "autres fichiers" conservent une largeur minimale nominale de 1% pour rester visibles, tandis que l'espace libre peut atteindre une largeur réellement nulle.
- Le cycle de vie de la vue est piloté par `Component.onCompleted`/`Component.onDestruction`, qui appellent `controller.setViewActive()`, afin que le contrôleur ne démarre les scans locaux que lorsque l'onglet Storage est effectivement affiché.

## Tests
Aucun test automatisé ajouté ; les tests pour Storage restent hors périmètre de ce jalon, conformément aux directives Linux v4 déjà en vigueur pour Activities.

## Notes
Le backend (`StorageController`, `StorageScanner`) est déjà implémenté dans la branche de base `linux-v4/storage-scanner-and-controller`. Cette PR se limite au câblage de la vue QML sur ce contrôleur.

</details>

---

## Summary
This PR wires the Storage tab's QML view to the existing `StorageController` (implemented on the base branch `linux-v4/storage-scanner-and-controller`), replacing the static placeholder with a functional view that supports a loading state, a segmented usage bar, and an error state.

## Changes
- Added `StorageUsageCard.qml`: a card showing the volume name, total usage, a segmented bar (synced / other files / free space) with a single rounded mask, and a loading state with placeholders.
- Added `StorageErrorState.qml`: an error state with an illustration, localized title/description, and a "Retry" button that calls `controller.retry()`.
- Renamed `StoragePlaceholder.qml` to `storage/StorageView.qml`, now bound to `StorageController`: it renders either `StorageUsageCard` or `StorageErrorState` depending on `controller.state`, and reports its visibility to the controller via `setViewActive(true/false)`.
- `MainWindowView.qml`: replaced the direct placeholder instantiation with a lazy `Loader`, active only when the Storage tab is selected and the window is visible, and added the required `storageController` property.
- Updated `CMakeLists.txt` to reference the added and renamed QML files.
- Expanded `AGENTS.md` documentation with Linux v4 conventions: Swiss German orthography (`ss` instead of `ß`) for German translations, using `Qt::StringLiterals` (`u"..."_s`) instead of `QStringLiteral`, Storage graph layout/masking rules, and a description of the `storagecontroller.*` / `storagescanner.*` components.

## Technical Details
- The storage bar graph is masked with `MultiEffect` using a single rounded rectangular `maskSource` rather than rounding individual segments, since `Rectangle.clip` is rectangular in Qt Quick and per-segment rounding breaks when the leading segment is zero or subpixel-sized.
- The "sync" and "other files" segments keep a nominal 1% minimum width to stay visible, while free space can reach a true zero width.
- View lifecycle is driven by `Component.onCompleted`/`Component.onDestruction`, which call `controller.setViewActive()`, so the controller only starts local scans while the Storage tab is actually visible.

## Testing
No automated tests added; Storage tests remain out of scope for this milestone, consistent with the existing Linux v4 guidance already applied to Activities.

## Notes
The backend (`StorageController`, `StorageScanner`) is already implemented on the base branch `linux-v4/storage-scanner-and-controller`. This PR is scoped strictly to wiring the QML view to that controller.

## Screenshots

### StorageUsageCard
Screenshot of the storage view showing the `StorageUsageCard` component with a real sync.

<img width="2056" height="1552" alt="image" src="https://github.com/user-attachments/assets/1e16a3f7-3c2e-40b0-bdcd-c785dc8fb67a" />

### StorageErrorState
Screenshot showing the `StorageErrorState` component.

(You can test it in a real synchronisation by creating a directory you don't have permission to access and waiting for the synchronisation to finish, or by switching to another tab and then switching back to the Storage tab):

```bash
mkdir abc && chmod 700 abc && sudo chown root: abc
```

<img width="2056" height="1552" alt="image" src="https://github.com/user-attachments/assets/0345f722-a12f-46fc-89cd-7beca2415645" />

