### PR TITLE
fix(sync-local-delete-job): Let the canRun method return ExitCode::System instead of ExitCode::DataError when the item to delete is not found on disk

### DIFF
--- a/src/libsyncengine/jobs/local/synclocaldeletejob.cpp
+++ b/src/libsyncengine/jobs/local/synclocaldeletejob.cpp
@@ -133,7 +133,7 @@ ExitInfo SyncLocalDeleteJob::canRun() {
 
     if (!exists) {
         LOGW_DEBUG(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(absoluteLocalPath()));
-        return {ExitCode::DataError, ExitCause::NotFound};
+        return {ExitCode::SystemError, ExitCause::NotFound};
     }
 
     if (_remoteNodeId.empty()) {

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -42,7 +42,7 @@ namespace KDC {
 class LocalDeleteJobMockingTrash : public SyncLocalDeleteJob {
     public:
         explicit LocalDeleteJobMockingTrash(const std::shared_ptr<SyncPal> syncPal, const SyncPath &absolutePath) :
-            SyncLocalDeleteJob(syncPal, absolutePath) {};
+            SyncLocalDeleteJob(syncPal, absolutePath){};
         void setMoveToTrashFailed(const bool failed) { _moveToTrashFailed = failed; };
         void setLiteSyncEnabled(const bool enabled) { _liteSyncIsEnabled = enabled; };
         void setMockMoveToTrash(const bool mocked) { _moveToTrashIsMocked = mocked; }
@@ -270,7 +270,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         public:
             LocalDeleteJobMock(const std::shared_ptr<SyncPal> syncPal, const SyncPath &relativePath, const bool isLiteSyncEnabled,
                                RemoteNodeId remoteNodeId, ForceToTrash forceToTrash = ForceToTrash::No) :
-                SyncLocalDeleteJob(syncPal, relativePath, isLiteSyncEnabled, std::move(remoteNodeId), forceToTrash) {
+                SyncLocalDeleteJob(syncPal, relativePath, isLiteSyncEnabled, std::move(remoteNodeId), forceToTrash){
 
                 };
             void setRemoteItemRelativePath(const SyncPath &remoteItemPath) { _remoteItemRelativePath = remoteItemPath; }
@@ -286,6 +286,13 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
 
     const bool liteSyncIsEnabled = false;
     _syncPal->_syncInfo.targetPath = SyncPath{}; // Standard synchronisation.
+
+    // The local file does not exist: cannot run, returns ExitCode::SystemError and ExitCause::NotFound
+    {
+        LocalDeleteJobMock deleteJob(_syncPal, "non-existing-file.txt", liteSyncIsEnabled, NodeId{});
+        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::SystemError, ExitCause::NotFound), deleteJob.canRun());
+    }
+
 
     _syncPal->setLocalPath(temporaryDirectory.path());
     {


### PR DESCRIPTION
When `SyncLocalDeleteJob` returns ` {ExitCode::SystemError, ExitCause::NotFound}` instead of 
`{ExitCode::DataError, ExitCause::NotFound}`, the synchronization continues even if the item to delete is not found on disk.

This behavior is desirable since it does not interrupt the propagation step, allowing thus more synchronization progress.  This is why this PR implements such a change.