### PR TITLE
fix: extended level was mapped to info level + extended flag instead of debug level + extended flag

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
@@ -300,7 +300,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             {
                 target.UseLog = true;
                 target.ExtendedLog = true;
-                target.LogLevel = Logger.Level.Info;
+                target.LogLevel = Logger.Level.Debug;
             }
             else
             {


### PR DESCRIPTION
fix: extended level was mapped to info level + extended flag instead of debug level + extended flag