### PR TITLE
feat: Integrate hash request v3 with upload session changes

### DIFF
--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -719,7 +719,7 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
-IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum) noexcept {
+IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum, size_t chunkSize /*= 0*/) noexcept {
     using enum IoError;
     checksum.clear();
 
@@ -731,16 +731,23 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum) n
 
 #if defined(KD_MACOS)
         bool isAlias = false;
-        IoError aliasError = Success;
-        if (!IoHelper::_checkIfAlias(path, isAlias, aliasError)) return aliasError;
+        if (auto aliasError = Success; !IoHelper::_checkIfAlias(path, isAlias, aliasError)) return aliasError;
         if (isAlias) return InvalidArgument;
 #endif
+
+        bool chunked = true;
+        if (chunkSize == 0) {
+            // Get file size to determine the chunk size
+            uint64_t fileSize = 0;
+            if (auto ioError = IoError::Unknown; !getFileSize(path, fileSize, ioError)) return ioError;
+            chunkSize = static_cast<size_t>(fileSize);
+            chunked = false;
+        }
 
         IoError openError = Success;
         std::ifstream ifs;
         if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
-        constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
         std::vector<char> buffer(chunkSize);
 
         XXH3_state_t *state = XXH3_createState();
@@ -769,7 +776,7 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum) n
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 
-        checksum = "xxh3:" + Utility::xxHashToStr(hash);
+        checksum = (chunked ? "N:xxh3:" : "xxh3:") + Utility::xxHashToStr(hash);
         return Success;
     } catch (const std::bad_alloc &) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -735,13 +735,10 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum, s
         if (isAlias) return InvalidArgument;
 #endif
 
-        bool chunked = true;
-        if (chunkSize == 0) {
-            // Get file size to determine the chunk size
-            uint64_t fileSize = 0;
-            if (auto ioError = IoError::Unknown; !getFileSize(path, fileSize, ioError)) return ioError;
-            chunkSize = static_cast<size_t>(fileSize);
-            chunked = false;
+        const bool chunked = chunkSize != 0;
+        if (!chunked) {
+            constexpr size_t defaultBufferSize = 8 * 1024 * 1024;
+            chunkSize = defaultBufferSize;
         }
 
         IoError openError = Success;
@@ -781,7 +778,7 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum, s
             return Unknown;
         }
 
-        XXH64_hash_t hash = XXH3_64bits_digest(state);
+        const XXH64_hash_t hash = XXH3_64bits_digest(state);
         (void) XXH3_freeState(state);
 
         checksum = (chunked ? "N:xxh3:" : "xxh3:") + Utility::xxHashToStr(hash);

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -762,7 +762,8 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum, s
 
         std::streamsize readBytes(0);
         while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
-            if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
+            const auto chunkHash = Utility::computeXxHash(buffer.data(), static_cast<size_t>(readBytes));
+            if (XXH3_64bits_update(state, chunkHash.data(), chunkHash.length()) == XXH_ERROR) {
                 XXH3_freeState(state);
                 return Unknown;
             }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -756,26 +756,33 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum, s
         }
 
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
-            XXH3_freeState(state);
+            (void) XXH3_freeState(state);
             return Unknown;
         }
 
         std::streamsize readBytes(0);
         while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
-            const auto chunkHash = Utility::computeXxHash(buffer.data(), static_cast<size_t>(readBytes));
-            if (XXH3_64bits_update(state, chunkHash.data(), chunkHash.length()) == XXH_ERROR) {
-                XXH3_freeState(state);
-                return Unknown;
+            if (chunked) {
+                const auto chunkHash = Utility::computeXxHash(buffer.data(), static_cast<size_t>(readBytes));
+                if (XXH3_64bits_update(state, chunkHash.data(), chunkHash.length()) == XXH_ERROR) {
+                    (void) XXH3_freeState(state);
+                    return Unknown;
+                }
+            } else {
+                if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
+                    (void) XXH3_freeState(state);
+                    return Unknown;
+                }
             }
         }
 
         if (ifs.bad()) {
-            XXH3_freeState(state);
+            (void) XXH3_freeState(state);
             return Unknown;
         }
 
         XXH64_hash_t hash = XXH3_64bits_digest(state);
