### PR TITLE
fix: Blacklist propagator issues

### DIFF
--- a/src/libsyncengine/jobs/syncjob.h
+++ b/src/libsyncengine/jobs/syncjob.h
@@ -40,7 +40,7 @@ class SyncJob : public AbstractJob {
         void setProgressExpectedFinalValue(const int64_t newExpectedFinishProgress) {
             _expectedFinishProgress = newExpectedFinishProgress;
         }
-        void setProgressPercentCallback(const std::function<void(UniqueId, int)> &newCallback) {
+        void setProgressPercentCallback(const std::function<void(UniqueId, int16_t)> &newCallback) {
             _progressPercentCallback = newCallback;
         }
 

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -120,7 +120,7 @@ bool ProgressInfo::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
     return true;
 }
 
-bool ProgressInfo::setProgress(const SyncPath &path, int progress) {
+bool ProgressInfo::setProgress(const SyncPath &path, int16_t progress) {
     const std::scoped_lock lock(_mutex);
     const auto it = GetItemIterator(path);
     if (it == _currentItems.end() || it->second.empty()) {

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -43,7 +43,7 @@ class ProgressInfo {
         [[nodiscard]] bool update() const { return _update; }
         void updateEstimates();
         [[nodiscard]] bool initProgress(const SyncFileItem &item);
-        [[nodiscard]] bool setProgress(const SyncPath &path, int progress);
+        [[nodiscard]] bool setProgress(const SyncPath &path, int16_t progress);
         [[nodiscard]] bool setProgressComplete(const SyncPath &path, SyncFileStatus status);
         [[nodiscard]] bool setSyncFileItemRemoteId(const SyncPath &path, const NodeId &remoteId);
         [[nodiscard]] bool getSyncFileItem(const SyncPath &path, SyncFileItem &item);

--- a/src/libsyncengine/progress/syncfileitem.h
+++ b/src/libsyncengine/progress/syncfileitem.h
@@ -62,7 +62,7 @@ class SyncFileItem {
         inline int64_t size() const { return _size; }
         inline void setSize(int64_t newSize) { _size = newSize; }
         inline int progress() const { return _progress; }
-        inline void setProgress(const int newProgress) { _progress = newProgress; }
+        inline void setProgress(const int16_t newProgress) { _progress = newProgress; }
         inline UniqueId operationId() const { return _operationId; }
         inline void setOperationId(const UniqueId newOperationId) { _operationId = newOperationId; }
         inline SyncTime modTime() const { return _modTime; }
@@ -101,7 +101,7 @@ class SyncFileItem {
         CancelType _cancelType{CancelType::None};
         std::string _error;
         int64_t _size{0};
-        int _progress{0}; // %
+        int16_t _progress{0}; // %
         UniqueId _operationId{0};
         SyncTime _modTime{0};
         SyncTime _creationTime{0};

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -68,7 +68,7 @@ void ExecutorWorker::setJobCallbacks(const std::shared_ptr<SyncJob> &job) {
     // The callbacks must not keep either the job or its executor alive. Jobs can finish after a SyncPal stop has released its
     // workers and progress state.
     const std::weak_ptr<SyncJob> weakJob = job;
-    const auto progressPercentCallback = [weakExecutor, weakJob]([[maybe_unused]] UniqueId, int progress /* % */) {
+    const auto progressPercentCallback = [weakExecutor, weakJob]([[maybe_unused]] UniqueId, int16_t progress /* % */) {
         const auto executor = weakExecutor.lock();
         const auto currentJob = weakJob.lock();
         if (!executor || !currentJob) {
@@ -80,7 +80,7 @@ void ExecutorWorker::setJobCallbacks(const std::shared_ptr<SyncJob> &job) {
     job->setProgressPercentCallback(progressPercentCallback);
 }
 
-void ExecutorWorker::updateJobProgress(const std::shared_ptr<SyncJob> &job, const int progress) {
+void ExecutorWorker::updateJobProgress(const std::shared_ptr<SyncJob> &job, const int16_t progress) {
     if (!_syncPal->setProgress(job->affectedFilePath(), progress)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: path=" << Utility::formatSyncPath(job->affectedFilePath())
                                                                            << L", progress=" << progress << L"%" << L", jobId="

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -74,7 +74,7 @@ class ExecutorWorker : public OperationProcessor, public std::enable_shared_from
 
     private:
         void setJobCallbacks(const std::shared_ptr<SyncJob> &job);
-        void updateJobProgress(const std::shared_ptr<SyncJob> &job, int progress);
+        void updateJobProgress(const std::shared_ptr<SyncJob> &job, const int16_t progress);
         void initProgressManager();
         void initSyncFileItem(SyncOpPtr syncOp, SyncFileItem &syncItem);
 

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1507,24 +1507,22 @@ ExitInfo SyncPal::handleAccessDeniedItem(const SyncPath &relativeLocalPath, bool
         return ExitInfo(ExitCode::SystemError, Utility::exitCauseFromInaccessibleSyncDirectory(localPath()));
     }
 
-    LOG_IF_FAIL(_localFSObserverWorker)
-    LOG_IF_FAIL(_remoteFSObserverWorker)
-    if (!_localFSObserverWorker || !_remoteFSObserverWorker) return ExitCode::LogicError;
-
     NodeId localNodeId;
-    if (const auto exitInfo = liveSnapshot(ReplicaSide::Local).getItemId(relativeLocalPath, localNodeId);
-        !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
-        return exitInfo;
-    }
     NodeId remoteNodeId;
-    if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(relativeLocalPath, remoteNodeId);
-        !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
-        return exitInfo;
+    if (_localFSObserverWorker && _remoteFSObserverWorker) {
+        if (const auto exitInfo = liveSnapshot(ReplicaSide::Local).getItemId(relativeLocalPath, localNodeId);
+            !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
+            return exitInfo;
+        }
+        if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(relativeLocalPath, remoteNodeId);
+            !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
+            return exitInfo;
+        }
     }
 
     // File type cannot be fetched for an access denied item, using File as default.
-    Error error(syncDbId(), localNodeId, remoteNodeId, NodeType::File, relativeLocalPath, ConflictType::None,
-                InconsistencyType::None, CancelType::None, "", ExitCode::SystemError, cause);
+    const Error error(syncDbId(), localNodeId, remoteNodeId, NodeType::File, relativeLocalPath, ConflictType::None,
+                      InconsistencyType::None, CancelType::None, "", ExitCode::SystemError, cause);
     addError(error);
 
     if (localNodeId.empty()) {
@@ -1555,7 +1553,12 @@ ExitInfo SyncPal::handleAccessDeniedItem(const SyncPath &relativeLocalPath, bool
         return {ExitCode::DbError, ExitCause::Unknown};
     }
 
-    // Blacklist the item
+    if (!_tmpBlacklistManager) {
+        // Can happen if the sync is restarting
+        return ExitCode::Ok;
+    }
+
+    // Tmp blacklist the item
     if (!localNodeId.empty()) {
         _tmpBlacklistManager->blacklistItem(localNodeId, relativeLocalPath, ReplicaSide::Local);
     }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -601,7 +601,7 @@ bool SyncPal::initProgress(const SyncFileItem &item) {
     return currentProgressInfo && currentProgressInfo->initProgress(item);
 }
 
-bool SyncPal::setProgress(const SyncPath &relativePath, int progress) {
+bool SyncPal::setProgress(const SyncPath &relativePath, int16_t progress) {
     const auto currentProgressInfo = progressInfo();
     if (!currentProgressInfo) {
         return false;

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -422,7 +422,6 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::shared_ptr<UpdateTree> _remoteUpdateTree{nullptr};
         std::shared_ptr<ConflictQueue> _conflictQueue{nullptr};
         std::shared_ptr<SyncOperationList> _syncOps{nullptr};
-        mutable std::mutex _progressInfoMutex;
         std::shared_ptr<ProgressInfo> _progressInfo{nullptr};
 
         // Workers
@@ -463,7 +462,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         void stopEstimateUpdates();
         void updateEstimates();
         [[nodiscard]] bool initProgress(const SyncFileItem &item);
-        [[nodiscard]] bool setProgress(const SyncPath &relativePath, int progress);
+        [[nodiscard]] bool setProgress(const SyncPath &relativePath, int16_t progress);
         [[nodiscard]] bool setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status,
                                                const NodeId &newRemoteNodeId = {});
 
@@ -482,6 +481,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::shared_ptr<CacheDirectory> _cacheDirectory;
 
         TooManyDeletesUserChoice _manyDeleteOpsUserChoice{TooManyDeletesUserChoice::None};
+
+        mutable std::mutex _progressInfoMutex;
 
         // TODO : Refactor to not use friend classes (should be reserved for test purpose).
         friend class SyncPalWorker;

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -175,7 +175,7 @@ void SyncPalWorker::checkForMassDeletions() const {
     }
 }
 
-ExitInfo SyncPalWorker::ensureBlackListIsPropagated(int trial) {
+ExitInfo SyncPalWorker::ensureBlackListIsPropagated(int16_t trial) {
     LOG_DEBUG(_logger, "Ensure Blacklist is propagated (trial " << trial + 1 << ")");
 
     if (trial) {
@@ -216,7 +216,8 @@ ExitInfo SyncPalWorker::ensureBlackListIsPropagated(int trial) {
         return exitInfo;
     }
 
-    std::erase_if(blacklistedNodes, [&tmpBlacklistedNodes](const auto &value) { return tmpBlacklistedNodes.contains(value); });
+    (void) std::erase_if(blacklistedNodes,
+                         [&tmpBlacklistedNodes](const auto &value) { return tmpBlacklistedNodes.contains(value); });
 
     // Check if any of the blacklisted nodes are still in the db.
     std::function<ExitInfo(const NodeSet &, bool &)> areBlacklistedNodesStillInDb = [this](const NodeSet &nodes, bool &found) {

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -175,7 +175,29 @@ void SyncPalWorker::checkForMassDeletions() const {
     }
 }
 
-ExitInfo SyncPalWorker::ensureBlackListIsPropagated() {
+ExitInfo SyncPalWorker::ensureBlackListIsPropagated(int trial) {
+    LOG_DEBUG(_logger, "Ensure Blacklist is propagated (trial " << trial + 1 << ")");
+
+    if (trial) {
+        LOG_DEBUG(_logger, "Restarting blacklist propagator");
+        UserActionScopedLock lock;
+        const std::chrono::milliseconds timeout(5000);
+        if (!lock.tryLock(_syncPal, timeout)) {
+            LOG_SYNCPAL_WARN(Log::instance()->getLogger(),
+                             "Could not acquire user action lock for propagateSyncIdSetChange. Another user action is "
+                             "running, aborting.");
+            return {ExitCode::DataError, ExitCause::BlackListPropagationError};
+        }
+
+        _isPaused = true;
+        if (ExitInfo exitInfo = _syncPal->propagateSyncIdSetChange(false); !exitInfo) {
+            LOG_SYNCPAL_WARN(_logger, "Error propagating blacklist changes");
+            _isPaused = false;
+            return exitInfo;
+        }
+        _isPaused = false;
+    }
+
     // Check if any of the Blacklisted directory still in the db, if yes, restart the blacklist propagator.
     // It might happen if it as previously been stopped or encountered a locked directory / file.
     NodeSet blacklistedNodes;
@@ -185,6 +207,18 @@ ExitInfo SyncPalWorker::ensureBlackListIsPropagated() {
         return exitInfo;
     }
 
+    // Remove temporary blacklisted nodes from the list of blacklisted nodes.
+    NodeSet tmpBlacklistedNodes;
+    if (ExitInfo exitInfo =
+                SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::TmpRemoteBlacklist, tmpBlacklistedNodes);
+        !exitInfo) {
+        LOG_SYNCPAL_WARN(_logger, "Error in SyncNodeCache::syncNodes");
+        return exitInfo;
+    }
+
+    std::erase_if(blacklistedNodes, [&tmpBlacklistedNodes](const auto &value) { return tmpBlacklistedNodes.contains(value); });
+
+    // Check if any of the blacklisted nodes are still in the db.
     std::function<ExitInfo(const NodeSet &, bool &)> areBlacklistedNodesStillInDb = [this](const NodeSet &nodes, bool &found) {
         found = false;
         for (const auto &nodeId: nodes) {
@@ -205,37 +239,12 @@ ExitInfo SyncPalWorker::ensureBlackListIsPropagated() {
         return exitInfo;
     }
 
-    if (!found) return ExitCode::Ok;
-
-    LOG_WARN(_logger, "Blacklisted nodes still exist in SyncDb, restarting blacklist propagator");
-
-    {
-        UserActionScopedLock lock;
-        const std::chrono::milliseconds timeout(5000);
-        if (!lock.tryLock(_syncPal, timeout)) {
-            LOG_SYNCPAL_WARN(Log::instance()->getLogger(),
-                             "Could not acquire user action lock for propagateSyncIdSetChange. Another user action is "
-                             "running, aborting.");
+    if (found) {
+        LOG_SYNCPAL_WARN(_logger, "Blacklisted nodes still exist in SyncDb");
+        if (trial >= 1) {
             return {ExitCode::DataError, ExitCause::BlackListPropagationError};
         }
-
-        _isPaused = true;
-        if (ExitInfo exitInfo = _syncPal->propagateSyncIdSetChange(false); !exitInfo) {
-            LOG_SYNCPAL_WARN(_logger, "Error propagating blacklist changes");
-            _isPaused = false;
-            return exitInfo;
-        }
-        _isPaused = false;
-    }
-
-    if (ExitInfo exitInfo = areBlacklistedNodesStillInDb(blacklistedNodes, found); !exitInfo) {
-        LOG_SYNCPAL_WARN(_logger, "Error while checking if blacklisted nodes still exist in SyncDb");
-        return exitInfo;
-    }
-
-    if (found) {
-        LOG_SYNCPAL_WARN(_logger, "Blacklisted nodes still exist after retry, giving up");
-        return {ExitCode::DataError, ExitCause::BlackListPropagationError};
+        return ensureBlackListIsPropagated(trial + 1);
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -83,7 +83,7 @@ class SyncPalWorker : public ISyncWorker {
          */
         bool isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, std::optional<NodeId> &outLocalNodeId);
 
-        ExitInfo ensureBlackListIsPropagated(int trial = 0);
+        ExitInfo ensureBlackListIsPropagated(int16_t trial = 0);
 
         void ensureMinimumPermission();
 

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -83,7 +83,7 @@ class SyncPalWorker : public ISyncWorker {
          */
         bool isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, std::optional<NodeId> &outLocalNodeId);
 
-        ExitInfo ensureBlackListIsPropagated();
+        ExitInfo ensureBlackListIsPropagated(int trial = 0);
 
         void ensureMinimumPermission();
 

--- a/src/libsyncengine/update_detection/blacklist_changes_propagator/blacklistpropagator.cpp
+++ b/src/libsyncengine/update_detection/blacklist_changes_propagator/blacklistpropagator.cpp
@@ -238,12 +238,20 @@ ExitInfo BlacklistPropagator::removeItem(const NodeId &localNodeId, const NodeId
         job.setBypassCheck(true);
         job.runSynchronously();
         if (!job.exitInfo()) {
-            LOGW_SYNCPAL_WARN(Log::instance()->getLogger(),
-                              L"Failed to remove item with " << Utility::formatSyncPath(absoluteLocalPath) << L" ("
-                                                             << CommonUtility::s2ws(localNodeId)
-                                                             << L") removed from local replica. It will not be blacklisted.");
+            LOGW_SYNCPAL_WARN(Log::instance()->getLogger(), L"Failed to remove item with "
+                                                                    << Utility::formatExitInfo(absoluteLocalPath, job.exitInfo())
+                                                                    << L" (" << CommonUtility::s2ws(localNodeId)
+                                                                    << L"), it will be temporarily blacklisted.");
             removeFromDb = false; // Do not remove from DB so that the item will be processed next sync and we will retry to
                                   // remove it from filesystem (we can have transient errors like file locks)
+
+            if (job.exitInfo() == ExitInfo{ExitCode::SystemError, ExitCause::FileAccessError}) {
+                if (ExitInfo exitInfo = _syncPal->handleAccessDeniedItem(localPath, false); !exitInfo) {
+                    LOGW_SYNCPAL_WARN(Log::instance()->getLogger(), L"Error in SyncPal::handleAccessDeniedItem: "
+                                                                            << Utility::formatExitInfo(localPath, exitInfo));
+                    return exitInfo;
+                }
+            }
         } else {
             LOGW_SYNCPAL_DEBUG(Log::instance()->getLogger(), L"Item with " << Utility::formatSyncPath(absoluteLocalPath) << L" ("
                                                                            << CommonUtility::s2ws(localNodeId)
@@ -258,8 +266,8 @@ ExitInfo BlacklistPropagator::removeItem(const NodeId &localNodeId, const NodeId
             return ExitCode::DbError;
         }
         if (!found) {
-            LOG_SYNCPAL_WARN(Log::instance()->getLogger(), "Node not found in node table for dbId=" << dbId);
-            return ExitCode::DataError;
+            // The item is not synchronized
+            LOG_SYNCPAL_DEBUG(Log::instance()->getLogger(), "Node not found in node table for dbId=" << dbId);
         }
     }
 

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -267,6 +267,9 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         // Exits if the item is excluded.
         if (checkTemplate && ExclusionTemplateCache::instance()->isExcluded(dbPath)) return ExitCode::Ok;
 
+        // Exits if the item is temporary blacklisted
+        if (_syncPal->isTmpBlacklisted(dbPath, side)) return ExitCode::Ok;
+
         // Delete operation
         const auto fsOp = std::make_shared<FSOperation>(OperationType::Delete, nodeId, dbNode.type(),
                                                         dbNode.created().has_value() ? dbNode.created().value() : 0,

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -267,7 +267,7 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         // Exits if the item is excluded.
         if (checkTemplate && ExclusionTemplateCache::instance()->isExcluded(dbPath)) return ExitCode::Ok;
 
-        // Exits if the item is temporary blacklisted
+        // Exits if the item is temporarily blacklisted.
         if (_syncPal->isTmpBlacklisted(dbPath, side)) return ExitCode::Ok;
 
         // Delete operation

--- a/test/libsyncengine/syncpal/testsyncpalworker.cpp
+++ b/test/libsyncengine/syncpal/testsyncpalworker.cpp
@@ -462,22 +462,6 @@ void TestSyncPalWorker::testHandleBackError() {
     CPPUNIT_ASSERT_EQUAL(backoffVariable::baseDelay, syncPalWorker->pauseDuration());
 }
 
-void TestSyncPalWorker::testEnsureBlackListIsPropagatedIgnoresMissingNode() {
-    _syncPal = std::make_shared<MockSyncPal>(std::make_shared<VfsOff>(VfsSetupParams(Log::instance()->getLogger())), _sync.dbId(),
-                                             KDRIVE_VERSION_STRING);
-    const auto mockSyncPal = std::dynamic_pointer_cast<MockSyncPal>(_syncPal);
-    CPPUNIT_ASSERT(mockSyncPal);
-
-    auto syncPalWorker = std::make_shared<MockSyncPalWorker>(mockSyncPal, "Mock Main", "M_MAIN", std::chrono::seconds(0));
-    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, SyncNodeCache::instance()->initCache(mockSyncPal->syncDbId(), mockSyncPal->syncDb()));
-
-    NodeSet blacklistedNodes = {"missing-remote-node-id"};
-    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok,
-                         SyncNodeCache::instance()->update(mockSyncPal->syncDbId(), SyncNodeType::BlackList, blacklistedNodes));
-
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), syncPalWorker->ensureBlackListIsPropagated());
-}
-
 void TestSyncPalWorker::testEnsureBlackListIsPropagated() {
     _syncPal = std::make_shared<MockSyncPal>(std::make_shared<VfsOff>(VfsSetupParams(Log::instance()->getLogger())), _sync.dbId(),
                                              KDRIVE_VERSION_STRING);
@@ -509,6 +493,58 @@ void TestSyncPalWorker::testEnsureBlackListIsPropagated() {
 
     CPPUNIT_ASSERT(mockSyncPal->syncDb()->node(dbNodeId, dbNode, found));
     CPPUNIT_ASSERT(!found);
+}
+
+void TestSyncPalWorker::testEnsureBlackListIsPropagatedIgnoresMissingNode() {
+    _syncPal = std::make_shared<MockSyncPal>(std::make_shared<VfsOff>(VfsSetupParams(Log::instance()->getLogger())), _sync.dbId(),
+                                             KDRIVE_VERSION_STRING);
+    const auto mockSyncPal = std::dynamic_pointer_cast<MockSyncPal>(_syncPal);
+    CPPUNIT_ASSERT(mockSyncPal);
+
+    auto syncPalWorker = std::make_shared<MockSyncPalWorker>(mockSyncPal, "Mock Main", "M_MAIN", std::chrono::seconds(0));
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, SyncNodeCache::instance()->initCache(mockSyncPal->syncDbId(), mockSyncPal->syncDb()));
+
+    NodeSet blacklistedNodes = {"missing-remote-node-id"};
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok,
+                         SyncNodeCache::instance()->update(mockSyncPal->syncDbId(), SyncNodeType::BlackList, blacklistedNodes));
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), syncPalWorker->ensureBlackListIsPropagated());
+}
+
+void TestSyncPalWorker::testEnsureBlackListIsPropagatedIgnoreTmpBlacklistedNode() {
+    _syncPal = std::make_shared<MockSyncPal>(std::make_shared<VfsOff>(VfsSetupParams(Log::instance()->getLogger())), _sync.dbId(),
+                                             KDRIVE_VERSION_STRING);
+    const auto mockSyncPal = std::dynamic_pointer_cast<MockSyncPal>(_syncPal);
+    CPPUNIT_ASSERT(mockSyncPal);
+
+    auto syncPalWorker = std::make_shared<MockSyncPalWorker>(mockSyncPal, "Mock Main", "M_MAIN", std::chrono::seconds(0));
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, SyncNodeCache::instance()->initCache(mockSyncPal->syncDbId(), mockSyncPal->syncDb()));
+
+    const NodeId blacklistedNodeId = "existing-remote-node-id";
+    const DbNode node(0, mockSyncPal->syncDb()->rootNode().nodeId(), Str("A"), Str("A"), "existing-local-node-id",
+                      blacklistedNodeId, testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultTime,
+                      NodeType::Directory, 0, std::nullopt);
+    DbNodeId dbNodeId = 0;
+    bool constraintError = false;
+    CPPUNIT_ASSERT(mockSyncPal->syncDb()->insertNode(node, dbNodeId, constraintError));
+    CPPUNIT_ASSERT(!constraintError);
+
+    NodeSet blacklistedNodes = {blacklistedNodeId};
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok,
+                         SyncNodeCache::instance()->update(mockSyncPal->syncDbId(), SyncNodeType::BlackList, blacklistedNodes));
+
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, SyncNodeCache::instance()->update(mockSyncPal->syncDbId(),
+                                                                         SyncNodeType::TmpRemoteBlacklist, blacklistedNodes));
+
+    bool found = false;
+    DbNode dbNode;
+    CPPUNIT_ASSERT(mockSyncPal->syncDb()->node(dbNodeId, dbNode, found));
+    CPPUNIT_ASSERT(found);
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), syncPalWorker->ensureBlackListIsPropagated());
+
+    CPPUNIT_ASSERT(mockSyncPal->syncDb()->node(dbNodeId, dbNode, found));
+    CPPUNIT_ASSERT(found);
 }
 
 } // namespace KDC

--- a/test/libsyncengine/syncpal/testsyncpalworker.h
+++ b/test/libsyncengine/syncpal/testsyncpalworker.h
@@ -49,8 +49,9 @@ class TestSyncPalWorker : public CppUnit::TestFixture {
         CPPUNIT_TEST(testInternalPause2);
         CPPUNIT_TEST(testInternalPause3);
         CPPUNIT_TEST(testHandleBackError);
-        CPPUNIT_TEST(testEnsureBlackListIsPropagatedIgnoresMissingNode);
         CPPUNIT_TEST(testEnsureBlackListIsPropagated);
+        CPPUNIT_TEST(testEnsureBlackListIsPropagatedIgnoresMissingNode);
+        CPPUNIT_TEST(testEnsureBlackListIsPropagatedIgnoreTmpBlacklistedNode);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -88,8 +89,9 @@ class TestSyncPalWorker : public CppUnit::TestFixture {
          * maxDelay), and that the counter resets when the sync reaches the Idle step.
          */
         void testHandleBackError();
-        void testEnsureBlackListIsPropagatedIgnoresMissingNode();
         void testEnsureBlackListIsPropagated();
+        void testEnsureBlackListIsPropagatedIgnoresMissingNode();
+        void testEnsureBlackListIsPropagatedIgnoreTmpBlacklistedNode();
 
         void testStopDuringInternalPause();
         void testDestroyDuringInternalPause();


### PR DESCRIPTION
If the BlacklistPropagator is unable to delete a folder due to an access issue, it is temporarily blacklisted instead of exiting with an error.