### PR TITLE
feat(ui): add ManyDeletesDialog with global modal host

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -276,6 +276,9 @@
   durable cache mutations stay signal-driven through `CachePipeline`.
 - `ui/`: QML shell, product windows, design tokens, reusable components, and bundled UI assets such as tray icons and
   onboarding Lottie animations.
+    - `ui/dialogs/`: app-global dialog composition. `GlobalModalHost` stays alive across waiting, onboarding, and main
+      routes; feature queueing remains in the owning C++ controller until several global modal families require shared
+      arbitration.
     - `ui/windows/main/`: main-window shell, remaining temporary tab placeholders, and feature families grouped under
       `activities/`, `home/`, and `sidebar/`. Home presentation is split between its root composition, `shortcuts/`,
       `states/`, and versioned generated `animations/`. The shell is loaded only when `AppRouter` marks the main window
@@ -294,15 +297,18 @@
     - `ui/features/`: future reusable product features shared by several windows, such as sync configuration.
     - `ui/components/`: reusable presentation primitives without product-window ownership. Main-window sidebar
       primitives accept display values and emit interactions; they do not read `AppCache`, own selection, or call
-      services directly.
+      services directly. `IKModal` and `IKModalButton` provide the styled in-app modal surface and semantic action roles;
+      feature dialogs supply their own wording, state, and actions.
     - `ui/chrome/`: shared window chrome: frameless shell, header bar, controls, resize handles, and shadow wrapper.
       Top-level app-owned QML windows should use `IKShadowedWindow`; its `headerBackgroundData` and `headerData` slots
       accept page-specific header visuals and content while preserving the standard move, resize, minimize, maximize,
-      and close behavior. Onboarding uses `headerOverlaysContent` so window controls do not shift its fixed visual
-      composition. The window decoration controller limits input to the surface and resize handles without clipping the
-      diffuse shadow. It publishes `_GTK_FRAME_EXTENTS` on X11/XWayland so those window managers align the visible
-      surface rather than the transparent shadow during snapping and maximization. Native Wayland intentionally uses
-      public Qt APIs only and therefore snaps the complete native window, including its transparent shadow margin.
+      and close behavior. `IKWindowResizeHandles` is the single owner of custom-frame resize hit areas and can be reused
+      by an interaction layer above a modal overlay without unblocking the underlying application content. Onboarding
+      uses `headerOverlaysContent` so window controls do not shift its fixed visual composition. The window decoration
+      controller limits input to the surface and resize handles without clipping the diffuse shadow. It publishes
+      `_GTK_FRAME_EXTENTS` on X11/XWayland so those window managers align the visible surface rather than the transparent
+      shadow during snapping and maximization. Native Wayland intentionally uses public Qt APIs only and therefore snaps
+      the complete native window, including its transparent shadow margin.
     - `ui/windows/onboarding/animations/`: versioned generated QML animation components produced from Lottie JSON
       payloads. Do not edit these files manually. They are excluded from `qmllint`; validation belongs to the generator
       and the QML compilation step.
@@ -403,6 +409,9 @@ cmake --build build-linux/build/build/Debug --target kDrive kDrive_client kdrive
 - Pass stable app-owned controllers such as `OnboardingSessionManager` and `MainSidebarController` to `Main.qml` as
   initial properties. Pass controllers/models down through explicit required QML properties; do not add dynamic context
   properties for window-owned composition.
+- Keep app-global modals in `GlobalModalHost` so they survive route loader changes. Contextual onboarding/settings
+  modals should instantiate `IKModal` in their owning window or view instead of moving their workflow into the global
+  host.
 
 ## IPC And Error Handling
 

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -146,6 +146,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/chrome/IKShadowedWindow.qml
         ui/chrome/IKWindowControlButton.qml
         ui/chrome/IKWindowHeader.qml
+        ui/chrome/IKWindowResizeHandles.qml
         ui/components/IKBadge.qml
         ui/components/IKAvatar.qml
         ui/components/IKDriveIcon.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -123,6 +123,7 @@ set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)
         ui/tokens/IKActivities.qml
         ui/tokens/IKOnboarding.qml
         ui/tokens/IKMainWindow.qml
+        ui/tokens/IKModalTokens.qml
         ui/tokens/IKWaiting.qml
 )
 
@@ -149,6 +150,8 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKAvatar.qml
         ui/components/IKDriveIcon.qml
         ui/components/IKLoadingSpinner.qml
+        ui/components/IKModal.qml
+        ui/components/IKModalButton.qml
         ui/components/IKSidebarItem.qml
         ui/components/IKDriveSyncSelectorItem.qml
         ui/components/IKToolTip.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -158,6 +158,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKToolTip.qml
         ui/components/IKTintedIcon.qml
         ui/components/IKErrorBanner.qml
+        ui/dialogs/ManyDeletesDialog.qml
         ui/windows/main/BlockingErrorPlaceholder.qml
         ui/windows/main/MainToolbar.qml
         ui/windows/main/MainWindowView.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -158,6 +158,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKToolTip.qml
         ui/components/IKTintedIcon.qml
         ui/components/IKErrorBanner.qml
+        ui/dialogs/GlobalModalHost.qml
         ui/dialogs/ManyDeletesDialog.qml
         ui/windows/main/BlockingErrorPlaceholder.qml
         ui/windows/main/MainToolbar.qml

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -153,7 +153,8 @@ void AppClientLinux::setupSignalConnections() {
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
-    (void) connect(&_manyDeletesController, &ManyDeletesController::presentationRequested, this, &AppClientLinux::openMainWindow);
+    (void) connect(&_manyDeletesController, &ManyDeletesController::presentationRequested, this,
+                   &AppClientLinux::handleManyDeletesPresentationRequested);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::openOnboardingWindowRequested, &_systemTrayController,
                    &SystemTrayController::showMainWindow);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,
