### PR TITLE
fix(updater): bring Sparkle windows to the foreground

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -230,7 +230,7 @@ void AppServer::init() {
 #if defined(KD_MACOS)
     // Qt emits ApplicationActive when macOS asks an already running application to reopen.
     connect(this, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state) {
-        if (state == Qt::ApplicationActive) showSynthesis();
+        if (state == Qt::ApplicationActive && (!_updateManager || !_updateManager->isUpdateSessionInProgress())) showSynthesis();
     });
 #endif
 

--- a/src/server/updater/abstractupdater.h
+++ b/src/server/updater/abstractupdater.h
@@ -58,6 +58,7 @@ class AbstractUpdater {
         virtual void onUpdateFound() = 0;
         virtual void setQuitCallback(const std::function<void()> & /*quitCallback*/) { /* Redefined in child class if necessary */
         }
+        [[nodiscard]] virtual bool isUpdateSessionInProgress() const { return false; }
         void setStateChangeCallback(const std::function<void(UpdateState)> &stateChangeCallback);
 
         static void skipVersion(const std::string &skippedVersion);

--- a/src/server/updater/sparkleupdater.h
+++ b/src/server/updater/sparkleupdater.h
@@ -31,6 +31,7 @@ class SparkleUpdater final : public AbstractUpdater {
 
         void setQuitCallback(const std::function<void()> &quitCallback) override;
         void startInstaller() override;
+        [[nodiscard]] bool isUpdateSessionInProgress() const override;
 
         void unskipVersion() override;
 

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -232,8 +232,7 @@ void SparkleUpdater::startInstaller() {
         LOG_WARN(KDC::Log::instance()->getLogger(), "Initialization error!");
         return;
     }
-    [d->updater checkForUpdatesInBackground];
-    [d->spuStandardUserDriver showUpdateInFocus];
+    [d->updater checkForUpdates];
 }
 
 void SparkleUpdater::unskipVersion() {

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -232,7 +232,8 @@ void SparkleUpdater::startInstaller() {
         LOG_WARN(KDC::Log::instance()->getLogger(), "Initialization error!");
         return;
     }
-    [d->updater checkForUpdates];
+    [d->updater checkForUpdatesInBackground];
+    [d->spuStandardUserDriver showUpdateInFocus];
 }
 
 void SparkleUpdater::unskipVersion() {

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -236,6 +236,10 @@ void SparkleUpdater::startInstaller() {
     [d->spuStandardUserDriver showUpdateInFocus];
 }
 
+bool SparkleUpdater::isUpdateSessionInProgress() const {
+    return d->updater && [d->updater sessionInProgress];
+}
+
 void SparkleUpdater::unskipVersion() {
     AbstractUpdater::unskipVersion();
 

--- a/src/server/updater/updatemanager.h
+++ b/src/server/updater/updatemanager.h
@@ -52,6 +52,7 @@ class UpdateManager final : public QObject {
         void forceRefresh() const { slotTimerFired(); }
         void startInstaller() const;
         void setQuitCallback(const std::function<void()> &quitCallback) const { _updater->setQuitCallback(quitCallback); }
+        [[nodiscard]] bool isUpdateSessionInProgress() const { return _updater->isUpdateSessionInProgress(); }
 
         std::unique_ptr<AbstractUpdater> &updater() { return _updater; }
 


### PR DESCRIPTION
## Summary

Fixes a macOS focus issue where clicking a Sparkle updater window immediately brought the kDrive Swift GUI back to the foreground.

This PR prevents the server from asking the Swift GUI to activate while Sparkle owns an active update session.

## Root Cause

Sparkle is hosted by the server process, while the macOS v4 interface runs in the separate `kDrive.gui` process.

When the user clicked a Sparkle window:

1. macOS activated the server process that owns the Sparkle UI.
2. `AppServer` observed `Qt::ApplicationActive`.
3. The server treated every activation as a request to reopen kDrive and emitted `UTILITY_SHOW_SYNTHESIS`.
4. The Swift GUI received that signal and activated its main window with `orderFrontRegardless()`.
5. The Swift GUI therefore immediately covered the Sparkle window the user had clicked.

## Changes

- Added `AbstractUpdater::isUpdateSessionInProgress()` with a default `false` implementation so non-macOS updater implementations retain their existing behavior.

- Implemented the method in `SparkleUpdater` using Sparkle’s public `sessionInProgress` property.

- Exposed the state through `UpdateManager`.

- Updated the macOS server activation handler to only request that the GUI show its main window when no Sparkle update session is active.

## Result

During an active Sparkle update session, clicking the updater UI activates the process that owns it without emitting `UTILITY_SHOW_SYNTHESIS`. The Swift GUI no longer steals foreground focus, allowing the user to interact with the Sparkle window normally.

Outside an active Sparkle session, reopening kDrive retains the existing behavior and still brings the Swift GUI to the front.

## Validation

- Formatted the touched files with Xcode’s `clang-format`.
- Ran `git diff --check`.
- Built the `updater` target successfully.
- Built the production `kDrive` server target successfully.
- Manual validation still required: start an update with the Swift GUI visible, click the Sparkle update window, and confirm it remains frontmost.