### PR TITLE
fix(updater): dispatch Sparkle UI calls on main thread to prevent crash

### DIFF
--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -237,7 +237,7 @@ void SparkleUpdater::startInstaller() {
         return;
     }
 
-    if ([d->updater sessionInProgress]) {
+    if ([d->updater sessionInProgress] && [d->updater canCheckForUpdates]) {
         LOG_INFO(KDC::Log::instance()->getLogger(), "An update session is already in progress, bringing it to focus.");
         [d->spuStandardUserDriver showUpdateInFocus];
         return;

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -226,14 +226,30 @@ void SparkleUpdater::setQuitCallback(const std::function<void()> &quitCallback) 
 }
 
 void SparkleUpdater::startInstaller() {
-    reset(versionInfo().downloadUrl);
+    // Sparkle and AppKit require all UI operations on the main thread.
+    if (!NSThread.isMainThread) {
+        dispatch_sync(dispatch_get_main_queue(), ^{ startInstaller(); });
+        return;
+    }
 
     if (!d->updater || !d->spuStandardUserDriver) {
         LOG_WARN(KDC::Log::instance()->getLogger(), "Initialization error!");
         return;
     }
+
+    if ([d->updater sessionInProgress]) {
+        LOG_INFO(KDC::Log::instance()->getLogger(), "An update session is already in progress, bringing it to focus.");
+        [d->spuStandardUserDriver showUpdateInFocus];
+        return;
+    }
+
+    reset(versionInfo().downloadUrl);
+
+    if (!d->updater || !d->spuStandardUserDriver) {
+        LOG_WARN(KDC::Log::instance()->getLogger(), "Initialization error after reset!");
+        return;
+    }
     [d->updater checkForUpdatesInBackground];
-    [d->spuStandardUserDriver showUpdateInFocus];
 }
 
 bool SparkleUpdater::isUpdateSessionInProgress() const {


### PR DESCRIPTION
## Problem

When the user clicked the "Update" button a second time after an update had already been proposed, the app crashed inside `SparkleUpdater::startInstaller()` and `SparkleUpdater::reset()`.

The root cause was a **thread-safety violation**: `startInstaller()` is invoked from a Poco thread pool (`UpdaterStartInstallerJob`), but Sparkle and AppKit require all UI-related operations to run on the **main thread**. Calls such as `dismissUpdateInstallation`, `showUpdateInFocus`, and `checkForUpdatesInBackground` were executed on a background thread, triggering an `assert` inside Sparkle and ultimately an `abort`.

Relevant crash stack:
```
-[SPUStandardUserDriver dismissUpdateInstallation].cold.1
-[SPUStandardUserDriver dismissUpdateInstallation]
KDC::SparkleUpdater::reset(const std::string &)
KDC::SparkleUpdater::startInstaller()
KDC::UpdaterStartInstallerJob::process()
Poco::PooledThread::run()
```

## Fix

Two minimal changes to `sparkleupdater.mm`:

### 1. Enforce main thread in `startInstaller()`
A guard at the top of the function redirects execution to the main thread via `dispatch_sync` when called from a background thread. This ensures that all subsequent Sparkle/AppKit calls in the function — and in `reset()` — are always executed on the correct thread.

```objc
if (!NSThread.isMainThread) {
    dispatch_sync(dispatch_get_main_queue(), ^{ startInstaller(); });
    return;
}
```

### 2. Avoid unnecessary `reset()` when a session is already in progress
If Sparkle already has an active update session (e.g. the update window is open), calling `reset()` would needlessly tear down and recreate the updater. Instead, the existing session is simply brought back to focus via `showUpdateInFocus`.

```objc
if ([d->updater sessionInProgress]) {
    [d->spuStandardUserDriver showUpdateInFocus];
    return;
}
```

## Testing

Verified manually: clicking "Update" multiple times no longer crashes. The existing update window is correctly brought to the foreground on subsequent clicks.