### PR TITLE
fix: reduce log verbosity

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
@@ -102,7 +102,7 @@ namespace Infomaniak.kDrive.Pages
             }
             catch (OperationCanceledException)
             {
-                Logger.Log(Logger.Level.Warning, "Authentication process canceled by user.");
+                Logger.Log(Logger.Level.Info, "Authentication process canceled by user.");
             }
             catch (Exception ex)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
@@ -401,7 +401,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         public CancelType? CancelType { get; set; }
         public bool? AutoResolved { get; set; }
 
-        public String toString()
+        public override String ToString()
         {
             return $"ErrorInfo: DbId={DbId}, Time={Time}, Level={Level}, SyncDbId={SyncDbId}, ExitCode={ExitCode}, ExitCause={ExitCause}, NodeType={NodeType}, Path={Path}, DestinationPath={DestinationPath}, LocalNodeId={LocalNodeId}, RemoteNodeId={RemoteNodeId}, ConflictType={ConflictType}, InconsistencyType={InconsistencyType}, CancelType={CancelType}, AutoResolved={AutoResolved}";
         }

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
@@ -400,6 +400,11 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         public InconsistencyType? InconsistencyType { get; set; }
         public CancelType? CancelType { get; set; }
         public bool? AutoResolved { get; set; }
+
+        public String toString()
+        {
+            return $"ErrorInfo: DbId={DbId}, Time={Time}, Level={Level}, SyncDbId={SyncDbId}, ExitCode={ExitCode}, ExitCause={ExitCause}, NodeType={NodeType}, Path={Path}, DestinationPath={DestinationPath}, LocalNodeId={LocalNodeId}, RemoteNodeId={RemoteNodeId}, ConflictType={ConflictType}, InconsistencyType={InconsistencyType}, CancelType={CancelType}, AutoResolved={AutoResolved}";
+        }
     }
 
     public static partial class ConversionHelper

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1417,12 +1417,12 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         }
                         else
                         {
-                            Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs, ErrorInfo: {errorInfo}");
+                            Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs, {errorInfo}");
                         }
                     }
                     else
                     {
-                        Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} has invalid SyncDbId {errorInfo.SyncDbId}, ErrorInfo: {errorInfo}.");
+                        Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} has invalid SyncDbId {errorInfo.SyncDbId}, {errorInfo}.");
                     }
                 }
             });

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1417,12 +1417,12 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         }
                         else
                         {
-                            Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs.");
+                            Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} references Sync with DbId {errorInfo.SyncDbId}, but it was not found among all Syncs, ErrorInfo: {errorInfo}");
                         }
                     }
                     else
                     {
-                        Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} has invalid SyncDbId {errorInfo.SyncDbId}.");
+                        Logger.Log(Logger.Level.Error, $"Error with DbId {errorInfo.DbId} has invalid SyncDbId {errorInfo.SyncDbId}, ErrorInfo: {errorInfo}.");
                     }
                 }
             });

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
@@ -417,7 +417,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     }
                     else
                     {
-                        Logger.Log(Logger.Level.Warning, $"Received reply for unknown request ID {data.Id}");
+                        Logger.Log(Logger.Level.Debug, $"Received reply for unknown request ID {data.Id}");
                     }
                     break;
                 case CommMessageType.Signal:

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
@@ -417,7 +417,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     }
                     else
                     {
-                        Logger.Log(Logger.Level.Debug, $"Received reply for unknown request ID {data.Id}");
+                        Logger.Log(Logger.Level.Debug, $"Received reply for unknown or canceled request ID {data.Id}");
                     }
                     break;
                 case CommMessageType.Signal:

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/NotificationManager.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/NotificationManager.cs
@@ -56,7 +56,7 @@ namespace Infomaniak.kDrive
         {
             if (Availability != AppNotificationAvailability.Available)
             {
-                Logger.Log(Logger.Level.Warning, $"App notifications are not available: {Availability} ({AppNotificationManager.Default.Setting})");
+                Logger.Log(Logger.Level.Info, $"App notifications are not available: {Availability} ({AppNotificationManager.Default.Setting})");
                 return;
             }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
@@ -170,7 +170,7 @@ namespace Infomaniak.kDrive.ViewModels
             catch (OperationCanceledException)
             {
                 CurrentOAuth2State = OAuth2State.Error;
-                Logger.Log(Logger.Level.Warning, "Authentication process canceled by user.");
+                Logger.Log(Logger.Level.Info, "Authentication process canceled by user.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This pull request focuses on improving logging clarity and debuggability throughout the codebase. The main changes include adjusting log levels for certain messages, enhancing error logs with more context, and adding a helpful `ToString` method to the `ErrorInfo` class.

**Logging Level Adjustments:**

* Changed log level from `Warning` to `Info` for messages about user-canceled authentication in both `LogginErrorPage.xaml.cs` and `Onboarding.cs` to reduce unnecessary warning noise. [[1]](diffhunk://#diff-630e08923fe493135fda867a52c80cf184701fc3f3d2ab3fd9005fd0e8e5fe25L105-R105) [[2]](diffhunk://#diff-00b407ff6db4c395a06cada1b357885ca967bdfff34742b9c8b611c03888846cL173-R173)
* Changed log level from `Warning` to `Info` for unavailable app notification messages in `NotificationManager.cs`.
* Changed log level from `Warning` to `Debug` for replies to unknown or canceled request IDs in `TcpServerCommClient.cs`, making the logs less noisy in production.

**Error Logging Improvements:**

* Enhanced error logs in `ServerCommService.cs` to include the full `ErrorInfo` object, providing more context for debugging sync errors.

**Codebase Enhancements:**

* Added an override of `ToString()` to the `ErrorInfo` class, which outputs all relevant fields, making it easier to log and inspect error details.