### PR TITLE
feat(log-upload): Extract and upload extensions log

### DIFF
--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -787,4 +787,16 @@ ExitCause Utility::exitCauseFromInaccessibleSyncDirectory(const SyncPath &syncDi
     return ExitCause::SyncDirAccessError;
 }
 
+#if defined(KD_MACOS) || defined(KD_LINUX)
+std::string Utility::escapePath(const SyncPath &path) {
+    std::string escapedPath = path.string();
+    size_t pos = 0;
+    while ((pos = escapedPath.find('\'', pos)) != std::string::npos) {
+        (void) escapedPath.replace(pos, 1, "'\\''");
+        pos += 4;
+    }
+    return escapedPath;
+}
+#endif
+
 } // namespace KDC

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -152,6 +152,7 @@ struct COMMONSERVER_EXPORT Utility {
         static bool runDetachedProcess(std::wstring cmd);
 #endif
 #if defined(KD_MACOS) || defined(KD_LINUX)
+        static std::string escapePath(const SyncPath &path);
         static bool runCommand(const std::string &launchPath, const std::vector<std::string> &arguments = {});
 #endif
 

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.cpp
@@ -121,6 +121,7 @@ ExitInfo LogUploadJob::runJob() {
         return exitInfo;
     }
 
+
     if (const ExitInfo exitInfo = archive(_generatedArchivePath); !exitInfo) {
         LOG_WARN(Log::instance()->getLogger(), "Error in LogUploadJob::archive: " << exitInfo);
         handleJobFailure(exitInfo);
@@ -239,6 +240,8 @@ ExitInfo LogUploadJob::archive(SyncPath &generatedArchivePath) {
         LOG_WARN(Log::instance()->getLogger(), "Unable to generate user description file: " << exitInfo);
         return exitInfo;
     }
+
+    extractExtensionsLog();
 
     SyncName archiveName;
     if (const ExitInfo exitInfo = getArchiveName(archiveName); !exitInfo) {
@@ -420,10 +423,9 @@ ExitInfo LogUploadJob::generateUserDescriptionFile(const SyncPath &outputPath) c
         file << std::endl;
     } else {
         file << "Unable to retrieve drive ID(s)" << std::endl;
-        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllUsers");
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllDrives");
         _addErrorCallback(Error(ERR_ID, ExitCode::DbError, ExitCause::DbAccessError));
     }
-
 
     file.close();
     if (file.bad()) {
@@ -432,6 +434,18 @@ ExitInfo LogUploadJob::generateUserDescriptionFile(const SyncPath &outputPath) c
     }
 
     return ExitCode::Ok;
+}
+
+void LogUploadJob::extractExtensionsLog() const {
+    const SyncPath filePath = _tmpJobWorkingDir / "kdrive_extension_logs.txt";
+
+    // Properly escape the path to prevent shell injection
+    const auto escapedPath = Utility::escapePath(filePath);
+    const auto command = std::string("log show --predicate 'eventMessage BEGINSWITH \"[KD]\"' --last 24h > '") + escapedPath +
+                         std::string("'");
+    if (!Utility::runCommand("/bin/sh", {"-c", command})) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in Utility::runCommand to extract kDrive extension logs");
+    }
 }
 
 ExitInfo LogUploadJob::generateArchive(const SyncPath &directoryToCompress, const SyncPath &destPath,

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.cpp
@@ -241,7 +241,9 @@ ExitInfo LogUploadJob::archive(SyncPath &generatedArchivePath) {
         return exitInfo;
     }
 
+#if defined(KD_MACOS)
     extractExtensionsLog();
+#endif
 
     SyncName archiveName;
     if (const ExitInfo exitInfo = getArchiveName(archiveName); !exitInfo) {

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.cpp
@@ -436,6 +436,7 @@ ExitInfo LogUploadJob::generateUserDescriptionFile(const SyncPath &outputPath) c
     return ExitCode::Ok;
 }
 
+#if defined(KD_MACOS)
 void LogUploadJob::extractExtensionsLog() const {
     const SyncPath filePath = _tmpJobWorkingDir / "kdrive_extension_logs.txt";
 
@@ -447,6 +448,7 @@ void LogUploadJob::extractExtensionsLog() const {
         LOG_WARN(Log::instance()->getLogger(), "Error in Utility::runCommand to extract kDrive extension logs");
     }
 }
+#endif
 
 ExitInfo LogUploadJob::generateArchive(const SyncPath &directoryToCompress, const SyncPath &destPath,
                                        const SyncName &archiveNameWithoutExtension, SyncPath &finalPath) {

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.h
@@ -90,11 +90,12 @@ class LogUploadJob : public SyncJob, public std::enable_shared_from_this<LogUplo
          */
         ExitInfo generateUserDescriptionFile(const SyncPath &outputPath) const;
 
+#if defined(KD_MACOS)
         /*! Extracts the extensions log file from the system logs and copies it to the temporary job working directory.
          * Non blocking on error.
          */
         void extractExtensionsLog() const;
-
+#endif
 
         // Update the log upload state in the database (appstate table).
         void updateLogUploadState(LogUploadState newState) const;

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.h
@@ -90,6 +90,11 @@ class LogUploadJob : public SyncJob, public std::enable_shared_from_this<LogUplo
          */
         ExitInfo generateUserDescriptionFile(const SyncPath &outputPath) const;
 
+        /*! Extracts the extensions log file from the system logs and copies it to the temporary job working directory.
+         * Non blocking on error.
+         */
+        void extractExtensionsLog() const;
+
 
         // Update the log upload state in the database (appstate table).
         void updateLogUploadState(LogUploadState newState) const;

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/loguploadjob.h
@@ -94,7 +94,7 @@ class LogUploadJob : public SyncJob, public std::enable_shared_from_this<LogUplo
         /*! Extracts the extensions log file from the system logs and copies it to the temporary job working directory.
          * Non blocking on error.
          */
-        void extractExtensionsLog() const;
+        virtual void extractExtensionsLog() const;
 #endif
 
         // Update the log upload state in the database (appstate table).

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -547,4 +547,29 @@ void TestUtility::testTryCreateTmpFile() {
     }
 }
 
+#if defined(KD_MACOS) || defined(KD_LINUX)
+void TestUtility::testEscapePath() {
+    // Test simple path without special characters
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test"), Utility::escapePath(SyncPath("/tmp/test")));
+
+    // Test path with single quotes — each ' is replaced by '\'' (4 chars: quote, backslash, quote, quote)
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test'\\''file"), Utility::escapePath(SyncPath("/tmp/test'file")));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/'\\''quoted'\\''path"), Utility::escapePath(SyncPath("/tmp/'quoted'path")));
+
+    // Test path with multiple single quotes
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test'\\'''\\''file"), Utility::escapePath(SyncPath("/tmp/test''file")));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/'\\''test'\\''file'\\''path"), Utility::escapePath(SyncPath("/tmp/'test'file'path")));
+
+    // Test path with spaces and other characters (no quotes, so unchanged)
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test file"), Utility::escapePath(SyncPath("/tmp/test file")));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test;command"), Utility::escapePath(SyncPath("/tmp/test;command")));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test&command"), Utility::escapePath(SyncPath("/tmp/test&command")));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test|command"), Utility::escapePath(SyncPath("/tmp/test|command")));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test$(command)"), Utility::escapePath(SyncPath("/tmp/test$(command)")));
+
+    // Test path with quote followed by semicolon (injection attempt - quote gets escaped)
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/test'\\''; rm -rf /"), Utility::escapePath(SyncPath("/tmp/test'; rm -rf /")));
+}
+#endif
+
 } // namespace KDC

