### PR TITLE
fix(sync): prevent use-after-free from late job callbacks on stop

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -59,6 +59,35 @@ namespace KDC {
 ExecutorWorker::ExecutorWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName) :
     OperationProcessor(syncPal, name, shortName, false) {}
 
+void ExecutorWorker::setJobCallbacks(const std::shared_ptr<SyncJob> &job) {
+    const std::weak_ptr<ExecutorWorker> weakExecutor = weak_from_this();
+    job->setAdditionalCallback([weakExecutor](const UniqueId jobId) {
+        if (const auto executor = weakExecutor.lock()) executor->executorCallback(jobId);
+    });
+
+    // The callbacks must not keep either the job or its executor alive. Jobs can finish after a SyncPal stop has released its
+    // workers and progress state.
+    const std::weak_ptr<SyncJob> weakJob = job;
+    const auto progressPercentCallback = [weakExecutor, weakJob]([[maybe_unused]] UniqueId, int progress /* % */) {
+        const auto executor = weakExecutor.lock();
+        const auto currentJob = weakJob.lock();
+        if (!executor || !currentJob) {
+            return;
+        }
+
+        executor->updateJobProgress(currentJob, progress);
+    };
+    job->setProgressPercentCallback(progressPercentCallback);
+}
+
+void ExecutorWorker::updateJobProgress(const std::shared_ptr<SyncJob> &job, const int progress) {
+    if (!_syncPal->setProgress(job->affectedFilePath(), progress)) {
+        LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: path=" << Utility::formatSyncPath(job->affectedFilePath())
+                                                                           << L", progress=" << progress << L"%" << L", jobId="
+                                                                           << job->jobId());
+    }
+}
+
 void ExecutorWorker::executorCallback(const UniqueId jobId) {
     _terminatedJobs.push(jobId);
 }
@@ -162,28 +191,7 @@ void ExecutorWorker::execute() {
         }
 
         if (job) {
-            job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
-
-            // Use a weak_ptr to avoid a reference cycle:
-            // The job owns the progress callback, and capturing a shared_ptr<SyncJob> inside
-            // the callback would create a cycle (job → callback → job).
-            // This would prevent the job from being destroyed after completion and removal
-            // from the job map, resulting in a memory leak.
-            std::weak_ptr<SyncJob> weakJobPtr = job;
-            const auto progressPercentCallback = [weakJobPtr, this]([[maybe_unused]] UniqueId, int progress /* % */) {
-                auto job = weakJobPtr.lock();
-                if (!job) {
-                    LOG_SYNCPAL_WARN(_logger, "Job no longer exists in progress callback");
-                    return;
-                }
-
-                if (!_syncPal->setProgress(job->affectedFilePath(), progress)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: path="
-                                                       << Utility::formatSyncPath(job->affectedFilePath()) << L", progress="
-                                                       << progress << L"%" << L", jobId=" << job->jobId());
-                }
-            };
-            job->setProgressPercentCallback(progressPercentCallback);
+            setJobCallbacks(job);
 
             SyncJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
             (void) _ongoingJobs.try_emplace(job->jobId(), job);

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -62,7 +62,7 @@ class TerminatedJobsQueue : public std::recursive_mutex {
         std::queue<UniqueId> _terminatedJobs;
 };
 
