### PR TITLE
fix: JobManager extended tests issues

### DIFF
--- a/src/libsyncengine/jobs/abstractjob.cpp
+++ b/src/libsyncengine/jobs/abstractjob.cpp
@@ -42,7 +42,7 @@ AbstractJob::AbstractJob() :
 AbstractJob::~AbstractJob() {
     _mainCallback = nullptr;
     _additionalCallback = nullptr;
-    if (ParametersCache::isExtendedLogEnabled()) {
+    if (_isExtendedLog) {
         LOG_DEBUG(_logger, "Job " << _jobId << " deleted");
     }
     log4cplus::threadCleanup();
@@ -61,7 +61,7 @@ ExitInfo AbstractJob::runSynchronously() {
 }
 
 void AbstractJob::abort() {
-    if (ParametersCache::isExtendedLogEnabled()) {
+    if (_isExtendedLog) {
         LOG_DEBUG(_logger, "Aborting job " << jobId());
     }
     _aborted = true;

--- a/src/libsyncengine/jobs/jobmanager.cpp
+++ b/src/libsyncengine/jobs/jobmanager.cpp
@@ -111,8 +111,8 @@ void JobManager::run() noexcept {
         }
 
         auto availableThreads = availableThreadsInPool();
-        // Always keep 1 thread available for jobs with highest priority
-        while (availableThreads > 1 && !_stop && _data.hasQueuedJob()) {
+        // Always keep threads available for jobs with highest priority
+        while (availableThreads > highPriorityCapacity() && !_stop && _data.hasQueuedJob()) {
             const auto [job, priority] = _data.pop();
             if (canRunJob(job)) {
                 startJob(job, priority);
@@ -165,14 +165,6 @@ void JobManager::addToPendingJobs(const std::shared_ptr<AbstractJob> job, const 
         return;
     }
     LOG_DEBUG(Log::instance()->getLogger(), "Job " << job->jobId() << " is pending (thread pool maximum capacity reached)");
-}
-
-int JobManager::availableThreadsInPool() const {
-    try {
-        return _threadPool.available();
-    } catch (Poco::Exception &) {
-        return 0;
-    }
 }
 
 bool JobManager::canRunJob(const std::shared_ptr<AbstractJob>) const {

--- a/src/libsyncengine/jobs/jobmanager.h
+++ b/src/libsyncengine/jobs/jobmanager.h
@@ -59,11 +59,14 @@ class JobManager {
 
         void setPoolCapacity(int nbThread);
         void decreasePoolCapacity();
+        uint64_t capacity() const { return static_cast<uint64_t>(_threadPool.capacity()); }
+        uint64_t highPriorityCapacity() const { return 1; }
+        uint64_t normalPriorityCapacity() const { return capacity() - highPriorityCapacity(); }
 
         const JobManagerData &data() const { return _data; }
 
     protected:
-        int availableThreadsInPool() const;
+        uint64_t availableThreadsInPool() const { return static_cast<uint64_t>(_threadPool.available()); }
         virtual bool canRunJob(const std::shared_ptr<AbstractJob> job) const;
 
     private:

--- a/src/libsyncengine/jobs/jobmanager.h
+++ b/src/libsyncengine/jobs/jobmanager.h
@@ -66,7 +66,10 @@ class JobManager {
         const JobManagerData &data() const { return _data; }
 
     protected:
-        uint64_t availableThreadsInPool() const { return static_cast<uint64_t>(_threadPool.available()); }
+        uint64_t availableThreadsInPool() const {
+            const auto availableThreads = _threadPool.available();
+            return availableThreads > 0 ? static_cast<uint64_t>(availableThreads) : 0;
+        }
         virtual bool canRunJob(const std::shared_ptr<AbstractJob> job) const;
 
     private:

--- a/src/libsyncengine/jobs/jobmanagerdata.cpp
+++ b/src/libsyncengine/jobs/jobmanagerdata.cpp
@@ -37,6 +37,7 @@ std::pair<std::shared_ptr<AbstractJob>, Poco::Thread::Priority> JobManagerData::
 }
 
 bool JobManagerData::hasQueuedJob() const {
+    const std::scoped_lock lock(_mutex);
     return !_queuedJobs.empty();
 }
 

--- a/src/libsyncengine/jobs/syncjobmanager.cpp
+++ b/src/libsyncengine/jobs/syncjobmanager.cpp
@@ -21,6 +21,7 @@
 #include "jobs/network/kDrive_API/upload/upload_session/driveuploadsession.h"
 
 #include <memory>
+#include <algorithm>
 
 namespace KDC {
 SyncJobManager::SyncJobManager() :
@@ -59,8 +60,7 @@ bool SyncJobManager::canRunJob(const std::shared_ptr<AbstractJob> job) const {
         if (currentJobIsBigFileDownloadJob && isBigFileDownloadJob(getJob(runningJobId))) {
             // Another big download job is running.
             bigDownloadCounter++;
-            if (bigDownloadCounter >= maxNumberParallelBigDownloads) {
-                // Allow max 3 big file download jobs in parallel.
+            if (bigDownloadCounter >= std::min(maxNumberParallelBigDownloads, normalPriorityCapacity())) {
                 return false;
             }
         }

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1742,7 +1742,7 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
         public:
             explicit GetInfoUserJobMock(const UserDbId userDbId, const ApiToken &apiToken) :
                 GetInfoUserJob(userDbId),
-                _apiToken(apiToken) {};
+                _apiToken(apiToken) {}
 
             [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const override {
                 return Poco::Net::HTTPResponse(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED);

--- a/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
+++ b/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
@@ -397,7 +397,7 @@ void TestSyncJobManagerSingleton::testCanRunjob() {
             Utility::msleep(100);
         }
         CPPUNIT_ASSERT_EQUAL(true, noMoreRun);
-        CPPUNIT_ASSERT_EQUAL(maxNumberParallelBigDownloads, counter);
+        CPPUNIT_ASSERT_EQUAL(std::min(maxNumberParallelBigDownloads, SyncJobManagerSingleton::instance()->normalPriorityCapacity()), counter);
 
         while (!SyncJobManagerSingleton::instance()->_data._managedJobs.empty()) {
             Utility::msleep(100);


### PR DESCRIPTION
```
Sentry detected a crash in the app Test(3)
[804550:804550:20260825,024118.726356:ERROR elf_dynamic_array_reader.h:64] tag not found
[804550:804550:20260825,024118.727878:ERROR file_io_posix.cc:145] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[804550:804550:20260825,024118.727909:ERROR file_io_posix.cc:145] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
./infomaniak-build-tools/run-tests.sh: line 40: 804547 Segmentation fault      (core dumped) ./$(basename "$tester")
KDC::TestUpdateTreeWorker::testResetNodesRecursiveDelete---------- Failure: kDrive_test_syncengine ----------
```