### PR TITLE
feat(sentry): wire Qt logs to Sentry breadcrumbs and runtime tags

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -295,6 +295,9 @@
 - `app/services/parametersservice.*`: targeted facade for application settings updates. It starts from the confirmed
   `ParametersStore` snapshot, sends the full `PARAMETERS_UPDATE` payload, and updates the store only after server
   confirmation.
+- `app/services/sentryservice.*`: Linux v4 Sentry coordinator. It reconciles cached and server-confirmed consent,
+  publishes normalized Linux/Qt runtime tags after the GUI application exists, and refreshes the distribution channel
+  from the confirmed `ParametersStore` snapshot.
 - `app/services/syncservice.*`: targeted sync use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
 - `ui/`: QML shell, product windows, design tokens, reusable components, and bundled UI assets such as tray icons and

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -160,7 +160,8 @@
 
 ## Current Structure
 
-- `main.cpp`: process entry point + single-instance lock file.
+- `main.cpp`: process entry point, single-instance lock file, and Linux-v4 opt-in for forwarding Qt logs to Sentry
+  breadcrumbs.
 - `appclientlinux.*`: top-level app wiring (logging, QML warning forwarding, IPC lifecycle,
   dispatcher/service/coordinator ownership).
 - `app/appconstants.h`: app-level non-translatable constants, mirroring the Windows `AppConstants` role where useful.
@@ -191,7 +192,8 @@
 - `app/services/serviceeventbus.*`: shared high-level service event hub (single UI subscription point for generic
   cross-service failures). Owned once by `AppClientLinux` and injected by reference into app services.
 - `app/services/sentryservice.*`: Linux v4 Sentry coordinator. Owns cached consent reconciliation, delayed
-  linux-v4-specific Sentry initialization, authenticated user binding, and UI/process capture helpers.
+  linux-v4-specific Sentry initialization, authenticated user binding, and UI/process capture helpers. Qt log
+  breadcrumbs use the shared `Logger` bridge and remain inert whenever this service has not activated Sentry.
 - `app/cache/appcache.*`: graph-backed cache (`AppCache` QObject) - owns configured users/accounts/drives/syncs, the
   single volatile runtime snapshot for each sync, split sync/server errors, per-user available drives, cascade removals,
   and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.

--- a/src/gui4/linux/app/services/sentryservice.cpp
+++ b/src/gui4/linux/app/services/sentryservice.cpp
@@ -23,12 +23,16 @@
 #include "app/services/parametersservice.h"
 #include "config.h"
 #include "libcommon/log/sentry/handler.h"
+#include "libcommon/utility/utility.h"
 
+#include <QGuiApplication>
 #include <QLoggingCategory>
 #include <QSettings>
 
 #include <algorithm>
 #include <cstdlib>