-class ExecutorWorker : public OperationProcessor {
+class ExecutorWorker : public OperationProcessor, public std::enable_shared_from_this<ExecutorWorker> {
     public:
         ExecutorWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName);
 
@@ -73,6 +73,8 @@ class ExecutorWorker : public OperationProcessor {
         void execute() override;
 
     private:
+        void setJobCallbacks(const std::shared_ptr<SyncJob> &job);
+        void updateJobProgress(const std::shared_ptr<SyncJob> &job, int progress);
         void initProgressManager();
         void initSyncFileItem(SyncOpPtr syncOp, SyncFileItem &syncItem);
 

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -421,11 +421,17 @@ bool SyncPal::wipeOldPlaceholders() {
 }
 
 void SyncPal::loadProgress(SyncProgress &syncProgress) const {
-    syncProgress._currentFile = _progressInfo->completedFiles();
-    syncProgress._totalFiles = std::max(_progressInfo->completedFiles(), _progressInfo->totalFiles());
-    syncProgress._completedSize = _progressInfo->completedSize();
-    syncProgress._totalSize = std::max(_progressInfo->completedSize(), _progressInfo->totalSize());
-    syncProgress._estimatedRemainingTime = _progressInfo->totalProgress().estimatedEta();
+    const auto currentProgressInfo = progressInfo();
+    if (!currentProgressInfo) {
+        syncProgress = {};
+        return;
+    }
+
+    syncProgress._currentFile = currentProgressInfo->completedFiles();
+    syncProgress._totalFiles = std::max(currentProgressInfo->completedFiles(), currentProgressInfo->totalFiles());
+    syncProgress._completedSize = currentProgressInfo->completedSize();
+    syncProgress._totalSize = std::max(currentProgressInfo->completedSize(), currentProgressInfo->totalSize());
+    syncProgress._estimatedRemainingTime = currentProgressInfo->totalProgress().estimatedEta();
 }
 
 void SyncPal::createSharedObjects() {
@@ -436,7 +442,7 @@ void SyncPal::createSharedObjects() {
     _remoteUpdateTree = std::make_shared<UpdateTree>(ReplicaSide::Remote, _syncDb->rootNode());
     _conflictQueue = std::make_shared<ConflictQueue>(_localUpdateTree, _remoteUpdateTree);
     _syncOps = std::make_shared<SyncOperationList>();
-    _progressInfo = std::make_shared<ProgressInfo>(shared_from_this());
+    setProgressInfo(std::make_shared<ProgressInfo>(shared_from_this()));
 
     initSharedObjects();
 }
@@ -451,7 +457,7 @@ void SyncPal::freeSharedObjects() {
     _remoteUpdateTree.reset();
     _conflictQueue.reset();
     _syncOps.reset();
-    _progressInfo.reset();
+    clearProgressInfo();
 
     // Check that there is no memory leak
     LOG_IF_FAIL(_localSnapshot.use_count() == 0);
@@ -462,7 +468,7 @@ void SyncPal::freeSharedObjects() {
     // LOG_IF_FAIL(_remoteUpdateTree.use_count() == 0); // Can happen if handleAccessDeniedItem is deleting a node
     LOG_IF_FAIL(_conflictQueue.use_count() == 0);
     LOG_IF_FAIL(_syncOps.use_count() == 0);
-    LOG_IF_FAIL(_progressInfo.use_count() == 0);
+    LOG_IF_FAIL(!progressInfo());
 }
 
 void SyncPal::initSharedObjects() {
@@ -575,27 +581,33 @@ bool SyncPal::createOrOpenDb(const SyncPath &syncDbPath, const std::string &vers
 }
 
 void SyncPal::resetEstimateUpdates() {
-    _progressInfo->reset();
+    if (const auto currentProgressInfo = progressInfo()) currentProgressInfo->reset();
 }
 
 void SyncPal::startEstimateUpdates() {
-    _progressInfo->setUpdate(true);
+    if (const auto currentProgressInfo = progressInfo()) currentProgressInfo->setUpdate(true);
 }
 
 void SyncPal::stopEstimateUpdates() {
-    _progressInfo->setUpdate(false);
+    if (const auto currentProgressInfo = progressInfo()) currentProgressInfo->setUpdate(false);
 }
 
 void SyncPal::updateEstimates() {
-    _progressInfo->updateEstimates();
+    if (const auto currentProgressInfo = progressInfo()) currentProgressInfo->updateEstimates();
 }
 
 bool SyncPal::initProgress(const SyncFileItem &item) {
-    return _progressInfo->initProgress(item);
+    const auto currentProgressInfo = progressInfo();
+    return currentProgressInfo && currentProgressInfo->initProgress(item);
 }
 
 bool SyncPal::setProgress(const SyncPath &relativePath, int progress) {
-    if (_progressInfo && !_progressInfo->setProgress(relativePath, progress)) {
+    const auto currentProgressInfo = progressInfo();
+    if (!currentProgressInfo) {
+        return false;
+    }
+
+    if (!currentProgressInfo->setProgress(relativePath, progress)) {
         LOG_SYNCPAL_WARN(_logger, "Error in ProgressInfo::setProgress");
         return false;
     }
@@ -607,7 +619,7 @@ bool SyncPal::setProgress(const SyncPath &relativePath, int progress) {
     }
     if (!found) {
         SyncFileItem item;
-        if (!getSyncFileItem(relativePath, item)) {
+        if (!currentProgressInfo->getSyncFileItem(relativePath, item)) {
             LOG_SYNCPAL_WARN(_logger, "Error in SyncPal::getSyncFileItem");
             return false;
         }
@@ -620,14 +632,19 @@ bool SyncPal::setProgress(const SyncPath &relativePath, int progress) {
 }
 
 bool SyncPal::setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status, const NodeId &newRemoteNodeId) {
+    const auto currentProgressInfo = progressInfo();
+    if (!currentProgressInfo) {
+        return false;
+    }
+
     if (!newRemoteNodeId.empty()) {
-        if (!_progressInfo->setSyncFileItemRemoteId(relativeLocalPath, newRemoteNodeId)) {
+        if (!currentProgressInfo->setSyncFileItemRemoteId(relativeLocalPath, newRemoteNodeId)) {
             LOG_SYNCPAL_WARN(_logger, "Error in ProgressInfo::setSyncFileItemRemoteId");
             // Continue anyway as this is not critical, the share menu on activities will not be available for this file
         }
     }
 
-    if (!_progressInfo->setProgressComplete(relativeLocalPath, status)) {
+    if (!currentProgressInfo->setProgressComplete(relativeLocalPath, status)) {
         LOG_SYNCPAL_WARN(_logger, "Error in ProgressInfo::setProgressComplete");
         return false;
     }
@@ -693,7 +710,8 @@ void SyncPal::directDownloadCallback(UniqueId jobId) {
 }
 
 bool SyncPal::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
-    return _progressInfo->getSyncFileItem(path, item);
+    const auto currentProgressInfo = progressInfo();
+    return currentProgressInfo && currentProgressInfo->getSyncFileItem(path, item);
 }
 
 void SyncPal::resetSnapshotInvalidationCounters() {
@@ -972,8 +990,26 @@ std::shared_ptr<UpdateTree> SyncPal::updateTree(ReplicaSide side) const {
     return (side == ReplicaSide::Local ? _localUpdateTree : _remoteUpdateTree);
 }
 
+std::shared_ptr<ProgressInfo> SyncPal::progressInfo() const {
+    const std::scoped_lock lock(_progressInfoMutex);
+    return _progressInfo;
+}
+
+void SyncPal::setProgressInfo(std::shared_ptr<ProgressInfo> progressInfo) {
+    const std::scoped_lock lock(_progressInfoMutex);
+    _progressInfo = std::move(progressInfo);
+}
+
+void SyncPal::clearProgressInfo() {
+    std::shared_ptr<ProgressInfo> progressInfoToRelease;
+    {
+        const std::scoped_lock lock(_progressInfoMutex);
+        progressInfoToRelease = std::move(_progressInfo);
+    }
+}
+
 void SyncPal::createProgressInfo() {
-    _progressInfo = std::shared_ptr<ProgressInfo>(new ProgressInfo(shared_from_this()));
+    setProgressInfo(std::make_shared<ProgressInfo>(shared_from_this()));
 }
 
 ExitCode SyncPal::fileRemoteIdFromLocalPath(const SyncPath &path, NodeId &nodeId) const {

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -38,6 +38,7 @@
 #include "libparms/db/parmsdb.h"
 
 #include <memory>
+#include <mutex>
 #include <comm.h>
 
 namespace KDC {
@@ -421,6 +422,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::shared_ptr<UpdateTree> _remoteUpdateTree{nullptr};
         std::shared_ptr<ConflictQueue> _conflictQueue{nullptr};
         std::shared_ptr<SyncOperationList> _syncOps{nullptr};
+        mutable std::mutex _progressInfoMutex;
         std::shared_ptr<ProgressInfo> _progressInfo{nullptr};
 
         // Workers
@@ -452,6 +454,9 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::shared_ptr<FSOperationSet> operationSet(ReplicaSide side) const;
 
         // Progress info management
+        [[nodiscard]] std::shared_ptr<ProgressInfo> progressInfo() const;
+        void setProgressInfo(std::shared_ptr<ProgressInfo> progressInfo);
+        void clearProgressInfo();
         void createProgressInfo();
         void resetEstimateUpdates();
         void startEstimateUpdates();

--- a/test/libsyncengine/propagation/executor/testexecutorworker.cpp
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.cpp
@@ -37,6 +37,13 @@
 
 namespace KDC {
 
+namespace {
+class LateCallbackJob final : public SyncJob {
+    public:
+        ExitInfo runJob() override { return ExitCode::Ok; }
+};
+} // namespace
+
 void TestExecutorWorker::setUp() {
     TestBase::start();
     const testhelpers::TestVariables testVariables;
@@ -392,6 +399,23 @@ void TestExecutorWorker::testTerminatedJobsQueue() {
     t2.join();
     t3.join();
     t4.join(); // Wait for all threads to finish.
+}
+
+void TestExecutorWorker::testLateJobCallbacksAfterStop() {
+    const auto job = std::make_shared<LateCallbackJob>();
+    _executorWorker->setJobCallbacks(job);
+    job->setMainCallback([]([[maybe_unused]] const UniqueId jobId) {});
+
+    const std::weak_ptr<ExecutorWorker> weakExecutor = _executorWorker;
+    _executorWorker.reset();
+    _syncPal->clearProgressInfo();
+
+    CPPUNIT_ASSERT(weakExecutor.expired());
+    CPPUNIT_ASSERT(!_syncPal->setProgress(SyncPath("late-callback"), 1));
+
+    // Both callbacks used to retain raw pointers into state released by SyncPal::stop().
+    job->setProgress(1);
+    CPPUNIT_ASSERT(job->runSynchronously());
 }
 
 void TestExecutorWorker::testPropagateConflictToDbAndTree() {

--- a/test/libsyncengine/propagation/executor/testexecutorworker.h
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.h
@@ -37,6 +37,7 @@ class TestExecutorWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDeleteOpNodes);
         CPPUNIT_TEST(testInitSyncFileItem);
         CPPUNIT_TEST(testCheckAlreadyExcluded);
+        CPPUNIT_TEST(testLateJobCallbacksAfterStop);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -54,6 +55,7 @@ class TestExecutorWorker : public CppUnit::TestFixture, public TestBase {
         void testInitSyncFileItem();
         void testDeleteOpNodes();
         void testCheckAlreadyExcluded();
+        void testLateJobCallbacksAfterStop();
 
         bool opsExist(SyncOpPtr op);
         SyncOpPtr generateSyncOperation(const DbNodeId dbNodeId, const SyncName &filename,


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Le serveur pouvait crasher avec un `SIGSEGV` lorsqu'une synchronisation était arrêtée (`SYNC_STOP`) alors que des uploads asynchrones étaient encore en vol. Un callback de progression tardif, émis par un job de chunk annulé, atteignait `SyncPal::setProgress()` en passant par un `ExecutorWorker` déjà détruit, puis déréférençait un `ProgressInfo` que `SyncPal::stop()` venait de libérer. Cette PR remplace cette hypothèse de durée de vie invalide par deux protections complémentaires et ajoute un test de non-régression.

## Changements
- `ExecutorWorker` hérite désormais de `std::enable_shared_from_this` et installe ses callbacks via une nouvelle méthode `setJobCallbacks()`, qui capture des `weak_ptr` vers l'executor et vers le job au lieu d'un `this` brut.
- Nouvelle méthode `ExecutorWorker::updateJobProgress()` qui porte le chemin nominal de remontée de progression, `execute()` se limitant à déléguer l'installation des callbacks puis à mettre le job en file.
- `SyncPal::_progressInfo` est protégé par un `_progressInfoMutex` dédié et n'est plus accessible qu'à travers trois helpers : `progressInfo()`, `setProgressInfo()` et `clearProgressInfo()`.
- Tous les consommateurs de `ProgressInfo` dans `SyncPal` (`loadProgress()`, `initProgress()`, `setProgress()`, `setProgressComplete()`, `getSyncFileItem()` et les quatre méthodes d'estimation `resetEstimateUpdates()`, `startEstimateUpdates()`, `stopEstimateUpdates()`, `updateEstimates()`) acquièrent une copie locale du `shared_ptr` et traitent son absence comme un état d'arrêt attendu.
- `setProgress()` réutilise son propre snapshot local au lieu de repasser par `SyncPal::getSyncFileItem()`, afin que toute l'opération travaille sur la même génération de `ProgressInfo`.
- Ajout de `TestExecutorWorker::testLateJobCallbacksAfterStop()`, qui déclenche les deux callbacks après la libération de l'executor et du `ProgressInfo`.

## Détails techniques
La séquence du crash analysée sur un core était la suivante :

    AbstractUploadSession::uploadChunkCallback()
      -> SyncJob::addProgress() -> SyncJob::setProgress()
        -> callback de progression installé par ExecutorWorker::execute()
          -> SyncPal::setProgress() -> SyncPal::getSyncFileItem()
            -> ProgressInfo::getSyncFileItem() -> SIGSEGV dans pthread_mutex_lock()

`SyncPal::stop()` attend la fin du thread de l'Executor, puis appelle `freeWorkers()` et `freeSharedObjects()`. Mais les jobs réseau tournent sur les threads du `JobManager` : leur annulation n'est pas une jointure. `AbstractUploadSession::uploadChunkCallback()` est appelé même sur un chunk annulé et publie encore la taille du chunk via `addProgress()`, si bien qu'un callback peut arriver après la destruction de l'`ExecutorWorker` et du `ProgressInfo`.

Les deux protections sont nécessaires et couvrent deux fenêtres distinctes :

1. **Callback démarrant après `freeWorkers()`** : le `weak_ptr` vers l'executor échoue à se verrouiller, le callback retourne sans toucher à `_syncPal`, au logger ni aux structures de l'Executor. Le `weak_ptr` déjà présent ne protégeait que la durée de vie du `SyncJob` (pour éviter un cycle de références), pas celle de l'Executor capturé par pointeur brut.
2. **Callback démarrant juste avant `freeWorkers()`** : `lock()` réussit et maintient l'Executor vivant, mais `SyncPal::stop()` peut continuer à libérer ses objets partagés. Le snapshot local de `ProgressInfo` garantit alors que l'objet reste vivant jusqu'à la fin de l'opération.

Un simple garde `if (_progressInfo)` ne suffisait pas : il laissait la data race sur l'instance `shared_ptr` elle-même (le control block est thread-safe, pas l'objet `shared_ptr` partagé), ainsi que la fenêtre check-then-use entre la vérification initiale et la relecture du membre dans `getSyncFileItem()`. C'est précisément cette seconde lecture qui apparaît dans la pile du core, avec `this = 0x0`.

`clearProgressInfo()` déplace la dernière référence dans une variable locale sous le mutex et laisse sa destruction se produire après la libération du verrou, afin que le destructeur de `ProgressInfo` ne s'exécute jamais sous `_progressInfoMutex`. Le mutex ne couvre que l'acquisition ou le remplacement du `shared_ptr`, jamais les accès DB, les notifications GUI ou les opérations longues de `ProgressInfo`.

Coût ajouté : deux `weak_ptr::lock()` par callback de progression, plus un verrou très court et une copie de `shared_ptr` par accès à `ProgressInfo`.

## Tests
- Nouveau test `KDC::TestExecutorWorker::testLateJobCallbacksAfterStop` : un `SyncJob` minimal (`LateCallbackJob`) permet de déclencher les deux callbacks sans accès réseau. Le test détruit l'Executor, appelle `clearProgressInfo()`, vérifie que le `weak_ptr` est expiré, que `setProgress()` échoue proprement, puis déclenche tardivement la progression et le callback de fin sans crash.
- Compilation de la cible `kDrive_test_syncengine` et exécution ciblée du nouveau test : OK.
- Reproduction manuelle sur une version non corrigée : créer une synchronisation avec un fichier nettement supérieur à 100 MiB (pour forcer une `DriveUploadSession`) plus de nombreux petits fichiers pour charger le `JobManager`, attendre l'apparition de plusieurs chunks en vol dans les logs, puis mettre la synchronisation en pause immédiatement. Une bande passante montante limitée facilite le déclenchement. Résultat attendu : crash intermittent avant le correctif, arrêt propre après.

</details>

---

## Summary
The server could crash with a `SIGSEGV` when a sync was stopped (`SYNC_STOP`) while asynchronous uploads were still in flight. A late progress callback, emitted by an aborted chunk job, reached `SyncPal::setProgress()` through an already destroyed `ExecutorWorker`, then dereferenced a `ProgressInfo` that `SyncPal::stop()` had just released. This PR replaces that invalid lifetime assumption with two complementary protections and adds a regression test.

## Changes
- `ExecutorWorker` now derives from `std::enable_shared_from_this` and installs its job callbacks through a new `setJobCallbacks()` method, which captures `weak_ptr` to both the executor and the job instead of a raw `this`.
- New `ExecutorWorker::updateJobProgress()` holds the nominal progress-forwarding path, leaving `execute()` to just delegate callback installation and queue the job.
- `SyncPal::_progressInfo` is now guarded by a dedicated `_progressInfoMutex` and reachable only through three helpers: `progressInfo()`, `setProgressInfo()` and `clearProgressInfo()`.
- Every `ProgressInfo` consumer in `SyncPal` (`loadProgress()`, `initProgress()`, `setProgress()`, `setProgressComplete()`, `getSyncFileItem()` and the four estimate methods `resetEstimateUpdates()`, `startEstimateUpdates()`, `stopEstimateUpdates()`, `updateEstimates()`) acquires a local `shared_ptr` snapshot and treats its absence as an expected shutdown state.
- `setProgress()` reuses its own local snapshot instead of calling back into `SyncPal::getSyncFileItem()`, so the whole operation works on a single `ProgressInfo` generation.
- Added `TestExecutorWorker::testLateJobCallbacksAfterStop()`, which fires both callbacks after the executor and the progress info have been released.

## Technical Details
The crash sequence observed on a core dump was:

    AbstractUploadSession::uploadChunkCallback()
      -> SyncJob::addProgress() -> SyncJob::setProgress()
        -> progress callback installed by ExecutorWorker::execute()
          -> SyncPal::setProgress() -> SyncPal::getSyncFileItem()
            -> ProgressInfo::getSyncFileItem() -> SIGSEGV in pthread_mutex_lock()

`SyncPal::stop()` waits for the Executor thread to exit, then calls `freeWorkers()` and `freeSharedObjects()`. Network jobs, however, run on `JobManager` threads: aborting them is not a join. `AbstractUploadSession::uploadChunkCallback()` runs even for an aborted chunk and still publishes the chunk size through `addProgress()`, so a callback can land after both the `ExecutorWorker` and the `ProgressInfo` are gone.

Both protections are required, because they cover two distinct windows:

1. **Callback starting after `freeWorkers()`**: the executor `weak_ptr` fails to lock and the callback returns without touching `_syncPal`, the logger or any Executor state. The pre-existing `weak_ptr` only protected the `SyncJob` lifetime (to avoid a reference cycle), never the Executor, which was captured as a raw pointer.
2. **Callback starting just before `freeWorkers()`**: `lock()` succeeds and keeps the Executor alive, but `SyncPal::stop()` can still go on releasing its shared objects. The local `ProgressInfo` snapshot is what keeps that object alive for the whole operation.

A plain `if (_progressInfo)` guard was not enough: it left the data race on the `shared_ptr` instance itself (the control block is thread-safe, a shared `shared_ptr` object is not), plus the check-then-use window between the initial test and the member being re-read inside `getSyncFileItem()`. That second read is exactly what the core stack shows, with `this = 0x0`.

`clearProgressInfo()` moves the last reference into a local variable under the mutex and lets it be destroyed after the lock is released, so `~ProgressInfo` never runs under `_progressInfoMutex`. The mutex only covers acquiring or replacing the `shared_ptr`, never DB access, GUI notifications or long `ProgressInfo` operations.

Added cost: two `weak_ptr::lock()` calls per progress callback, plus a very short lock and one `shared_ptr` copy per `ProgressInfo` access.

## Testing
- New test `KDC::TestExecutorWorker::testLateJobCallbacksAfterStop`: a minimal `SyncJob` (`LateCallbackJob`) makes it possible to fire both callbacks without any network access. The test destroys the Executor, calls `clearProgressInfo()`, asserts the `weak_ptr` is expired and that `setProgress()` fails cleanly, then triggers the late progress and completion callbacks without crashing.
- `kDrive_test_syncengine` target builds and the new test passes when run on its own.
- Manual reproduction on an unpatched build: create a test sync with one file well above 100 MiB (to force a `DriveUploadSession`) plus many small files to load the `JobManager`, wait until several chunks are in flight in the logs, then immediately pause that sync. A capped upload bandwidth makes the race easier to hit. Expected result: intermittent crash before the fix, clean shutdown after.
