### PR TITLE
fix(long-poll-job): Do not send a LongPoll request in absence of an access token. Throw a InvalidTokenError instead

### DIFF
--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -65,6 +65,7 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
 
         ExitInfo refreshToken();
         long tokenUpdateDurationFromNow();
+        [[nodiscard]] bool hasAccessToken() const { return !_apiToken.accessToken().empty(); }
 
     protected:
         std::string getSpecificUrl() override;

--- a/src/libsyncengine/jobs/network/jobexceptions.cpp
+++ b/src/libsyncengine/jobs/network/jobexceptions.cpp
@@ -31,6 +31,9 @@ ExitCode exception2ExitCode(const std::exception &exc) {
     if (dynamic_cast<const InvalidArgumentError *>(&exc)) {
         return ExitCode::LogicError;
     }
+    if (dynamic_cast<const EmptyTokenError *>(&exc)) {
+        return ExitCode::InvalidToken;
+    }
     if (dynamic_cast<const std::bad_alloc *>(&exc)) {
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/jobs/network/jobexceptions.h
+++ b/src/libsyncengine/jobs/network/jobexceptions.h
@@ -36,6 +36,10 @@ struct DataError : JobException {
         using JobException::JobException;
 };
 
+struct EmptyTokenError : JobException {
+        using JobException::JobException;
+};
+
 struct InvalidArgumentError : JobException {
         using JobException::JobException;
 };

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/longpolljob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/longpolljob.cpp
@@ -32,8 +32,8 @@ LongPollJob::LongPollJob(const DriveDbId driveDbId, const std::string &cursor, c
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 
     // Check if the mandatory access token is empty and throw an exception if it is.
-    // The access token is empty if it has been remotely revoked.
-    // Sending this request with an empty access token would raise an HTTP 422 error (Unprocessable Entity).
+    // This happens in particular when the token has been remotely revoked.
+    // Sending this request with an empty access token would result in a not-so-informative HTTP 422 error (Unprocessable Entity).
     if (!hasAccessToken()) throw EmptyTokenError("Access token is empty.");
 }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/longpolljob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/longpolljob.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "longpolljob.h"
+#include "jobs/network/jobexceptions.h"
 
 #include <Poco/Net/HTTPRequest.h>
 
@@ -24,11 +25,16 @@ namespace KDC {
 
 static const uint32_t apiTimout = 50;
 
-LongPollJob::LongPollJob(const int driveDbId, const std::string &cursor, const NodeSet &blacklist /*= {}*/) :
+LongPollJob::LongPollJob(const DriveDbId driveDbId, const std::string &cursor, const NodeSet &blacklist /*= {}*/) :
     AbstractListingJob(ApiType::NotifyDrive, driveDbId, blacklist),
     _cursor(cursor) {
     _customTimeout = apiTimout + 5; // Must be < 1 min (VPNs' default timeout)
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
+
+    // Check if the mandatory access token is empty and throw an exception if it is.
+    // The access token is empty if it has been remotely revoked.
+    // Sending this request with an empty access token would raise an HTTP 422 error (Unprocessable Entity).
+    if (!hasAccessToken()) throw EmptyTokenError("Access token is empty.");
 }
 
 std::string LongPollJob::getSpecificUrl() {

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/longpolljob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/longpolljob.h
@@ -24,7 +24,7 @@ namespace KDC {
 
 class LongPollJob final : public AbstractListingJob {
     public:
-        LongPollJob(int driveDbId, const std::string &cursor, const NodeSet &blacklist = {});
+        LongPollJob(DriveDbId driveDbId, const std::string &cursor, const NodeSet &blacklist = {});
 
     private:
         std::string getSpecificUrl() override;

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1996,7 +1996,6 @@ void TestNetworkJobs::testLongPollJobWithoutToken() {
     const auto exitInfo = jobWithToken.runSynchronously();
     CPPUNIT_ASSERT_EQUAL(ExitCode::BackError, exitInfo.code());
     CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(exitInfo), ExitInfo(ExitCode::BackError, ExitCause::HttpErr), exitInfo);
-    AbstractTokenNetworkJob::clearCache();
 
     clearAccessTokenCache();
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -43,8 +43,11 @@
 #include "jobs/network/kDrive_API/searchjob.h"
 #include "jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.h"
 #include "jobs/network/kDrive_API/listing/initfilelistwithcursorjob.h"
+#include "jobs/network/kDrive_API/listing/longpolljob.h"
 #include "jobs/network/kDrive_API/upload/uploadjob.h"
 #include "jobs/network/kDrive_API/upload/upload_session/driveuploadsession.h"
+
+#include "jobs/network/jobexceptions.h"
 
 #include "libcommonserver/keychainmanager/keychainmanager.h"
 #include "mocks/mockkeychainstorage.h"
@@ -1776,6 +1779,19 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
     }
 }
 
+void TestNetworkJobs::clearAccessTokenCache() {
+    // Clear the keychain key to test when there is no token in db/cache.
+    AbstractTokenNetworkJob::clearCache();
+
+    User user;
+    bool found = false;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectUser(_userDbId, user, found));
+    CPPUNIT_ASSERT(found);
+    user.setKeychainKey({});
+    CPPUNIT_ASSERT(ParmsDb::instance()->updateUser(user, found));
+    CPPUNIT_ASSERT(found);
+}
+
 void TestNetworkJobs::testGetInfoDriveOn401Error() {
     class GetInfoDriveJobMock final : public GetInfoDriveJob {
         public:
@@ -1791,16 +1807,9 @@ void TestNetworkJobs::testGetInfoDriveOn401Error() {
     const auto exitInfo = jobWithToken.runSynchronously();
     CPPUNIT_ASSERT_EQUAL(ExitCode::BackError, exitInfo.code());
     CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(exitInfo), ExitInfo(ExitCode::BackError, ExitCause::DriveAccessError), exitInfo);
-    AbstractTokenNetworkJob::clearCache();
 
-    // Clear the keychain key to test when there is no token in db/cache.
-    User user;
-    bool found = false;
-    CPPUNIT_ASSERT(ParmsDb::instance()->selectUser(_userDbId, user, found));
-    CPPUNIT_ASSERT(found);
-    user.setKeychainKey({});
-    CPPUNIT_ASSERT(ParmsDb::instance()->updateUser(user, found));
-    CPPUNIT_ASSERT(found);
+    clearAccessTokenCache();
+
     CPPUNIT_ASSERT_EQUAL(0, jobWithToken.trials());
 
     GetInfoDriveJobMock jobWithoutToken(_driveDbId);
@@ -1982,4 +1991,16 @@ void TestNetworkJobs::testPostFileModificationDate() {
     }
 }
 
+void TestNetworkJobs::testLongPollJobWithoutToken() {
+    LongPollJob jobWithToken(_driveDbId, "dummy_cursor_content");
+    const auto exitInfo = jobWithToken.runSynchronously();
+    CPPUNIT_ASSERT_EQUAL(ExitCode::BackError, exitInfo.code());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(exitInfo), ExitInfo(ExitCode::BackError, ExitCause::HttpErr), exitInfo);
+    AbstractTokenNetworkJob::clearCache();
+
+    clearAccessTokenCache();
+
+    CPPUNIT_ASSERT_THROW_MESSAGE("LongPollJob did not throw as expected", LongPollJob(_driveDbId, "dummy_cursor_content"),
+                                 EmptyTokenError);
+}
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -73,6 +73,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testExists);
         CPPUNIT_TEST(testGetAllFilesInDirectory);
         CPPUNIT_TEST(testPostFileModificationDate);
+        CPPUNIT_TEST(testLongPollJobWithoutToken);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -120,12 +121,15 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testExists();
         void testGetAllFilesInDirectory();
         void testPostFileModificationDate();
+        void testLongPollJobWithoutToken();
 
     private:
         bool createTestFiles();
 
         void testUpload(SyncTime creationTimeIn, SyncTime modificationTimeIn, SyncTime &creationTimeOut,
                         SyncTime &modificationTimeOut);
+
+        void clearAccessTokenCache();
 
         DriveDbId _driveDbId = 0;
         UserDbId _userDbId = 0;


### PR DESCRIPTION
This PR ensures that no `listing/longpoll` is sent if the access token is missing at the time of constructing the `LongPollJob` object.

This allows us to skip a useless request and write a clearer error message in the log of the server component when the token has been remotely revoked. 