-        XXH3_freeState(state);
+        (void) XXH3_freeState(state);
 
         checksum = (chunked ? "N:xxh3:" : "xxh3:") + Utility::xxHashToStr(hash);
         return Success;

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -138,11 +138,11 @@ struct IoHelper {
         //! Get the checksum of the file indicated by `path`.
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
-         \param ifs is an input file stream used to read the file contents.
          \param checksum is set with the checksum of the file indicated by `path`, or empty on error.
+         \param chunkSize is the size of the chunks to be used for computing the checksum.
          \return the IoError representing the success or failure of the operation.
          */
-        static IoError getFileChecksum(const SyncPath &path, std::string &checksum) noexcept;
+        static IoError getFileChecksum(const SyncPath &path, std::string &checksum, size_t chunkSize = 0) noexcept;
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -34,6 +34,7 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
     _nodeId(nodeId),
     _remoteSize(remoteSize) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
+    _apiVersion = 3;
 }
 
 ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
@@ -66,41 +67,21 @@ ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
 
 ExitInfo CheckHashMatchJob::runJob() noexcept {
     _hashMatch = false;
-    if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) {
+
+    int64_t localSize = 0;
+    if (const ExitInfo exitInfo = getFileSize(_filePath, localSize); !exitInfo) {
         LOGW_DEBUG(_logger, L"Failed to get local file size for " << Utility::formatSyncPath(_filePath)
                                                                   << L", skipping hash check: " << exitInfo);
         return exitInfo;
     }
 
-    if (_localSize != _remoteSize) {
-        LOGW_DEBUG(_logger, L"File size mismatch for " << Utility::formatSyncPath(_filePath) << L": local size = " << _localSize
+    if (localSize != _remoteSize) {
+        LOGW_DEBUG(_logger, L"File size mismatch for " << Utility::formatSyncPath(_filePath) << L": local size = " << localSize
                                                        << L", remote size = " << _remoteSize << L", skipping hash check");
         return ExitCode::Ok;
     }
 
-    const IoError checksumIoError = IoHelper::getFileChecksum(_filePath, _localHash);
-    if (checksumIoError == IoError::NoSuchFileOrDirectory) {
-        LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
-        return {ExitCode::SystemError, ExitCause::NotFound};
-    }
-
-    if (checksumIoError == IoError::AccessDenied) {
-        LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
-        return {ExitCode::SystemError, ExitCause::FileAccessError};
-    }
-
-    if (checksumIoError == IoError::InvalidArgument) {
-        LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
-        return ExitCode::Ok;
-    }
-
-    assert(checksumIoError == IoError::Success);
-    if (checksumIoError != IoError::Success) {
-        LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, checksumIoError));
-        return ExitCode::SystemError;
-    }
-
-    if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
+    if (const auto exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
         LOGW_DEBUG(_logger, L"Failed to get remote hash for " << Utility::formatSyncPath(_filePath) << L", skipping hash check: "
                                                               << exitInfo);
         return exitInfo;
@@ -117,6 +98,7 @@ std::string CheckHashMatchJob::getSpecificUrl() {
 }
 
 ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
+    // Extract remote checksum
     if (const auto exitInfo = AbstractTokenNetworkJob::handleResponse(is); !exitInfo) {
         return exitInfo;
     }
@@ -126,13 +108,33 @@ ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
     const auto dataObj = jsonRes()->getObject(dataKey);
     if (!dataObj) return {ExitCode::BackError, ExitCause::MissingReplyData};
 
-    if (!JsonParserUtility::extractValue(dataObj, hashKey, _remoteHash))
+    std::string remoteHash;
+    if (!JsonParserUtility::extractValue(dataObj, hashKey, remoteHash)) return {ExitCode::BackError, ExitCause::MissingReplyData};
+    size_t chunkSize = 0;
+    if (!JsonParserUtility::extractValue(dataObj, chunkSizeKey, chunkSize))
         return {ExitCode::BackError, ExitCause::MissingReplyData};
 
-    LOGW_INFO(_logger, L"Local hash:  " << CommonUtility::s2ws(_localHash) << L", remote hash: "
-                                        << CommonUtility::s2ws(_remoteHash) << L" for " << Utility::formatSyncPath(_filePath));
+    // Compute local checksum
+    std::string localHash;
+    if (const auto checksumIoError = IoHelper::getFileChecksum(_filePath, localHash, chunkSize);
+        checksumIoError == IoError::NoSuchFileOrDirectory) {
+        LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
+        return {ExitCode::SystemError, ExitCause::NotFound};
+    } else if (checksumIoError == IoError::AccessDenied) {
+        LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
+    } else if (checksumIoError == IoError::InvalidArgument) {
+        LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
+        return ExitCode::Ok;
+    } else if (checksumIoError != IoError::Success) {
+        LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, checksumIoError));
+        return ExitCode::SystemError;
+    }
 