--- a/test/libcommonserver/utility/testutility.h
+++ b/test/libcommonserver/utility/testutility.h
@@ -52,6 +52,7 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testUserName);
         CPPUNIT_TEST(testTryCreateTmpDir);
         CPPUNIT_TEST(testTryCreateTmpFile);
+        CPPUNIT_TEST(testEscapePath);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -87,6 +88,7 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testUserName();
         void testTryCreateTmpDir();
         void testTryCreateTmpFile();
+        void testEscapePath();
 
     private:
         bool checkNfcAndNfdNamesEqual(const SyncName &name, bool &equal);

--- a/test/libcommonserver/utility/testutility.h
+++ b/test/libcommonserver/utility/testutility.h
@@ -52,7 +52,9 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testUserName);
         CPPUNIT_TEST(testTryCreateTmpDir);
         CPPUNIT_TEST(testTryCreateTmpFile);
+#if defined(KD_MACOS) || defined(KD_LINUX)
         CPPUNIT_TEST(testEscapePath);
+#endif
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -88,7 +90,9 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testUserName();
         void testTryCreateTmpDir();
         void testTryCreateTmpFile();
+#if defined(KD_MACOS) || defined(KD_LINUX)
         void testEscapePath();
+#endif
 
     private:
         bool checkNfcAndNfdNamesEqual(const SyncName &name, bool &equal);

--- a/test/mocks/libsyncengine/jobs/network/API_v2/mockloguploadjob.h
+++ b/test/mocks/libsyncengine/jobs/network/API_v2/mockloguploadjob.h
@@ -65,5 +65,9 @@ class MockLogUploadJob : public LogUploadJob {
         std::function<ExitInfo(SyncPath &generatedArchivePath)> _archive;
         std::function<ExitInfo(const SyncPath &archivePath)> _upload;
         std::function<void()> _finalize;
+
+        void extractExtensionsLog() const override {
+            // Do nothing in the mock since this can take a long time
+        }
 };
 } // namespace KDC

--- a/test/mocks/libsyncengine/jobs/network/API_v2/mockloguploadjob.h
+++ b/test/mocks/libsyncengine/jobs/network/API_v2/mockloguploadjob.h
@@ -66,8 +66,10 @@ class MockLogUploadJob : public LogUploadJob {
         std::function<ExitInfo(const SyncPath &archivePath)> _upload;
         std::function<void()> _finalize;
 
+#if defined(KD_MACOS)
         void extractExtensionsLog() const override {
             // Do nothing in the mock since this can take a long time
         }
+#endif
 };
 } // namespace KDC


### PR DESCRIPTION
## Summary

Extracts kDrive extension logs (macOS) and includes them in the support log archive uploaded to the server.

## Changes

### `LogUploadJob`
- Added `extractExtensionsLog()` which runs `log show --predicate 'eventMessage BEGINSWITH "[KD]"' --last 24h` and saves the output to `kdrive_extension_logs.txt` in the archive working directory.
- The method is called during the `archive()` step, after log files are copied.

### `Utility::escapePath()` (macOS / Linux)
- New static helper that escapes single-quotes in a filesystem path using the `'\''}` shell idiom, preventing command injection when the path is interpolated into a shell command string.

### Unit tests
- Added `TestUtility::testEscapePath()` covering:
  - Plain paths (no-op)
  - Paths with single quotes (one or multiple)
  - Paths with shell metacharacters (`;`, `&`, `|`, `$(...)`) — left untouched since only `'` is dangerous in a single-quoted context
  - Injection attempt: `/tmp/test'; rm -rf /`

## Security

Using `/bin/sh -c` is necessary here because the output redirection (`>`) requires a shell. `Utility::escapePath()` ensures the output path cannot break out of the surrounding single-quoted argument.