+
+using namespace Qt::StringLiterals;
 
 namespace {
 
@@ -37,6 +41,30 @@ Q_LOGGING_CATEGORY(lcSentryService, "gui.v4.sentry", QtInfoMsg)
 constexpr char settingsOrganization[] = "Infomaniak";
 constexpr char settingsApplication[] = APPLICATION_NAME;
 constexpr char sentryConsentKey[] = "sentry/enabled";
+
+QString normalizedDisplayServer(const QString &platformPlugin) {
+    if (platformPlugin.contains(QStringLiteral("wayland"), Qt::CaseInsensitive)) {
+        return QStringLiteral("wayland");
+    }
+    if (platformPlugin.compare(QStringLiteral("xcb"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("x11");
+    }
+    return QStringLiteral("unknown");
+}
+
+QString normalizedDesktopEnvironment(const QString &desktopEnvironment) {
+    const QString normalized = desktopEnvironment.toLower();
+    if (normalized.contains(QStringLiteral("gnome"))) return QStringLiteral("gnome");
+    if (normalized.contains(QStringLiteral("kde")) || normalized.contains(QStringLiteral("plasma"))) {
+        return QStringLiteral("kde");
+    }
+    if (normalized.contains(QStringLiteral("cinnamon"))) return QStringLiteral("cinnamon");
+    if (normalized.contains(QStringLiteral("xfce"))) return QStringLiteral("xfce");
+    if (normalized.contains(QStringLiteral("mate"))) return QStringLiteral("mate");
+    if (normalized.contains(QStringLiteral("lxqt"))) return QStringLiteral("lxqt");
+    if (normalized.contains(QStringLiteral("lxde"))) return QStringLiteral("lxde");
+    return normalized.isEmpty() ? QStringLiteral("unknown") : QStringLiteral("other");
+}
 } // namespace
 
 namespace KDC {
@@ -49,6 +77,7 @@ SentryService::SentryService(ParametersService &parametersService, AppCache &app
     _parametersStore(parametersStore) {
     (void) connect(&_parametersStore, &ParametersStore::parametersInfoChanged, this,
                    &SentryService::reconcileConsentWithParametersStore);
+    updateLinuxRuntimeTags();
 }
 
 std::optional<bool> SentryService::readCachedConsent() {
@@ -89,6 +118,7 @@ void SentryService::initializeWithLinuxConfig() {
     if (sentry::Handler::isInitialized()) {
         qCInfo(lcSentryService) << "Sentry already initialized; activating handler";
         sentry::Handler::instance()->setIsSentryActivated(true);
+        updateLinuxRuntimeTags();
         return;
     }
 
@@ -102,7 +132,25 @@ void SentryService::initializeWithLinuxConfig() {
 
     sentry::Handler::instance()->setGlobalConfidentialityLevel(sentry::ConfidentialityLevel::Authenticated);
     sentry::Handler::instance()->setIsSentryActivated(true);
+    updateLinuxRuntimeTags();
     qCInfo(lcSentryService) << "Sentry initialized and activated";
+}
+
+void SentryService::updateLinuxRuntimeTags() {
+    if (!isInitialized() || qobject_cast<QGuiApplication *>(QCoreApplication::instance()) == nullptr) {
+        return;
+    }
+
+    const QString platformPlugin = QGuiApplication::platformName().toLower();
+    const QString desktopEnvironment = qEnvironmentVariable("XDG_CURRENT_DESKTOP");
+    const auto handler = sentry::Handler::instance();
+    handler->setTag("linux.distribution", CommonUtility::platformName().toStdString());
+    handler->setTag("linux.distribution_version", CommonUtility::osVersion());
+    handler->setTag("os.display_server", normalizedDisplayServer(platformPlugin).toStdString());
+    handler->setTag("os.desktop", normalizedDesktopEnvironment(desktopEnvironment).toStdString());
+    handler->setTag("os.packaging", qEnvironmentVariable("APPIMAGE").isEmpty() ? "other" : "appimage");
+    handler->setTag("runtime.qt_version", qVersion());
+    handler->setTag("qt.platform_plugin", platformPlugin.toStdString());
 }
 
 bool SentryService::isInitialized() {
@@ -227,6 +275,9 @@ void SentryService::reconcileConsentWithParametersStore() {
                             << currentParametersInfo->sentryEnabled();
     writeCachedConsent(currentParametersInfo->sentryEnabled());
     applyConsent(currentParametersInfo->sentryEnabled());
+    if (isInitialized()) {
+        sentry::Handler::instance()->setDistributionChannel(currentParametersInfo->distributionChannel());
+    }
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/sentryservice.cpp
+++ b/src/gui4/linux/app/services/sentryservice.cpp
@@ -149,7 +149,7 @@ void SentryService::updateLinuxRuntimeTags() {
     handler->setTag("os.display_server", normalizedDisplayServer(platformPlugin).toStdString());
     handler->setTag("os.desktop", normalizedDesktopEnvironment(desktopEnvironment).toStdString());
     handler->setTag("os.packaging", qEnvironmentVariable("APPIMAGE").isEmpty() ? "other" : "appimage");
-    handler->setTag("runtime.qt_version", qVersion());
+    handler->setTag("qt.version", qVersion());
     handler->setTag("qt.platform_plugin", platformPlugin.toStdString());
 }
 

--- a/src/gui4/linux/app/services/sentryservice.h
+++ b/src/gui4/linux/app/services/sentryservice.h
@@ -33,7 +33,8 @@ class ParametersStore;
 /**
  * Linux v4 Sentry coordinator.
  *
- * Role: own Linux v4 Sentry consent reconciliation, delayed initialization, user identity, and UI/process capture helpers.
+ * Role: own Linux v4 Sentry consent reconciliation, delayed initialization, runtime context, user identity, and UI/process
+ * capture helpers.
  * Non-role: decide server-side persistence; the server remains the source of truth for ParametersInfo.
  */
 class SentryService final : public QObject {
@@ -60,6 +61,7 @@ class SentryService final : public QObject {
         void updateAuthenticatedUser() const;
 
     private:
+        static void updateLinuxRuntimeTags();
         void reconcileConsentWithParametersStore();
         void applyConsent(bool enabled);
 

--- a/src/gui4/linux/main.cpp
+++ b/src/gui4/linux/main.cpp
@@ -26,6 +26,7 @@
 
 int main(int argc, char *argv[]) {
     KDC::Logger::installEarlyMessageHandler();
+    KDC::Logger::setSentryBreadcrumbsEnabled(true);
 
     KDC::CommonUtility::_workingDirPath = KDC::SyncPath(argv[0]).parent_path();
     KDC::CommonUtility::initAppImageEnvironment();

--- a/src/libcommon/log/sentry/handler.h
+++ b/src/libcommon/log/sentry/handler.h
@@ -110,6 +110,7 @@ class Handler {
 
         void setDistributionChannel(DistributionChannel channel);
         void setAppUUID(std::string appUUID);
+        void setTag(const std::string &key, const std::string &value);
         void setIsSentryActivated(bool isSentryActivated);
 
         // Returns the file path where non-crash events of type `appType` are written locally.
@@ -143,7 +144,6 @@ class Handler {
         sentry::ConfidentialityLevel _globalConfidentialityLevel = sentry::ConfidentialityLevel::Anonymous; // Default value
         sentry::ConfidentialityLevel _lastConfidentialityLevel = sentry::ConfidentialityLevel::None;
 
-        void setTag(const std::string &key, const std::string &value);
         void removeTag(const std::string &key) { sentry_remove_tag(key.c_str()); }
         // Convert a `SentryUser` structure to a `sentry_value_t` that can safely be passed to
         // `sentry_set_user(sentry_value_t)`

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -47,8 +47,6 @@ constexpr char logMessagePattern[] =
         "[%{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}] "
         "(%{threadid}) %{file}:%{line} - %{message}";
 
-static std::atomic_bool sentryBreadcrumbsEnabled{false};
-
 namespace KDC {
 
 static int8_t logLevelForMessageType(const QtMsgType type) noexcept {
@@ -117,7 +115,7 @@ static QString formatSentryBreadcrumb(const QMessageLogContext &ctx, const QStri
 }
 
 static void addSentryBreadcrumb(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
-    if (!sentryBreadcrumbsEnabled.load(std::memory_order_relaxed)) {
+    if (!Logger::sentryBreadcrumbsEnabled()) {
         return;
     }
 
@@ -189,7 +187,7 @@ void Logger::installEarlyMessageHandler() {
 }
 
 void Logger::setSentryBreadcrumbsEnabled(const bool enabled) {
-    sentryBreadcrumbsEnabled.store(enabled, std::memory_order_relaxed);
+    _sentryBreadcrumbsEnabled.store(enabled, std::memory_order_relaxed);
 }
 
 Logger::Logger(QObject *parent) :

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -116,20 +116,31 @@ static QString formatSentryBreadcrumb(const QMessageLogContext &ctx, const QStri
     return QStringLiteral("%1:%2 - %3").arg(fileNameString).arg(ctx.line).arg(message);
 }
 
-static void addSentryBreadcrumb(const QtMsgType type, const QString &breadcrumbMessage) {
+static void addSentryBreadcrumb(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
     if (!sentryBreadcrumbsEnabled.load(std::memory_order_relaxed)) {
         return;
     }
 
-    const std::string message = breadcrumbMessage.toStdString();
-    const sentry_value_t breadcrumb = sentry_value_new_breadcrumb(nullptr, message.c_str());
+    const std::string breadcrumbMessage = formatSentryBreadcrumb(ctx, message).toStdString();
+    const sentry_value_t breadcrumb = sentry_value_new_breadcrumb("default", breadcrumbMessage.c_str());
     (void) sentry_value_set_by_key(breadcrumb, "level", sentry_value_new_string(sentryLevelForMessageType(type)));
+
+    if (ctx.category != nullptr) {
+        static const auto guiV4Prefix = QStringLiteral("gui.v4.");
+        QString category = QString::fromUtf8(ctx.category);
+        if (category.startsWith(guiV4Prefix)) {
+            category.remove(0, guiV4Prefix.size());
+        }
+        const std::string breadcrumbCategory = category.toStdString();
+        (void) sentry_value_set_by_key(breadcrumb, "category", sentry_value_new_string(breadcrumbCategory.c_str()));
+    }
+
     sentry_add_breadcrumb(breadcrumb);
 }
 
 static void earlyLogCatcher(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
     const QString formattedMessage = formatLogMessageWithShortFile(type, ctx, message);
-    addSentryBreadcrumb(type, formatSentryBreadcrumb(ctx, message));
+    addSentryBreadcrumb(type, ctx, message);
     if (CommonUtility::logToConsoleEnabled()) {
         std::cerr << qPrintable(formattedMessage) << '\n';
     }
@@ -138,7 +149,7 @@ static void earlyLogCatcher(const QtMsgType type, const QMessageLogContext &ctx,
 static void kdriveLogCatcher(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
     auto *const logger = Logger::instance();
     const QString formattedMessage = formatLogMessageWithShortFile(type, ctx, message);
-    addSentryBreadcrumb(type, formatSentryBreadcrumb(ctx, message));
+    addSentryBreadcrumb(type, ctx, message);
 
     if (logLevelForMessageType(type) < logger->minLogLevel()) {
         return;

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -20,12 +20,15 @@
 #include "config.h"
 #include "libcommon/utility/utility.h"
 
+#include <sentry.h>
+
 #include <QDir>
 #include <QLoggingCategory>
 #include <QRegularExpression>
 #include <QStringList>
 #include <QThread>
 
+#include <atomic>
 #include <cstdint>
 #include <iostream>
 
@@ -43,6 +46,8 @@ constexpr char logMessagePattern[] =
         "%{time yyyy-MM-dd hh:mm:ss:zzz} "
         "[%{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}] "
         "(%{threadid}) %{file}:%{line} - %{message}";
+
+static std::atomic_bool sentryBreadcrumbsEnabled{false};
 
 namespace KDC {
 
@@ -63,9 +68,26 @@ static int8_t logLevelForMessageType(const QtMsgType type) noexcept {
     Q_UNREACHABLE();
 }
 
+static const char *sentryLevelForMessageType(const QtMsgType type) noexcept {
+    switch (type) {
+        case QtDebugMsg:
+            return "debug";
+        case QtInfoMsg:
+            return "info";
+        case QtWarningMsg:
+            return "warning";
+        case QtCriticalMsg:
+            return "error";
+        case QtFatalMsg:
+            return "fatal";
+    }
+
+    Q_UNREACHABLE();
+}
+
 static QString formatLogMessageWithShortFile(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
     SyncName fileName;
-    if (ctx.file) {
+    if (ctx.file != nullptr) {
         const SyncPath filePath(ctx.file);
         fileName = filePath.filename();
     }
@@ -80,20 +102,52 @@ static QString formatLogMessageWithShortFile(const QtMsgType type, const QMessag
     return qFormatLogMessage(type, ctxNew, message);
 }
 
-static void earlyLogCatcher(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
-    std::cerr << qPrintable(formatLogMessageWithShortFile(type, ctx, message)) << std::endl;
+static QString formatSentryBreadcrumb(const QMessageLogContext &ctx, const QString &message) {
+    if (ctx.file == nullptr) {
+        return message;
+    }
+
+    const SyncName fileName = SyncPath(ctx.file).filename();
+#if defined(KD_WINDOWS)
+    const QString fileNameString = QString::fromStdString(CommonUtility::toUnsafeStr(fileName));
+#else
+    const QString fileNameString = QString::fromStdString(fileName);
+#endif
+    return QStringLiteral("%1:%2 - %3").arg(fileNameString).arg(ctx.line).arg(message);
 }
 
-static void kdriveLogCatcher(QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
-    const auto logger = Logger::instance();
+static void addSentryBreadcrumb(const QtMsgType type, const QString &breadcrumbMessage) {
+    if (!sentryBreadcrumbsEnabled.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    const std::string message = breadcrumbMessage.toStdString();
+    const sentry_value_t breadcrumb = sentry_value_new_breadcrumb(nullptr, message.c_str());
+    (void) sentry_value_set_by_key(breadcrumb, "level", sentry_value_new_string(sentryLevelForMessageType(type)));
+    sentry_add_breadcrumb(breadcrumb);
+}
+
+static void earlyLogCatcher(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
+    const QString formattedMessage = formatLogMessageWithShortFile(type, ctx, message);
+    addSentryBreadcrumb(type, formatSentryBreadcrumb(ctx, message));
+    if (CommonUtility::logToConsoleEnabled()) {
+        std::cerr << qPrintable(formattedMessage) << '\n';
+    }
+}
+
+static void kdriveLogCatcher(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
+    auto *const logger = Logger::instance();
+    const QString formattedMessage = formatLogMessageWithShortFile(type, ctx, message);
+    addSentryBreadcrumb(type, formatSentryBreadcrumb(ctx, message));
+
     if (logLevelForMessageType(type) < logger->minLogLevel()) {
         return;
     }
 
     if (!logger->isNoop()) {
-        logger->doLog(formatLogMessageWithShortFile(type, ctx, message));
+        logger->doLog(formattedMessage);
     } else if (type >= QtCriticalMsg) {
-        std::cerr << qPrintable(formatLogMessageWithShortFile(type, ctx, message)) << std::endl;
+        std::cerr << qPrintable(formattedMessage) << '\n';
     }
 
 #if defined(Q_OS_WIN)
@@ -121,6 +175,10 @@ void Logger::installEarlyMessageHandler() {
 #else
     Q_UNUSED(earlyLogCatcher)
 #endif
+}
+
+void Logger::setSentryBreadcrumbsEnabled(const bool enabled) {
+    sentryBreadcrumbsEnabled.store(enabled, std::memory_order_relaxed);
 }
 
 Logger::Logger(QObject *parent) :

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -129,7 +129,7 @@ static void addSentryBreadcrumb(const QtMsgType type, const QMessageLogContext &
         static const auto guiV4Prefix = QStringLiteral("gui.v4.");
         QString category = QString::fromUtf8(ctx.category);
         if (category.startsWith(guiV4Prefix)) {
-            category.remove(0, guiV4Prefix.size());
+            (void) category.remove(0, guiV4Prefix.size());
         }
         const std::string breadcrumbCategory = category.toStdString();
         (void) sentry_value_set_by_key(breadcrumb, "category", sentry_value_new_string(breadcrumbCategory.c_str()));

--- a/src/libcommongui/logger.h
+++ b/src/libcommongui/logger.h
@@ -27,6 +27,7 @@
 #include <QMutex>
 #include <QTimer>
 
+#include <atomic>
 #include <chrono>
 
 namespace KDC {
@@ -56,6 +57,7 @@ class Logger : public QObject {
         static void installMessagePattern();
         static void installEarlyMessageHandler();
         static void setSentryBreadcrumbsEnabled(bool enabled);
+        static bool sentryBreadcrumbsEnabled() { return _sentryBreadcrumbsEnabled.load(std::memory_order_relaxed); }
 
         void postNotification(const QString &title, const QString &message);
 
@@ -107,6 +109,7 @@ class Logger : public QObject {
         int _minLogLevel;
         QTimer _watchLogSizeTimer;
         bool _isClientLog = false;
+        inline static std::atomic_bool _sentryBreadcrumbsEnabled{false};
 };
 
 } // namespace KDC

--- a/src/libcommongui/logger.h
+++ b/src/libcommongui/logger.h
@@ -55,6 +55,7 @@ class Logger : public QObject {
         static Logger *instance();
         static void installMessagePattern();
         static void installEarlyMessageHandler();
+        static void setSentryBreadcrumbsEnabled(bool enabled);
 
         void postNotification(const QString &title, const QString &message);
 


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR branche les messages de log Qt/QML sur les breadcrumbs Sentry et enrichit les événements Sentry du client Linux v4 avec des tags de contexte runtime (distribution, environnement de bureau, serveur d'affichage, packaging, version de Qt), afin de faciliter le diagnostic des rapports d'erreur.

## Changements
- Ajout de `Logger::setSentryBreadcrumbsEnabled` (flag atomique statique) pour activer/désactiver le transfert des logs Qt vers les breadcrumbs Sentry ; activé sans condition dans le `main.cpp` du client Linux v4.
- Les gestionnaires de logs `earlyLogCatcher` et `kdriveLogCatcher` (`logger.cpp`) formatent désormais chaque ligne de log en breadcrumb Sentry (niveau converti via `sentryLevelForMessageType`, message au format `fichier:ligne - message`, catégorie débarrassée du préfixe `gui.v4.`) ; ce comportement reste inerte tant que les breadcrumbs sont désactivés ou que Sentry n'est pas activé.
- Le repli console de `earlyLogCatcher` est désormais conditionné par `CommonUtility::logToConsoleEnabled()` au lieu d'écrire systématiquement sur `std::cerr`.
- La méthode `sentry::Handler::setTag` passe de privée à publique afin que des appelants externes (comme `SentryService`) puissent publier leurs propres tags.
- Ajout de `SentryService::updateLinuxRuntimeTags()`, appelée à la construction du service puis après (ré)activation de Sentry, pour publier les tags runtime Linux/Qt normalisés : `linux.distribution`, `linux.distribution_version`, `os.display_server` (wayland/x11/unknown), `os.desktop` (gnome/kde/cinnamon/xfce/mate/lxqt/lxde/other/unknown), `os.packaging` (appimage/other), `qt.version` et `qt.platform_plugin`.
- Le canal de distribution Sentry est désormais rafraîchi depuis le snapshot confirmé du `ParametersStore` à chaque réconciliation du consentement.
- Mise à jour de `src/gui4/linux/AGENTS.md` pour refléter le nouveau rôle de pont breadcrumbs de `main.cpp` et le rôle élargi de publication de tags runtime de `SentryService`.

## Détails techniques
Le tag `qt.version` a été renommé depuis `runtime.qt_version` en cours de développement, par cohérence avec les autres tags préfixés `qt.*`. `updateLinuxRuntimeTags()` ne s'exécute que si Sentry est initialisé et qu'une `QGuiApplication` existe (nécessaire pour lire `platformName()`), ce qui la rend sûre à appeler avant toute initialisation complète de l'UI.

</details>

---

## Summary
This PR wires Qt/QML log messages into Sentry breadcrumbs and enriches Sentry events on the Linux v4 client with runtime context tags (distribution, desktop environment, display server, packaging, Qt version), to make error reports easier to diagnose.

## Changes
- Add `Logger::setSentryBreadcrumbsEnabled` (a static atomic flag) to toggle forwarding of Qt log messages to Sentry breadcrumbs; enabled unconditionally in the Linux v4 `main.cpp`.
- `earlyLogCatcher` and `kdriveLogCatcher` in `logger.cpp` now format every log line into a Sentry breadcrumb (level mapped via `sentryLevelForMessageType`, message formatted as `file:line - message`, category stripped of the `gui.v4.` prefix); this stays inert whenever breadcrumbs are disabled or Sentry has not been activated.
- The stderr fallback in `earlyLogCatcher` is now gated behind `CommonUtility::logToConsoleEnabled()` instead of always printing to `std::cerr`.
- Promote `sentry::Handler::setTag` from private to public so callers outside the handler (such as `SentryService`) can publish custom tags.
- Add `SentryService::updateLinuxRuntimeTags()`, invoked at construction and after Sentry (re)activation, to publish normalized Linux/Qt runtime tags: `linux.distribution`, `linux.distribution_version`, `os.display_server` (wayland/x11/unknown), `os.desktop` (gnome/kde/cinnamon/xfce/mate/lxqt/lxde/other/unknown), `os.packaging` (appimage/other), and `qt.version`/`qt.platform_plugin`.
- Refresh the Sentry distribution channel from the confirmed `ParametersStore` snapshot whenever consent is reconciled.
- Update `src/gui4/linux/AGENTS.md` to document the new breadcrumb-bridging role of `main.cpp` and the expanded runtime-tag-publishing role of `SentryService`.

## Technical Details
The `qt.version` tag was renamed from `runtime.qt_version` during development, for consistency with the other `qt.*`-prefixed tags. `updateLinuxRuntimeTags()` only runs when Sentry is initialized and a `QGuiApplication` instance exists (required to read `platformName()`), making it safe to call before the UI is fully initialized.