@@ -329,6 +330,15 @@ void AppClientLinux::setupTranslations() {
     } else {
         qCInfo(lcAppClientLinux) << "no catalog for locale" << locale.name() << "- using English base";
     }
+}
+
+void AppClientLinux::handleManyDeletesPresentationRequested() {
+    if (_onboardingSessionManager.activeSession() != nullptr) {
+        qCInfo(lcAppClientLinux) << "Mass deletion dialog presentation deferred until onboarding is inactive";
+        return;
+    }
+
+    openMainWindow();
 }
 
 void AppClientLinux::openMainWindow() {

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -91,6 +91,8 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
                                                          "ActivityListModel is owned by ActivitiesController.");
     (void) qmlRegisterUncreatableType<ActivitiesController>("kDrive.UI", 1, 0, "ActivitiesController",
                                                             "ActivitiesController is owned by AppClientLinux.");
+    (void) qmlRegisterUncreatableType<ManyDeletesController>("kDrive.UI", 1, 0, "ManyDeletesController",
+                                                             "ManyDeletesController is owned by AppClientLinux.");
     (void) qmlRegisterUncreatableMetaObject(AppConstants::WebDrive::staticMetaObject, "kDrive.UI", 1, 0, "WebDrive",
                                             QStringLiteral("WebDrive only exposes enums."));
     _qmlEngine.setOutputWarningsToStandardError(false);
@@ -104,6 +106,7 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
             {QStringLiteral("mainSidebarController"), QVariant::fromValue<QObject *>(&_mainSidebarController)},
             {QStringLiteral("homeController"), QVariant::fromValue<QObject *>(&_homeController)},
             {QStringLiteral("activitiesController"), QVariant::fromValue<QObject *>(&_activitiesController)},
+            {QStringLiteral("manyDeletesController"), QVariant::fromValue<QObject *>(&_manyDeletesController)},
             {QStringLiteral("onboardingSessionManager"), QVariant::fromValue<QObject *>(&_onboardingSessionManager)},
             {QStringLiteral("systemTrayController"), QVariant::fromValue<QObject *>(&_systemTrayController)},
     });
