### PR TITLE
feat(onboarding): add default path and blacklist to pending sync config

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -249,7 +249,8 @@
   and the configured Home. Closing onboarding or removing the last configured sync selects the unconfigured Home on the
   next activation.
 - `app/cache/onboardingstate.*`: session-owned onboarding selected user, selected available-drive keys, and pending sync
-  configs.
+  configs. Advanced-settings validation replaces the complete selected-drive config map atomically so cancelling a
+  modal never leaks a partially edited drive.
 - `app/cache/parametersstore.*`: process-wide cache for server-owned application parameters (`ParametersInfo`). It is
   populated during the bootstrap sequence next to the product graph snapshot, but remains separate from `AppCache`
   because the server is still the persistence source of truth for application settings. It stores only the last
@@ -277,8 +278,9 @@
   controller, OAuth service, comm service, user service, app cache, and onboarding state so `AppClientLinux` does not
   accumulate login-specific workflow logic.
 - `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It
-  derives collision-free local folders, creates selected-drive syncs sequentially at the remote root, preserves only
-  failed and not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a failed `SYNC_ADD`.
+  derives collision-free local folders, creates selected-drive syncs sequentially with the validated remote blacklist,
+  preserves only failed and not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a
+  failed `SYNC_ADD`.
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.

--- a/src/gui4/linux/app/cache/cachetypes.h
+++ b/src/gui4/linux/app/cache/cachetypes.h
@@ -105,8 +105,11 @@ struct AvailableDriveContext {
 
 struct PendingSyncConfig {
         QString localPath;
+        QString defaultLocalPath;
         QString targetPath;
         QString targetNodeId;
+        std::vector<NodeId> blackList;
+        bool usesDefaultLocalPath{true};
         bool supportVfs{false};
         VirtualFileMode virtualFileMode{VirtualFileMode::Off};
 };

--- a/src/gui4/linux/app/cache/onboardingstate.cpp
+++ b/src/gui4/linux/app/cache/onboardingstate.cpp
@@ -19,6 +19,7 @@
 #include "onboardingstate.h"
 
 #include <algorithm>
+#include <ranges>
 
 Q_LOGGING_CATEGORY(lcOnboardingState, "gui.v4.onboardingstate", QtInfoMsg)
 
@@ -85,7 +86,8 @@ void OnboardingState::clearSelectedUser() {
 
 void OnboardingState::selectAvailableDrive(const AvailableDriveKey &key) {
     if (!belongsToSelectedUser(key)) {
-        qCWarning(lcOnboardingState) << "Drive select ignored: key does not belong to selected user | userDbId:" << key.userDbId << "/ selectedUserDbId:" << _selectedUserDbId;
+        qCWarning(lcOnboardingState) << "Drive select ignored: key does not belong to selected user | userDbId:" << key.userDbId
+                                     << "/ selectedUserDbId:" << _selectedUserDbId;
         return;
     }
     if (!_selectedAvailableDriveKeys.insert(key).second) {
@@ -124,11 +126,32 @@ void OnboardingState::clearSelectedAvailableDrives() {
 
 void OnboardingState::setPendingSyncConfig(const AvailableDriveKey &key, const PendingSyncConfig &config) {
     if (!belongsToSelectedUser(key) || !isAvailableDriveSelected(key)) {
-        qCWarning(lcOnboardingState) << "Pending sync config ignored: drive not selected or wrong user | userDbId:" << key.userDbId << "/ driveId:" << key.driveId;
+        qCWarning(lcOnboardingState) << "Pending sync config ignored: drive not selected or wrong user | userDbId:"
+                                     << key.userDbId << "/ driveId:" << key.driveId;
         return;
     }
     _pendingSyncConfigs[key] = config;
     emit pendingSyncConfigsChanged();
+}
+
+bool OnboardingState::replacePendingSyncConfigs(const std::unordered_map<AvailableDriveKey, PendingSyncConfig> &configs) {
+    if (configs.size() != _selectedAvailableDriveKeys.size()) {
+        qCWarning(lcOnboardingState) << "Pending sync configs replacement ignored: incomplete selected-drive map | configs:"
+                                     << configs.size() << "/ selected drives:" << _selectedAvailableDriveKeys.size();
+        return false;
+    }
+    for (const auto &key: configs | std::views::keys) {
+        if (!belongsToSelectedUser(key) || !isAvailableDriveSelected(key)) {
+            qCWarning(lcOnboardingState)
+                    << "Pending sync configs replacement ignored: drive not selected or wrong user | userDbId:" << key.userDbId
+                    << "/ driveId:" << key.driveId;
+            return false;
+        }
+    }
+
+    _pendingSyncConfigs = configs;
+    emit pendingSyncConfigsChanged();
+    return true;
 }
 
 void OnboardingState::clearPendingSyncConfig(const AvailableDriveKey &key) {
@@ -176,7 +199,8 @@ void OnboardingState::pruneSelectedAvailableDrives() {
             ++it;
             continue;
         }
-        qCDebug(lcOnboardingState) << "Selected drive pruned (no longer available) | userDbId:" << it->userDbId << "/ driveId:" << it->driveId;
+        qCDebug(lcOnboardingState) << "Selected drive pruned (no longer available) | userDbId:" << it->userDbId
+                                   << "/ driveId:" << it->driveId;
         pendingConfigsChanged = _pendingSyncConfigs.erase(*it) > 0 || pendingConfigsChanged;
         it = _selectedAvailableDriveKeys.erase(it);
         selectionChanged = true;

--- a/src/gui4/linux/app/cache/onboardingstate.h
+++ b/src/gui4/linux/app/cache/onboardingstate.h
@@ -60,6 +60,7 @@ class OnboardingState : public QObject {
         void toggleAvailableDrive(const AvailableDriveKey &key);
         void clearSelectedAvailableDrives();
         void setPendingSyncConfig(const AvailableDriveKey &key, const PendingSyncConfig &config);
+        [[nodiscard]] bool replacePendingSyncConfigs(const std::unordered_map<AvailableDriveKey, PendingSyncConfig> &configs);
         void clearPendingSyncConfig(const AvailableDriveKey &key);
         void reset();
 

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -97,8 +97,7 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
 
     const auto driveName = availableDrive->name();
     qCInfo(lcOnboardingSyncCreationCoordinator)
-            << "Requesting onboarding sync path | driveId:" << key.driveId
-            << "/ driveName:" << QString::fromStdString(driveName);
+            << "Requesting onboarding sync path | driveId:" << key.driveId << "/ driveName:" << QString::fromStdString(driveName);
     const QPointer<OnboardingSyncCreationCoordinator> self(this);
     _commService.requestFindGoodPathForNewSync(CommonUtility::str2CommString(driveName),
                                                [self, key](const ExitInfo &exitInfo, const GoodPathResult &result) {
@@ -128,6 +127,7 @@ void OnboardingSyncCreationCoordinator::handleGoodPathResult(const AvailableDriv
 
     PendingSyncConfig config;
     config.localPath = Path2QStr(result.goodPath);
+    config.defaultLocalPath = config.localPath;
     if (config.localPath.isEmpty()) {
         qCWarning(lcOnboardingSyncCreationCoordinator)
                 << "Server returned an empty onboarding sync path | driveId:" << key.driveId;
@@ -156,6 +156,7 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
     request.serverFolderPath = QStr2Path(config.targetPath);
     request.serverFolderNodeId = QStr2Str(config.targetNodeId);
     request.liteSync = false;
+    request.blackList = config.blackList;
 
     qCInfo(lcOnboardingSyncCreationCoordinator)
             << "Creating onboarding sync | driveId:" << key.driveId << "/ localPath:" << config.localPath;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR est la **base d'une pile de 8 PRs** qui découpe une fonctionnalité plus large : la configuration de synchronisation avancée dans l'onboarding Linux v4 (choix d'un dossier local personnalisé par kDrive, et sélection des dossiers distants à synchroniser).

## Changements
- `PendingSyncConfig` gagne trois champs : `defaultLocalPath`, `blackList` et `usesDefaultLocalPath`, afin que l'onboarding puisse distinguer l'état produit des chaînes d'affichage (le dossier par défaut reste connu même après qu'un utilisateur en choisit un personnalisé).
- Ajout de `OnboardingState::replacePendingSyncConfigs()` : remplace la map complète des configs des drives sélectionnés en une seule opération atomique, en rejetant toute map incomplète ou tout drive non sélectionné / appartenant à un autre utilisateur. Retourne un `[[nodiscard]] bool` pour que l'appelant sache si le commit a été refusé. Objectif : la validation des paramètres avancés doit committer tous les drives d'un coup, pour qu'annuler la modale ne puisse jamais laisser fuiter un drive partiellement modifié.
- `OnboardingSyncCreationCoordinator` renseigne désormais `defaultLocalPath` lors de la préparation d'une synchronisation, et surtout copie `config.blackList` dans `SyncAddRequest`. Sans ce changement, la sélection de dossiers d'un utilisateur n'atteindrait jamais le serveur.

## Détails techniques
- `replacePendingSyncConfigs()` n'a **aucun appelant dans cette PR**. Son consommateur est le contrôleur de configuration de synchronisation, quatre branches plus haut dans la pile. C'est une conséquence délibérée du découpage, pas du code mort laissé par erreur.
- Trois reformatages sans rapport avec la fonctionnalité sont inclus : `clang-format` a reformaté trois lignes de log trop longues (dans `selectAvailableDrive()`, `pruneSelectedAvailableDrives()`, `prepareSynchronization()`) qui n'étaient déjà pas conformes avant ce travail. Elles ont été conservées car le dépôt exige que `clang-format` soit appliqué sur les fichiers touchés ; les retirer aurait laissé les fichiers non conformes.

</details>

---

## Summary
This is the **base PR of a planned stack of 8** that splits a larger feature: advanced synchronization configuration in the Linux v4 onboarding (choosing a custom local folder per kDrive, and selecting which remote folders to sync).

## Changes
- `PendingSyncConfig` gains three fields: `defaultLocalPath`, `blackList`, and `usesDefaultLocalPath`, so onboarding can tell product state apart from display strings (the default folder stays known even after the user picks a custom one).
- New `OnboardingState::replacePendingSyncConfigs()`: replaces the whole selected-drive config map in one atomic operation, rejecting any incomplete map or any drive that is not selected / belongs to another user. Returns `[[nodiscard]] bool` so a caller knows the commit was refused. Rationale: advanced-settings validation must commit all drives at once, so cancelling the modal can never leak a partially edited drive.
- `OnboardingSyncCreationCoordinator` now fills `defaultLocalPath` when preparing a sync, and, importantly, copies `config.blackList` into `SyncAddRequest`. Without this, a user's folder selection would never reach the server.

## Technical Details
- `replacePendingSyncConfigs()` has no caller in this PR. Its consumer is the sync-configuration controller, four branches higher in the stack. This is a deliberate consequence of the split, not dead code left by accident.
- Three unrelated reformattings are included: `clang-format` reflowed three over-long log lines (in `selectAvailableDrive()`, `pruneSelectedAvailableDrives()`, `prepareSynchronization()`) that were already non-conformant before this work. They were kept because the repo requires clang-format on touched files; removing them would leave the files non-conformant.