-    if (_localHash != _remoteHash) return ExitCode::Ok;
+    LOGW_INFO(_logger, L"Local hash:  " << CommonUtility::s2ws(localHash) << L", remote hash: " << CommonUtility::s2ws(remoteHash)
+                                        << L" for " << Utility::formatSyncPath(_filePath));
+
+    if (localHash != remoteHash) return ExitCode::Ok;
     _hashMatch = true;
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -24,8 +24,7 @@ namespace KDC {
 
 class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filePath, const NodeId &nodeId,
-                          const int64_t remoteSize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filePath, const NodeId &nodeId, const int64_t remoteSize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
         [[nodiscard]] bool hashMatch() const { return _hashMatch; }
@@ -39,12 +38,8 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
         ExitInfo runJob() noexcept override;
 
         SyncPath _filePath;
-
         NodeId _nodeId;
-        std::string _remoteHash;
-        std::string _localHash;
 
-        int64_t _localSize = 0;
         int64_t _remoteSize = 0;
 
         bool _hashMatch = false;

--- a/src/libsyncengine/jobs/network/networkjobsparams.h
+++ b/src/libsyncengine/jobs/network/networkjobsparams.h
@@ -111,6 +111,7 @@ static const std::string isStaffKey = "is_staff";
 static const std::string updatedAtKey = "updated_at";
 static const std::string versionsKey = "versions";
 static const std::string hashKey = "hash";
+static const std::string chunkSizeKey = "chunk_size";
 
 static const std::string totalNbItemKey = "total";
 static const std::string pageKey = "page";

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1343,18 +1343,18 @@ class MockUploadJob : public UploadJob {
         bool _uploadPerformed = false;
 };
 
-void TestNetworkJobs::testUploadChecksumMismatch() {
+void TestNetworkJobs::testUploadChecksum() {
     // Upload a file, then modify its content and re-upload using the EDIT constructor.
     // The hash will differ, so the job must perform a real upload and return a valid node ID.
-    const LocalTemporaryDirectory localTmpDir("testUploadChecksumMismatch");
-    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadChecksumMismatch");
+    const LocalTemporaryDirectory localTmpDir("testUploadChecksum");
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadChecksum");
 
-    const SyncPath localFilePath = localTmpDir.path() / "test_checksum_mismatch.txt";
+    const SyncPath localFilePath = localTmpDir.path() / "test_checksum.txt";
     testhelpers::generateOrEditTestFile(localFilePath);
 
     const auto epochNow = std::chrono::system_clock::now().time_since_epoch();
     const SyncTime creationTime = std::chrono::duration_cast<std::chrono::seconds>(epochNow).count();
-    const SyncTime modificationTime = creationTime;
+    SyncTime modificationTime = creationTime;
 
     // Initial upload (CREATE)
     NodeId nodeId;
@@ -1371,80 +1371,55 @@ void TestNetworkJobs::testUploadChecksumMismatch() {
 
     // Modify the local file content so the hash no longer matches the remote
     testhelpers::generateOrEditTestFile(localFilePath);
-    const SyncTime newModificationTime = modificationTime + 10;
+    modificationTime += 10;
 
     // EDIT upload — checksum mismatch expected → must upload
     {
-        MockUploadJob editJob(nullptr, _driveDbId, localFilePath, nodeId, newModificationTime, uploadedSize);
+        MockUploadJob editJob(nullptr, _driveDbId, localFilePath, nodeId, modificationTime, uploadedSize);
         const ExitInfo exitInfo = editJob.runSynchronously();
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
         CPPUNIT_ASSERT_MESSAGE("Hash mismatch: a real upload should have occurred", editJob.uploadPerformed());
-        CPPUNIT_ASSERT_EQUAL(newModificationTime, editJob.modificationTime());
-    }
-}
-
-void TestNetworkJobs::testUploadChecksumMatch() {
-    // Upload a file, then re-upload the same content with a different modification time.
-    // The hash matches, so the job must skip the upload and only update the modification date.
-    const LocalTemporaryDirectory localTmpDir("testUploadChecksumMatch");
-    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadChecksumMatch");
-
-    const SyncPath localFilePath = localTmpDir.path() / "test_checksum_match.txt";
-    testhelpers::generateOrEditTestFile(localFilePath);
-
-    const auto epochNow = std::chrono::system_clock::now().time_since_epoch();
-    const SyncTime creationTime = std::chrono::duration_cast<std::chrono::seconds>(epochNow).count();
-    const SyncTime modificationTime = creationTime;
-
-    // Initial upload (CREATE)
-    NodeId nodeId;
-    int64_t uploadedSize = 0;
-    {
-        MockUploadJob createJob(nullptr, _driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(),
-                                creationTime, modificationTime);
-        const ExitInfo exitInfo = createJob.runSynchronously();
-        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
-        CPPUNIT_ASSERT_MESSAGE("CREATE upload must have been performed", createJob.uploadPerformed());
-        nodeId = createJob.nodeId();
-        uploadedSize = createJob.size();
+        CPPUNIT_ASSERT_EQUAL(modificationTime, editJob.modificationTime());
+        uploadedSize = editJob.size();
     }
 
     // EDIT upload — same file content
-    const SyncTime newModificationTime = modificationTime + 10;
+    modificationTime += 10;
     {
-        MockUploadJob editJob(nullptr, _driveDbId, localFilePath, nodeId, newModificationTime, uploadedSize);
+        MockUploadJob editJob(nullptr, _driveDbId, localFilePath, nodeId, modificationTime, uploadedSize);
         const ExitInfo exitInfo = editJob.runSynchronously();
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
         // No real upload: hash matched, only the modification date was updated
         CPPUNIT_ASSERT_MESSAGE("Hash match: upload must have been skipped", !editJob.uploadPerformed());
         // The modification time must reflect the server-confirmed value via PostFileModificationDateJob
-        CPPUNIT_ASSERT_EQUAL(newModificationTime, editJob.modificationTime());
+        CPPUNIT_ASSERT_EQUAL(modificationTime, editJob.modificationTime());
     }
 
     // Verify server-side modification time
     {
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
         CPPUNIT_ASSERT(verifyJob.runSynchronously());
-        CPPUNIT_ASSERT_EQUAL(newModificationTime, verifyJob.modificationTime());
+        CPPUNIT_ASSERT_EQUAL(modificationTime, verifyJob.modificationTime());
     }
 }
 
-void TestNetworkJobs::testUploadSessionChecksumMismatch() {
+void TestNetworkJobs::testUploadSessionChecksum() {
     // if (!testhelpers::isExtendedTest()) return;
 
     // Upload a file, then modify its content and re-upload using the EDIT constructor.
     // The hash will differ, so the job must perform a real upload and return a valid node ID.
-    const LocalTemporaryDirectory localTmpDir("testUploadSessionChecksumMismatch");
-    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionChecksumMismatch");
-    const SyncPath localFilePath = localTmpDir.path() / "test_checksum_mismatch.txt";
+    const LocalTemporaryDirectory localTmpDir("testUploadSessionChecksum");
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionChecksum");
+    const SyncPath localFilePath = localTmpDir.path() / "test_checksum.txt";
     testhelpers::generateTestFile(localFilePath, 101 * 1024 * 1024);
 
     const auto epochNow = std::chrono::system_clock::now().time_since_epoch();
     const SyncTime creationTime = std::chrono::duration_cast<std::chrono::seconds>(epochNow).count();
-    const SyncTime modificationTime = creationTime;
+    SyncTime modificationTime = creationTime;
 
     // Initial upload (CREATE)
     NodeId nodeId;
+    int64_t uploadedSize = 0;
     {
         DriveUploadSession createJob(nullptr, _driveDbId, nullptr, localFilePath, localFilePath.filename().native(),
                                      remoteTmpDir.id(), creationTime, modificationTime, 2);
@@ -1452,65 +1427,41 @@ void TestNetworkJobs::testUploadSessionChecksumMismatch() {
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
         nodeId = createJob.nodeId();
         CPPUNIT_ASSERT(!nodeId.empty());
+        uploadedSize = createJob.size();
     }
 
     // Modify the local file content so the hash no longer matches the remote
     testhelpers::generateTestFile(localFilePath, 101 * 1024 * 1024);
-    const SyncTime newModificationTime = modificationTime + 10;
+    modificationTime += 10;
 
     // EDIT upload — checksum mismatch expected → must upload
     {
-        DriveUploadSession editJob(nullptr, _driveDbId, nullptr, localFilePath, nodeId, newModificationTime, 2);
+        DriveUploadSession editJob(nullptr, _driveDbId, nullptr, localFilePath, nodeId, modificationTime, 2, uploadedSize);
         const ExitInfo exitInfo = editJob.runSynchronously();
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
         // A real upload must have occurred: the returned node ID must be non-empty
         CPPUNIT_ASSERT(!editJob.nodeId().empty());
-        CPPUNIT_ASSERT_EQUAL(newModificationTime, editJob.modificationTime());
-    }
-}
-
-void TestNetworkJobs::testUploadSessionChecksumMatch() {
-    // if (!testhelpers::isExtendedTest()) return;
-
-    // Upload a file, then re-upload the same content with a different modification time.
-    // The hash matches, so the job must skip the upload and only update the modification date.
-    const LocalTemporaryDirectory localTmpDir("testUploadSessionChecksumMatch");
-    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionChecksumMatch");
-    const SyncPath localFilePath = localTmpDir.path() / "test_checksum_match.txt";
-    testhelpers::generateTestFile(localFilePath, 101 * 1024 * 1024);
-
-    const auto epochNow = std::chrono::system_clock::now().time_since_epoch();
-    const SyncTime creationTime = std::chrono::duration_cast<std::chrono::seconds>(epochNow).count();
-    const SyncTime modificationTime = creationTime;
-
-    // Initial upload (CREATE)
-    NodeId nodeId;
-    {
-        DriveUploadSession createJob(nullptr, _driveDbId, nullptr, localFilePath, localFilePath.filename().native(),
-                                     remoteTmpDir.id(), creationTime, modificationTime, 2);
-        const ExitInfo exitInfo = createJob.runSynchronously();
-        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
-        nodeId = createJob.nodeId();
-        CPPUNIT_ASSERT(!nodeId.empty());
+        CPPUNIT_ASSERT_EQUAL(modificationTime, editJob.modificationTime());
+        uploadedSize = editJob.size();
     }
 
     // EDIT upload — same file content, only the modification time differs → must skip upload
-    const SyncTime newModificationTime = modificationTime + 10;
+    modificationTime += 10;
     {
-        DriveUploadSession editJob(nullptr, _driveDbId, nullptr, localFilePath, nodeId, newModificationTime, 2);
+        DriveUploadSession editJob(nullptr, _driveDbId, nullptr, localFilePath, nodeId, modificationTime, 2, uploadedSize);
         const ExitInfo exitInfo = editJob.runSynchronously();
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
         // No real upload: nodeId returned by the job should be non-empty (set from setOutputParameters)
         CPPUNIT_ASSERT(!editJob.nodeId().empty());
         // The modification time must reflect the server-confirmed value via PostFileModificationDateJob
-        CPPUNIT_ASSERT_EQUAL(newModificationTime, editJob.modificationTime());
+        CPPUNIT_ASSERT_EQUAL(modificationTime, editJob.modificationTime());
     }
 
     // Verify server-side modification time
     {
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
         CPPUNIT_ASSERT(verifyJob.runSynchronously());
-        CPPUNIT_ASSERT_EQUAL(newModificationTime, verifyJob.modificationTime());
+        CPPUNIT_ASSERT_EQUAL(modificationTime, verifyJob.modificationTime());
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1404,7 +1404,7 @@ void TestNetworkJobs::testUploadChecksum() {
 }
 
 void TestNetworkJobs::testUploadSessionChecksum() {
-    // if (!testhelpers::isExtendedTest()) return;
+    if (!testhelpers::isExtendedTest()) return;
 
     // Upload a file, then modify its content and re-upload using the EDIT constructor.
     // The hash will differ, so the job must perform a real upload and return a valid node ID.

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -55,10 +55,8 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testRename);
         CPPUNIT_TEST(testUpload);
         CPPUNIT_TEST(testUploadAborted);
-        CPPUNIT_TEST(testUploadChecksumMismatch);
-        CPPUNIT_TEST(testUploadChecksumMatch);
-        CPPUNIT_TEST(testUploadSessionChecksumMismatch);
-        CPPUNIT_TEST(testUploadSessionChecksumMatch);
+        CPPUNIT_TEST(testUploadChecksum);
+        CPPUNIT_TEST(testUploadSessionChecksum);
         CPPUNIT_TEST(testDriveUploadSessionConstructorException);
         CPPUNIT_TEST(testDriveUploadSessionSynchronous);
         CPPUNIT_TEST(testDriveUploadSessionAsynchronous);
@@ -106,10 +104,8 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testDuplicateRenameMove();
         void testRename();
         void testUpload();
-        void testUploadChecksumMismatch();
-        void testUploadChecksumMatch();
-        void testUploadSessionChecksumMismatch();
-        void testUploadSessionChecksumMatch();
+        void testUploadChecksum();
+        void testUploadSessionChecksum();
         void testUploadAborted();
         void testDriveUploadSessionConstructorException();
         void testDriveUploadSessionSynchronous();


### PR DESCRIPTION
## Description

This PR integrates the hash request v3 implementation into the upload session management workflow.

### Changes
- **IOHelper refactoring**: Optimized helper methods to support hash matching operations
- **Hash match job updates**: Refined the `CheckHashMatchJob` class to better align with v3 API requirements and upload session propagation
- **Network parameters**: Added new parameters to support enhanced hash checking capabilities

### Related Work
This change builds upon the hash-match-to-upload-sessions feature and ensures proper integration with the propagate-missing-changes-to-upload-session branch.

### Testing
Please verify:
- Hash matching operations work correctly with the updated v3 API
- Upload sessions properly propagate changes to the sync engine
- No regression in existing sync workflows

### Merge Strategy
This PR should be reviewed and tested before merging into feat/propagate-missing-changes-to-upload-session.