@@ -150,6 +153,7 @@ void AppClientLinux::setupSignalConnections() {
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
+    (void) connect(&_manyDeletesController, &ManyDeletesController::presentationRequested, this, &AppClientLinux::openMainWindow);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::openOnboardingWindowRequested, &_systemTrayController,
                    &SystemTrayController::showMainWindow);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -113,6 +113,7 @@ class AppClientLinux : public QApplication {
         void updateLoggerMinLevel() const;
         void requestQuit();
         void quitOnServerDisconnection();
+        void handleManyDeletesPresentationRequested();
         void openMainWindow();
         void openOnboardingFromHome();
         void handleConfiguredSyncsChanged();

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -20,6 +20,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import kDrive.UI
+import "dialogs"
 import "windows/main"
 import "windows/onboarding"
 import "windows/waiting"
@@ -31,6 +32,7 @@ IKShadowedWindow {
     required property var activitiesController
     required property var homeController
     required property var mainSidebarController
+    required property var manyDeletesController
     required property var onboardingSessionManager
     required property var systemTrayController
 
@@ -102,6 +104,12 @@ IKShadowedWindow {
     }
 
     onClosing: close => {
+        if (mainWindow.manyDeletesController.visible
+                && mainWindow.manyDeletesController.severity === ManyDeletesController.Hard) {
+            close.accepted = false
+            return
+        }
+
         if (mainWindow.systemTrayController.trayModeActive) {
             close.accepted = false;
             if (mainWindow.onboardingActive) {
@@ -156,6 +164,15 @@ IKShadowedWindow {
         anchors.fill: parent
         active: mainWindow.waitingActive
         sourceComponent: waitingComponent
+    }
+
+    GlobalModalHost {
+        anchors.fill: parent
+        manyDeletesController: mainWindow.manyDeletesController
+        surfaceInset: mainWindow.effectiveShadowMargin
+        surfaceRadius: mainWindow.surfaceRadius
+        targetWindow: mainWindow
+        windowMoveArea: mainWindow.headerMoveArea
     }
 
     Component {

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -37,6 +37,9 @@ IKShadowedWindow {
     required property var systemTrayController
 
     readonly property bool onboardingActive: onboardingSessionManager.activeSession !== null
+    readonly property bool manyDeletesPresentationAllowed: !onboardingActive
+                                                           && appRouter.mainWindowActive
+                                                           && visible
     readonly property bool waitingActive: !onboardingActive && !appRouter.mainWindowActive
 
     visible: false
@@ -104,7 +107,8 @@ IKShadowedWindow {
     }
 
     onClosing: close => {
-        if (mainWindow.manyDeletesController.visible
+        if (mainWindow.manyDeletesPresentationAllowed
+                && mainWindow.manyDeletesController.visible
                 && mainWindow.manyDeletesController.severity === ManyDeletesController.Hard) {
             close.accepted = false
             return
@@ -169,6 +173,7 @@ IKShadowedWindow {
     GlobalModalHost {
         anchors.fill: parent
         manyDeletesController: mainWindow.manyDeletesController
+        presentationAllowed: mainWindow.manyDeletesPresentationAllowed
         surfaceInset: mainWindow.effectiveShadowMargin
         surfaceRadius: mainWindow.surfaceRadius
         targetWindow: mainWindow

--- a/src/gui4/linux/ui/chrome/IKShadowedWindow.qml
+++ b/src/gui4/linux/ui/chrome/IKShadowedWindow.qml
@@ -55,6 +55,8 @@ Window {
                                                   : 0
     readonly property real surfaceWidth: Math.max(0, width - 2 * effectiveShadowMargin)
     readonly property real surfaceHeight: Math.max(0, height - 2 * effectiveShadowMargin)
+    readonly property rect headerMoveArea: Qt.rect(effectiveShadowMargin, effectiveShadowMargin,
+                                                   windowHeader.moveAreaWidth, effectiveHeaderHeight)
 
     function updateWindowDecoration() {
         if (!windowDecorationReady) {
@@ -166,84 +168,11 @@ Window {
             layer.enabled: true
         }
 
-        MouseArea {
-            x: surface.x - width
-            y: surface.y
-            width: IKWindow.resizeHandleThickness
-            height: surface.height
+        IKWindowResizeHandles {
+            anchors.fill: parent
+            targetWindow: root
+            surfaceInset: root.effectiveShadowMargin
             visible: root.customFrameVisible
-            cursorShape: Qt.SizeHorCursor
-            onPressed: root.startSystemResize(Qt.LeftEdge)
-        }
-
-        MouseArea {
-            x: surface.x + surface.width
-            y: surface.y
-            width: IKWindow.resizeHandleThickness
-            height: surface.height
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeHorCursor
-            onPressed: root.startSystemResize(Qt.RightEdge)
-        }
-
-        MouseArea {
-            x: surface.x
-            y: surface.y - height
-            width: surface.width
-            height: IKWindow.resizeHandleThickness
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeVerCursor
-            onPressed: root.startSystemResize(Qt.TopEdge)
-        }
-
-        MouseArea {
-            x: surface.x
-            y: surface.y + surface.height
-            width: surface.width
-            height: IKWindow.resizeHandleThickness
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeVerCursor
-            onPressed: root.startSystemResize(Qt.BottomEdge)
-        }
-
-        MouseArea {
-            x: surface.x - width
-            y: surface.y - height
-            width: IKWindow.resizeHandleThickness
-            height: IKWindow.resizeHandleThickness
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeFDiagCursor
-            onPressed: root.startSystemResize(Qt.TopEdge | Qt.LeftEdge)
-        }
-
-        MouseArea {
-            x: surface.x + surface.width
-            y: surface.y - height
-            width: IKWindow.resizeHandleThickness
-            height: IKWindow.resizeHandleThickness
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeBDiagCursor
-            onPressed: root.startSystemResize(Qt.TopEdge | Qt.RightEdge)
-        }
-
-        MouseArea {
-            x: surface.x - width
-            y: surface.y + surface.height
-            width: IKWindow.resizeHandleThickness
-            height: IKWindow.resizeHandleThickness
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeBDiagCursor
-            onPressed: root.startSystemResize(Qt.BottomEdge | Qt.LeftEdge)
-        }
-
-        MouseArea {
-            x: surface.x + surface.width
-            y: surface.y + surface.height
-            width: IKWindow.resizeHandleThickness
-            height: IKWindow.resizeHandleThickness
-            visible: root.customFrameVisible
-            cursorShape: Qt.SizeFDiagCursor
-            onPressed: root.startSystemResize(Qt.BottomEdge | Qt.RightEdge)
         }
     }
 }

--- a/src/gui4/linux/ui/chrome/IKWindowHeader.qml
+++ b/src/gui4/linux/ui/chrome/IKWindowHeader.qml
@@ -29,6 +29,7 @@ Item {
     property bool titleVisible: true
 
     readonly property bool maximized: targetWindow.visibility === Window.Maximized
+    readonly property real moveAreaWidth: windowMoveArea.width
 
     height: IKWindow.headerHeight
 
@@ -44,6 +45,8 @@ Item {
     }
 
     Item {
+        id: windowMoveArea
+
         anchors.left: parent.left
         anchors.right: windowControls.left
         anchors.top: parent.top

--- a/src/gui4/linux/ui/chrome/IKWindowResizeHandles.qml
+++ b/src/gui4/linux/ui/chrome/IKWindowResizeHandles.qml
@@ -1,0 +1,103 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import kDrive.UI
+
+// Shared system-resize hit areas for the custom frameless window, including interaction layers placed above a modal.
+Item {
+    id: root
+
+    required property var targetWindow
+    required property real surfaceInset
+
+    readonly property real surfaceWidth: Math.max(0, width - 2 * surfaceInset)
+    readonly property real surfaceHeight: Math.max(0, height - 2 * surfaceInset)
+
+    MouseArea {
+        x: root.surfaceInset - width
+        y: root.surfaceInset
+        width: IKWindow.resizeHandleThickness
+        height: root.surfaceHeight
+        cursorShape: Qt.SizeHorCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.LeftEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset + root.surfaceWidth
+        y: root.surfaceInset
+        width: IKWindow.resizeHandleThickness
+        height: root.surfaceHeight
+        cursorShape: Qt.SizeHorCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.RightEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset
+        y: root.surfaceInset - height
+        width: root.surfaceWidth
+        height: IKWindow.resizeHandleThickness
+        cursorShape: Qt.SizeVerCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.TopEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset
+        y: root.surfaceInset + root.surfaceHeight
+        width: root.surfaceWidth
+        height: IKWindow.resizeHandleThickness
+        cursorShape: Qt.SizeVerCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.BottomEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset - width
+        y: root.surfaceInset - height
+        width: IKWindow.resizeHandleThickness
+        height: IKWindow.resizeHandleThickness
+        cursorShape: Qt.SizeFDiagCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.TopEdge | Qt.LeftEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset + root.surfaceWidth
+        y: root.surfaceInset - height
+        width: IKWindow.resizeHandleThickness
+        height: IKWindow.resizeHandleThickness
+        cursorShape: Qt.SizeBDiagCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.TopEdge | Qt.RightEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset - width
+        y: root.surfaceInset + root.surfaceHeight
+        width: IKWindow.resizeHandleThickness
+        height: IKWindow.resizeHandleThickness
+        cursorShape: Qt.SizeBDiagCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.BottomEdge | Qt.LeftEdge)
+    }
+
+    MouseArea {
+        x: root.surfaceInset + root.surfaceWidth
+        y: root.surfaceInset + root.surfaceHeight
+        width: IKWindow.resizeHandleThickness
+        height: IKWindow.resizeHandleThickness
+        cursorShape: Qt.SizeFDiagCursor
+        onPressed: root.targetWindow.startSystemResize(Qt.BottomEdge | Qt.RightEdge)
+    }
+}

--- a/src/gui4/linux/ui/components/IKModal.qml
+++ b/src/gui4/linux/ui/components/IKModal.qml
@@ -1,0 +1,179 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import kDrive.UI
+
+// Reusable in-app modal surface. It deliberately owns presentation and focus only; feature state and actions stay in
+// the dialog that supplies bodyData and footerData.
+Popup {
+    id: root
+
+    required property string title
+    property url iconSource
+    property color iconColor: IKColors.textPrimary
+    property bool escapeDismissible: false
+    property bool actionsStacked: false
+    property int actionColumns: 2
+    property Item initialFocusItem: null
+    property real scrimInset: 0
+    property real scrimRadius: 0
+    property alias bodyData: bodyColumn.data
+    property alias footerData: footerLayout.data
+
+    signal dismissRequested
+
+    parent: Overlay.overlay
+    x: parent ? Math.round((parent.width - width) / 2) : 0
+    y: parent ? Math.round((parent.height - height) / 2) : 0
+    width: parent ? Math.min(IKModalTokens.width, Math.max(0, parent.width - 2 * IKModalTokens.screenMargin))
+                  : IKModalTokens.width
+    implicitHeight: modalContent.implicitHeight + topPadding + bottomPadding
+    padding: IKModalTokens.contentPadding
+    popupType: Popup.Item
+    modal: true
+    dim: true
+    focus: true
+    closePolicy: Popup.NoAutoClose
+
+    Shortcut {
+        sequence: StandardKey.Cancel
+        enabled: root.opened && root.escapeDismissible
+        context: Qt.WindowShortcut
+        onActivated: root.dismissRequested()
+    }
+
+    onOpened: Qt.callLater(function() {
+        if (root.initialFocusItem) {
+            root.initialFocusItem.forceActiveFocus()
+        }
+    })
+
+    Overlay.modal: Item {
+        Rectangle {
+            x: root.scrimInset
+            y: root.scrimInset
+            width: Math.max(0, parent.width - 2 * root.scrimInset)
+            height: Math.max(0, parent.height - 2 * root.scrimInset)
+            radius: root.scrimRadius
+            color: IKColors.modalScrim
+        }
+
+    }
+
+    enter: Transition {
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: IKModalTokens.enterDuration
+                easing.type: Easing.OutCubic
+            }
+            NumberAnimation {
+                property: "scale"
+                from: IKModalTokens.enterScale
+                to: 1
+                duration: IKModalTokens.enterDuration
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    exit: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 1
+            to: 0
+            duration: IKModalTokens.exitDuration
+            easing.type: Easing.InCubic
+        }
+    }
+
+    background: Rectangle {
+        radius: IKRadius.r16
+        color: IKColors.modalSurface
+        border.width: IKModalTokens.borderWidth
+        border.color: IKColors.modalBorder
+    }
+
+    contentItem: Column {
+        id: modalContent
+
+        spacing: IKModalTokens.contentSpacing
+        Accessible.role: Accessible.Dialog
+        Accessible.name: root.title
+
+        Item {
+            width: parent.width
+            implicitHeight: Math.max(headerIcon.height, titleText.implicitHeight)
+
+            IKTintedIcon {
+                id: headerIcon
+
+                width: visible ? IKModalTokens.iconSize : 0
+                height: visible ? IKModalTokens.iconSize : 0
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.iconSource.toString().length > 0
+                source: root.iconSource
+                color: root.iconColor
+            }
+
+            Text {
+                id: titleText
+
+                anchors.left: headerIcon.right
+                anchors.leftMargin: headerIcon.visible ? IKModalTokens.headerSpacing : 0
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.title
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.title3Size
+                font.weight: IKFonts.emphasized
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        Column {
+            id: bodyColumn
+
+            width: parent.width
+            spacing: IKModalTokens.bodySpacing
+        }
+
+        Item {
+            width: parent.width
+            implicitHeight: footerLayout.implicitHeight
+
+            GridLayout {
+                id: footerLayout
+
+                anchors.right: parent.right
+                width: root.actionsStacked ? parent.width : implicitWidth
+                columns: root.actionsStacked ? 1 : root.actionColumns
+                columnSpacing: IKModalTokens.actionSpacing
+                rowSpacing: IKModalTokens.actionSpacing
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/components/IKModal.qml
+++ b/src/gui4/linux/ui/components/IKModal.qml
@@ -56,7 +56,7 @@ Popup {
     closePolicy: Popup.NoAutoClose
 
     Shortcut {
-        sequence: StandardKey.Cancel
+        sequences: [ StandardKey.Cancel ]
         enabled: root.opened && root.escapeDismissible
         context: Qt.WindowShortcut
         onActivated: root.dismissRequested()

--- a/src/gui4/linux/ui/components/IKModalButton.qml
+++ b/src/gui4/linux/ui/components/IKModalButton.qml
@@ -1,0 +1,106 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+Button {
+    id: root
+
+    enum Role {
+        Primary,
+        Secondary,
+        Destructive
+    }
+
+    property int role: IKModalButton.Primary
+    property bool actionEnabled: true
+    property bool busy: false
+
+    readonly property color foregroundColor: {
+        if (!actionEnabled && !busy) {
+            return IKColors.actionDisabled
+        }
+        if (role === IKModalButton.Secondary) {
+            return IKColors.actionPrimary
+        }
+        return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary
+    }
+    readonly property color focusBorderColor: {
+        if (role === IKModalButton.Secondary) {
+            return IKColors.accentPrimary
+        }
+        return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary
+    }
+
+    enabled: actionEnabled && !busy
+    implicitWidth: Math.max(IKModalTokens.buttonMinimumWidth,
+                            buttonText.implicitWidth + 2 * IKModalTokens.buttonHorizontalPadding)
+    implicitHeight: IKModalTokens.buttonHeight
+    padding: 0
+    leftPadding: IKModalTokens.buttonHorizontalPadding
+    rightPadding: IKModalTokens.buttonHorizontalPadding
+    focusPolicy: Qt.StrongFocus
+    hoverEnabled: true
+    opacity: actionEnabled || busy ? 1 : IKModalTokens.disabledOpacity
+
+    contentItem: Item {
+        Text {
+            id: buttonText
+
+            anchors.fill: parent
+            visible: !root.busy
+            text: root.text
+            color: root.foregroundColor
+            font.pixelSize: IKFonts.bodySize
+            font.weight: IKFonts.emphasized
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+
+        IKLoadingSpinner {
+            anchors.centerIn: parent
+            visible: root.busy
+            width: IKModalTokens.buttonSpinnerSize
+            height: IKModalTokens.buttonSpinnerSize
+            strokeWidth: 2
+            color: root.foregroundColor
+        }
+    }
+
+    background: Rectangle {
+        radius: IKRadius.r6
+        color: {
+            if (root.role === IKModalButton.Secondary) {
+                return root.hovered || root.down ? IKColors.modalSecondaryActionHover : "transparent"
+            }
+            if (root.role === IKModalButton.Destructive) {
+                return root.down ? IKColors.actionDestructivePressed : IKColors.actionDestructive
+            }
+            return IKColors.actionPrimary
+        }
+        opacity: root.down ? IKModalTokens.pressedOpacity : root.hovered ? IKModalTokens.hoverOpacity : 1
+        border.width: root.visualFocus ? IKModalTokens.focusBorderWidth
+                                             : root.role === IKModalButton.Secondary ? IKModalTokens.borderWidth : 0
+        border.color: root.visualFocus ? root.focusBorderColor : IKColors.modalBorder
+    }
+}

--- a/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
+++ b/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
@@ -1,0 +1,74 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+// Always-alive composition point for app-global dialogs. Feature-specific queueing remains in each controller; a
+// cross-feature arbiter can be introduced here later if simultaneous global modal families become a real requirement.
+Item {
+    id: root
+
+    required property var manyDeletesController
+    required property real surfaceInset
+    required property real surfaceRadius
+    required property var targetWindow
+    required property rect windowMoveArea
+
+    ManyDeletesDialog {
+        id: manyDeletesDialog
+
+        controller: root.manyDeletesController
+        scrimInset: root.surfaceInset
+        scrimRadius: root.surfaceRadius
+    }
+
+    Item {
+        parent: Overlay.overlay
+        anchors.fill: parent
+        z: manyDeletesDialog.z + 1
+        visible: manyDeletesDialog.visible
+
+        Item {
+            id: modalWindowMoveArea
+
+            x: root.windowMoveArea.x
+            y: root.windowMoveArea.y
+            width: root.windowMoveArea.width
+            height: root.windowMoveArea.height
+
+            DragHandler {
+                target: null
+                acceptedButtons: Qt.LeftButton
+                onActiveChanged: {
+                    if (active) {
+                        root.targetWindow.startSystemMove()
+                    }
+                }
+            }
+        }
+
+        IKWindowResizeHandles {
+            anchors.fill: parent
+            targetWindow: root.targetWindow
+            surfaceInset: root.surfaceInset
+            visible: root.surfaceInset > 0
+        }
+    }
+}

--- a/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
+++ b/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
@@ -26,6 +26,7 @@ Item {
     id: root
 
     required property var manyDeletesController
+    required property bool presentationAllowed
     required property real surfaceInset
     required property real surfaceRadius
     required property var targetWindow
@@ -35,6 +36,7 @@ Item {
         id: manyDeletesDialog
 
         controller: root.manyDeletesController
+        presentationAllowed: root.presentationAllowed
         scrimInset: root.surfaceInset
         scrimRadius: root.surfaceRadius
     }

--- a/src/gui4/linux/ui/dialogs/ManyDeletesDialog.qml
+++ b/src/gui4/linux/ui/dialogs/ManyDeletesDialog.qml
@@ -1,0 +1,238 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import kDrive.UI
+
+IKModal {
+    id: root
+
+    enum PendingAction {
+        None,
+        Restore,
+        DeleteOnline
+    }
+
+    required property var controller
+    readonly property bool hardLimit: controller.severity === ManyDeletesController.Hard
+    property int pendingAction: ManyDeletesDialog.None
+    readonly property bool softLimit: controller.severity === ManyDeletesController.Soft
+    readonly property real requiredActionsWidth: {
+        if (softLimit) {
+            return openTrashButton.implicitWidth + closeButton.implicitWidth + IKModalTokens.actionSpacing;
+        }
+        return deleteOnlineButton.implicitWidth + restoreButton.implicitWidth + IKModalTokens.actionSpacing;
+    }
+
+    function synchronizePresentation() {
+        if (!controller.visible) {
+            root.close();
+            return;
+        }
+
+        doNotShowAgainCheckBox.checked = false;
+        root.pendingAction = ManyDeletesDialog.None;
+        if (!root.opened) {
+            root.open();
+        } else {
+            Qt.callLater(function () {
+                if (root.initialFocusItem) {
+                    root.initialFocusItem.forceActiveFocus();
+                }
+            });
+        }
+    }
+
+    actionsStacked: requiredActionsWidth > availableWidth
+    escapeDismissible: softLimit && !controller.busy
+    iconColor: hardLimit ? IKColors.modalHardWarningIcon : IKColors.statusMediumWarning
+    iconSource: "qrc:/assets/main/triangle-alert.svg"
+    initialFocusItem: softLimit ? closeButton : restoreButton
+    title: qsTrId("manyDeleteDialogTitle").arg(controller.itemCount)
+
+    bodyData: [
+        Text {
+            color: IKColors.textSecondary
+            font.pixelSize: IKFonts.bodySize
+            lineHeight: IKFonts.title2Size
+            lineHeightMode: Text.FixedHeight
+            text: root.hardLimit ? qsTrId("manyDeleteDialogHardLimitContent") : qsTrId("manyDeleteDialogSoftLimitContent")
+            width: parent.width
+            wrapMode: Text.WordWrap
+        },
+        CheckBox {
+            id: doNotShowAgainCheckBox
+
+            focusPolicy: Qt.StrongFocus
+            hoverEnabled: true
+            padding: 0
+            spacing: IKSpacing.s8
+            text: qsTrId("manyDeleteDialogSoftLimitDoNotShowAgain")
+            visible: root.softLimit
+            width: parent.width
+
+            contentItem: Text {
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.bodySize
+                leftPadding: doNotShowAgainCheckBox.indicator.width + doNotShowAgainCheckBox.spacing
+                text: doNotShowAgainCheckBox.text
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.WordWrap
+            }
+            indicator: Rectangle {
+                border.color: doNotShowAgainCheckBox.visualFocus ? IKColors.accentPrimary : IKColors.textTertiary
+                border.width: doNotShowAgainCheckBox.visualFocus ? IKModalTokens.focusBorderWidth : IKModalTokens.borderWidth
+                color: doNotShowAgainCheckBox.checked ? IKColors.actionPrimary : "transparent"
+                implicitHeight: IKModalTokens.checkboxSize
+                implicitWidth: IKModalTokens.checkboxSize
+                radius: IKRadius.r4
+                x: doNotShowAgainCheckBox.leftPadding
+                y: Math.round((doNotShowAgainCheckBox.height - height) / 2)
+
+                Text {
+                    anchors.centerIn: parent
+                    color: IKColors.actionOnPrimary
+                    font.pixelSize: IKFonts.subheadlineSize
+                    font.weight: IKFonts.emphasized
+                    text: "✓"
+                    visible: doNotShowAgainCheckBox.checked
+                }
+            }
+        },
+        Rectangle {
+            color: IKColors.statusLightWarning
+            implicitHeight: visible ? errorContent.implicitHeight + 2 * IKModalTokens.errorPadding : 0
+            radius: IKRadius.r8
+            visible: root.hardLimit && root.controller.submissionFailed
+            width: parent.width
+
+            Row {
+                id: errorContent
+
+                anchors.left: parent.left
+                anchors.leftMargin: IKModalTokens.errorPadding
+                anchors.right: parent.right
+                anchors.rightMargin: IKModalTokens.errorPadding
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: IKSpacing.s8
+
+                IKTintedIcon {
+                    anchors.top: parent.top
+                    color: IKColors.statusStrongWarning
+                    height: IKModalTokens.errorIconSize
+                    source: "qrc:/assets/main/triangle-alert.svg"
+                    width: IKModalTokens.errorIconSize
+                }
+                Column {
+                    spacing: IKSpacing.s4
+                    width: Math.max(0, parent.width - x)
+
+                    Text {
+                        color: IKColors.textPrimary
+                        font.pixelSize: IKFonts.bodySize
+                        font.weight: IKFonts.emphasized
+                        text: qsTrId("defaultErrorTitle")
+                        width: parent.width
+                        wrapMode: Text.WordWrap
+                    }
+                    Text {
+                        color: IKColors.textSecondary
+                        font.pixelSize: IKFonts.subheadlineSize
+                        text: qsTrId("unexpectedErrorTeachingTipContent")
+                        width: parent.width
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+        }
+    ]
+    footerData: [
+        IKModalButton {
+            id: openTrashButton
+
+            Layout.fillWidth: root.actionsStacked
+            actionEnabled: root.controller.canOpenTrash && !root.controller.busy
+            role: IKModalButton.Secondary
+            text: qsTrId("buttonOpenTrash")
+            visible: root.softLimit
+
+            onClicked: root.controller.openTrash(doNotShowAgainCheckBox.checked)
+        },
+        IKModalButton {
+            id: closeButton
+
+            Layout.fillWidth: root.actionsStacked
+            actionEnabled: !root.controller.busy
+            role: IKModalButton.Primary
+            text: qsTrId("buttonClose")
+            visible: root.softLimit
+
+            onClicked: root.controller.dismissSoft(doNotShowAgainCheckBox.checked)
+        },
+        IKModalButton {
+            id: deleteOnlineButton
+
+            Layout.fillWidth: root.actionsStacked
+            actionEnabled: !root.controller.busy
+            busy: root.controller.busy && root.pendingAction === ManyDeletesDialog.DeleteOnline
+            role: IKModalButton.Destructive
+            text: qsTrId("manyDeleteDialogHardLimitSecondary")
+            visible: root.hardLimit
+
+            onClicked: {
+                root.pendingAction = ManyDeletesDialog.DeleteOnline;
+                root.controller.deleteOnline();
+            }
+        },
+        IKModalButton {
+            id: restoreButton
+
+            Layout.fillWidth: root.actionsStacked
+            actionEnabled: !root.controller.busy
+            busy: root.controller.busy && root.pendingAction === ManyDeletesDialog.Restore
+            role: IKModalButton.Primary
+            text: qsTrId("manyDeleteDialogHardLimitPrimary")
+            visible: root.hardLimit
+
+            onClicked: {
+                root.pendingAction = ManyDeletesDialog.Restore;
+                root.controller.restoreFiles();
+            }
+        }
+    ]
+
+    Component.onCompleted: synchronizePresentation()
+    onDismissRequested: controller.dismissSoft(doNotShowAgainCheckBox.checked)
+
+    Connections {
+        function onBusyChanged() {
+            if (!root.controller.busy) {
+                root.pendingAction = ManyDeletesDialog.None;
+            }
+        }
+        function onPresentationChanged() {
+            root.synchronizePresentation();
+        }
+
+        target: root.controller
+    }
+}

--- a/src/gui4/linux/ui/dialogs/ManyDeletesDialog.qml
+++ b/src/gui4/linux/ui/dialogs/ManyDeletesDialog.qml
@@ -33,6 +33,7 @@ IKModal {
     }
 
     required property var controller
+    required property bool presentationAllowed
     readonly property bool hardLimit: controller.severity === ManyDeletesController.Hard
     property int pendingAction: ManyDeletesDialog.None
     readonly property bool softLimit: controller.severity === ManyDeletesController.Soft
@@ -44,7 +45,7 @@ IKModal {
     }
 
     function synchronizePresentation() {
-        if (!controller.visible) {
+        if (!controller.visible || !presentationAllowed) {
             root.close();
             return;
         }
@@ -222,6 +223,7 @@ IKModal {
 
     Component.onCompleted: synchronizePresentation()
     onDismissRequested: controller.dismissSoft(doNotShowAgainCheckBox.checked)
+    onPresentationAllowedChanged: synchronizePresentation()
 
     Connections {
         function onBusyChanged() {

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -106,6 +106,9 @@ QtObject {
     readonly property color actionPrimary: accentPrimary
     readonly property color actionOnPrimary: darkMode ? _p.neutralBlue800 : _p.neutralBlue100
     readonly property color actionDisabled: _p.gray400
+    readonly property color actionDestructive: _p.red500
+    readonly property color actionDestructivePressed: _p.red600
+    readonly property color actionOnDestructive: _p.white
 
     // Text
     readonly property color textPrimary: darkMode ? _p.neutralBlue50 : _p.neutralBlue800
@@ -182,4 +185,9 @@ QtObject {
     readonly property color activitiesActionMenuHover: surfaceTertiary
     readonly property color sidebarNotificationSurface: surfacePrimary
     readonly property color sidebarNotificationBorder: surfaceTertiary
+    readonly property color modalSurface: onboardingSurfacePrimary
+    readonly property color modalBorder: surfaceTertiary
+    readonly property color modalScrim: _p.neutralBlack35
+    readonly property color modalSecondaryActionHover: surfaceTertiary
+    readonly property color modalHardWarningIcon: actionDestructive
 }

--- a/src/gui4/linux/ui/tokens/IKModalTokens.qml
+++ b/src/gui4/linux/ui/tokens/IKModalTokens.qml
@@ -1,0 +1,46 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma Singleton
+import QtQuick
+
+QtObject {
+    readonly property real width: 480
+    readonly property real screenMargin: IKSpacing.s32
+    readonly property real contentPadding: IKSpacing.s24
+    readonly property real contentSpacing: IKSpacing.s24
+    readonly property real bodySpacing: IKSpacing.s16
+    readonly property real headerSpacing: IKSpacing.s12
+    readonly property real actionSpacing: IKSpacing.s8
+    readonly property real iconSize: 24
+    readonly property real buttonHeight: 36
+    readonly property real buttonMinimumWidth: 104
+    readonly property real buttonHorizontalPadding: IKSpacing.s16
+    readonly property real buttonSpinnerSize: 16
+    readonly property real checkboxSize: 18
+    readonly property real errorIconSize: 18
+    readonly property real errorPadding: IKSpacing.s12
+    readonly property real borderWidth: 1
+    readonly property real focusBorderWidth: 2
+    readonly property real disabledOpacity: 0.55
+    readonly property real hoverOpacity: 0.92
+    readonly property real pressedOpacity: 0.82
+    readonly property real enterScale: 0.97
+    readonly property int enterDuration: 140
+    readonly property int exitDuration: 100
+}


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR ajoute la couche de présentation de la boîte de dialogue de suppression massive (`ManyDeletesDialog`) sur Linux, ainsi que l'infrastructure de modales réutilisables (`IKModal`, `IKModalButton`, `IKModalTokens`) et un `GlobalModalHost` qui héberge les modales globales de l'application au-dessus de la fenêtre principale.

## Changements
- Ajout du composant `IKModal`, une surface de modale réutilisable (basée sur `Popup`) avec scrim, icône/titre d'en-tête, zone de contenu et zone d'actions, animations d'entrée/sortie configurables
- Ajout du composant `IKModalButton` avec des rôles Primary/Secondary/Destructive et un état `busy`
- Ajout du singleton `IKModalTokens` regroupant les constantes de mise en page, d'espacement et de timing des modales
- Ajout des couleurs d'action destructive et des couleurs de surface/bordure/scrim de modale dans `IKColors`
- Extraction des zones de redimensionnement de fenêtre d'`IKShadowedWindow` vers un composant partagé `IKWindowResizeHandles`, réutilisable au-dessus d'un overlay de modale sans bloquer le contenu applicatif sous-jacent
- Ajout de `moveAreaWidth` sur `IKWindowHeader` et de `headerMoveArea` sur `IKShadowedWindow` pour exposer la zone de déplacement de la fenêtre et permettre sa réutilisation dans un contexte d'overlay
- Ajout de `ManyDeletesDialog` (basé sur `IKModal`) présentant le cas de la limite souple (ouvrir la corbeille / fermer, avec case "ne plus afficher") et celui de la limite dure (restaurer / supprimer en ligne, avec états `busy` et erreur), piloté par `ManyDeletesController`
- Ajout de `GlobalModalHost`, point de composition toujours actif dans `Main.qml` pour les dialogues globaux de l'application, hébergeant `ManyDeletesDialog` et fournissant la couche d'interaction de déplacement/redimensionnement de fenêtre au-dessus de l'overlay de modale
- Enregistrement de `ManyDeletesController` auprès du moteur QML, câblage de la propriété `manyDeletesController` dans `Main.qml`, et connexion de `presentationRequested` à `openMainWindow`
- Blocage de la fermeture de la fenêtre principale tant que la boîte de dialogue de limite dure est visible
- Mise à jour de la documentation `AGENTS.md` pour le nouveau répertoire `ui/dialogs/` et les conventions `IKModal`/`GlobalModalHost`

## Détails techniques
`IKModal` ne possède volontairement que la présentation et le focus ; l'état métier et les actions restent dans le dialogue appelant via `bodyData`/`footerData`, ce qui garde le composant réutilisable pour de futures modales.

`GlobalModalHost` recrée le déplacement/redimensionnement de fenêtre au-dessus de l'overlay de la modale (via `IKWindowResizeHandles` et un `DragHandler`), car le contenu du `Popup` se place au-dessus du chrome de fenêtre normal et intercepte ses hit-tests.

`ManyDeletesDialog` calcule `actionsStacked` en comparant la largeur cumulée des boutons à la largeur disponible, afin que les actions passent sur une seule colonne plutôt que de déborder ou d'être tronquées dans la largeur fixe de la modale. L'échappement pour fermer n'est actif que sur le cas de limite souple (`escapeDismissible: softLimit && !busy`) ; la limite dure impose de restaurer ou de supprimer en ligne et bloque la fermeture de la fenêtre.

## Notes
Cette PR dépend de `ManyDeletesController`, introduit dans la branche de base `linux-v4/massive-deletes-workflow` ; elle n'ajoute que la couche de présentation qui le pilote.

</details>

---

## Summary
This PR adds the presentation layer for the massive-deletes dialog (`ManyDeletesDialog`) on Linux, along with a reusable modal infrastructure (`IKModal`, `IKModalButton`, `IKModalTokens`) and a `GlobalModalHost` that hosts app-global dialogs above the main window.

## Changes
- Add `IKModal`, a reusable in-app modal surface (built on `Popup`) with scrim, header icon/title, body slot, and footer action slot, with configurable enter/exit animations
- Add `IKModalButton` with Primary/Secondary/Destructive role-based styling and a `busy` state
- Add the `IKModalTokens` singleton grouping modal layout, spacing, and timing constants
- Add destructive action colors and modal surface/border/scrim colors to `IKColors`
- Extract window resize hit-areas out of `IKShadowedWindow` into a shared `IKWindowResizeHandles` component, reusable above a modal overlay without blocking the underlying application content
- Add `moveAreaWidth` to `IKWindowHeader` and `headerMoveArea` to `IKShadowedWindow` to expose the window drag region for reuse in overlay contexts
- Add `ManyDeletesDialog` (built on `IKModal`) presenting the soft-limit case (open trash / close, with a "do not show again" option) and the hard-limit case (restore / delete online, with busy and error states), driven by `ManyDeletesController`
- Add `GlobalModalHost`, an always-alive composition point in `Main.qml` for app-global dialogs, hosting `ManyDeletesDialog` and providing the window move/resize interaction layer above the modal overlay
- Register `ManyDeletesController` with the QML engine, wire the `manyDeletesController` property into `Main.qml`, and connect `presentationRequested` to `openMainWindow`
- Block main window close while the hard-limit many-deletes dialog is visible
- Update `AGENTS.md` documentation for the new `ui/dialogs/` directory and the `IKModal`/`GlobalModalHost` conventions

## Technical Details
`IKModal` deliberately owns only presentation and focus; feature state and actions stay in the calling dialog via `bodyData`/`footerData`, keeping the component reusable for future modals.

`GlobalModalHost` recreates window move/resize above the modal overlay (via `IKWindowResizeHandles` and a `DragHandler`), since `Popup` content sits above the normal window chrome and intercepts its hit-testing.

`ManyDeletesDialog` computes `actionsStacked` by comparing the summed button widths against the available width, so actions wrap to a single column instead of overflowing or being truncated within the modal's fixed width. Escape-to-dismiss is only enabled for the soft-limit path (`escapeDismissible: softLimit && !busy`); the hard limit requires restoring or deleting online and blocks window close.

## Notes
This PR depends on `ManyDeletesController`, introduced in the base branch `linux-v4/massive-deletes-workflow`; it only adds the presentation layer driving it.

# Screenshots
||Dark|Light|
|---|---|---|
|Hard|<img width="2056" height="1552" alt="hard-dark" src="https://github.com/user-attachments/assets/30f079f3-974b-46e9-99f9-d52001897326" />|<img width="2056" height="1552" alt="hard-light" src="https://github.com/user-attachments/assets/3cbde545-ebb0-42a4-9a48-48be4449d956" />|
|Soft|<img width="2056" height="1552" alt="soft-limit-dark" src="https://github.com/user-attachments/assets/5963d749-a21e-432d-92f5-17105ea18638" />|<img width="2056" height="1552" alt="soft-limit-light" src="https://github.com/user-attachments/assets/522309f2-cf9b-49b4-834a-3fb96160ea0f" />|



