### PR TITLE
fix(onboarding): add keyboard focus and accessibility support

### DIFF
--- a/src/gui4/linux/ui/tokens/IKOnboarding.qml
+++ b/src/gui4/linux/ui/tokens/IKOnboarding.qml
@@ -90,6 +90,8 @@ QtObject {
     readonly property real driveSelectionCellSpacing: IKSpacing.s8
     readonly property real driveSelectionCellMinHeight: 40
     readonly property real driveSelectionCheckboxSize: 16
+    readonly property real buttonFocusBorderWidth: 2
+    readonly property real driveSelectionCellFocusBorderWidth: 2
     readonly property real driveSelectionDriveIconSize: 20
     readonly property real driveSelectionDriveIconRadius: 5
     readonly property real driveSelectionDriveIconGlyphInset: 4

--- a/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
@@ -60,6 +60,8 @@ AbstractButton {
     Accessible.description: root.accountName
     Accessible.checkable: root.cellEnabled
     Accessible.checked: root.checked
+    // Assistive technologies invoke either action depending on how they read the cell, so both reach the model.
+    Accessible.onPressAction: root.requestToggle()
     Accessible.onToggleAction: root.requestToggle()
 
     HoverHandler {

--- a/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
@@ -21,27 +21,30 @@ import QtQuick.Controls
 import QtQuick.Shapes
 import kDrive.UI
 
-Item {
+// A drive is picked with the keyboard as well as with the mouse, so the cell is a control rather than a decorated
+// mouse target: AbstractButton then handles Space, the focus on click, and the focus ring below through `visualFocus`.
+// It stays non-checkable on purpose, because the checked state belongs to the model and a click would overwrite it.
+AbstractButton {
     id: root
 
     property int row: -1
     property string driveName: ""
     property string accountName: ""
     property color driveColor: IKColors.driveDefaultColor
-    property bool checked: false
     property bool cellEnabled: true
     property string disabledTooltip: ""
 
-    signal toggled(int row)
+    // Named apart from AbstractButton's own `toggled()`, which a same-named signal would invalidly override.
+    signal toggleRequested(int row)
 
-    function toggleFromKeyboard(): void {
+    function requestToggle(): void {
         if (root.cellEnabled) {
-            root.toggled(root.row)
+            root.toggleRequested(root.row)
         }
     }
 
     function driveNameContainsMouse() {
-        const point = cellMouseArea.mapToItem(driveNameText, cellMouseArea.mouseX, cellMouseArea.mouseY)
+        const point = root.mapToItem(driveNameText, cellHover.point.position.x, cellHover.point.position.y)
         return point.x >= 0 && point.x <= driveNameText.width && point.y >= 0 && point.y <= driveNameText.height
     }
 
@@ -49,22 +52,26 @@ Item {
     implicitHeight: Math.max(IKOnboarding.driveSelectionCellMinHeight,
                              contentRow.implicitHeight + IKOnboarding.driveSelectionCellPadding * 2)
 
-    // A drive is picked with the keyboard as well as with the mouse: the cell is a checkable control, not a
-    // decorated mouse target.
-    activeFocusOnTab: root.cellEnabled
+    focusPolicy: root.cellEnabled ? Qt.StrongFocus : Qt.NoFocus
+    onClicked: root.requestToggle()
+
     Accessible.role: Accessible.CheckBox
     Accessible.name: root.driveName
     Accessible.description: root.accountName
     Accessible.checkable: root.cellEnabled
     Accessible.checked: root.checked
-    Keys.onSpacePressed: root.toggleFromKeyboard()
-    Keys.onReturnPressed: root.toggleFromKeyboard()
-    Keys.onEnterPressed: root.toggleFromKeyboard()
+    Accessible.onToggleAction: root.requestToggle()
+
+    HoverHandler {
+        id: cellHover
+
+        cursorShape: root.cellEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+    }
 
     Rectangle {
         anchors.fill: parent
         radius: IKOnboarding.driveSelectionCellRadius
-        color: cellMouseArea.containsMouse && root.cellEnabled
+        color: cellHover.hovered && root.cellEnabled
                ? IKColors.surfaceSecondary
                : IKColors.onboardingDriveCellSurface
         opacity: root.cellEnabled ? 1 : 0.5
@@ -146,24 +153,11 @@ Item {
         }
     }
 
-    MouseArea {
-        id: cellMouseArea
-
-        anchors.fill: parent
-        hoverEnabled: true
-        cursorShape: root.cellEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-        onClicked: {
-            if (root.cellEnabled) {
-                root.forceActiveFocus(Qt.MouseFocusReason)
-                root.toggled(root.row)
-            }
-        }
-    }
-
-    // Drawn above the cell content so the focus ring stays visible over the hover and selection fills.
+    // Drawn above the cell content so the focus ring stays visible over the hover and selection fills. It follows
+    // `visualFocus`, so it appears for keyboard navigation only and stays hidden when the cell is clicked.
     Rectangle {
         anchors.fill: parent
-        visible: root.activeFocus
+        visible: root.visualFocus
         radius: IKOnboarding.driveSelectionCellRadius
         color: "transparent"
         border.width: IKOnboarding.driveSelectionCellFocusBorderWidth
@@ -171,7 +165,7 @@ Item {
     }
 
     IKToolTip {
-        visible: root.cellEnabled && cellMouseArea.containsMouse && root.driveNameContainsMouse() && driveNameText.truncated
+        visible: root.cellEnabled && cellHover.hovered && root.driveNameContainsMouse() && driveNameText.truncated
         delay: IKOnboarding.driveSelectionTooltipDelay
         text: root.driveName
         padding: IKOnboarding.driveSelectionTooltipPadding
@@ -182,7 +176,7 @@ Item {
     }
 
     IKToolTip {
-        visible: !root.cellEnabled && cellMouseArea.containsMouse && root.disabledTooltip.length > 0
+        visible: !root.cellEnabled && cellHover.hovered && root.disabledTooltip.length > 0
         delay: IKOnboarding.driveSelectionTooltipDelay
         text: root.disabledTooltip
         padding: IKOnboarding.driveSelectionTooltipPadding

--- a/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
@@ -43,11 +43,6 @@ AbstractButton {
         }
     }
 
-    function driveNameContainsMouse() {
-        const point = root.mapToItem(driveNameText, cellHover.point.position.x, cellHover.point.position.y)
-        return point.x >= 0 && point.x <= driveNameText.width && point.y >= 0 && point.y <= driveNameText.height
-    }
-
     implicitWidth: IKOnboarding.driveSelectionListWidth
     implicitHeight: Math.max(IKOnboarding.driveSelectionCellMinHeight,
                              contentRow.implicitHeight + IKOnboarding.driveSelectionCellPadding * 2)
@@ -140,6 +135,21 @@ AbstractButton {
                 lineHeightMode: Text.FixedHeight
                 lineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
                 elide: Text.ElideRight
+
+                HoverHandler {
+                    id: driveNameHover
+                }
+
+                IKToolTip {
+                    visible: root.cellEnabled && driveNameHover.hovered && driveNameText.truncated
+                    delay: IKOnboarding.driveSelectionTooltipDelay
+                    text: root.driveName
+                    padding: IKOnboarding.driveSelectionTooltipPadding
+                    maximumTextWidth: IKOnboarding.driveSelectionTooltipMaxWidth
+                    foregroundColor: IKColors.onboardingTooltipText
+                    surfaceColor: IKColors.onboardingTooltipSurface
+                    textLineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
+                }
             }
 
             Text {
@@ -164,17 +174,6 @@ AbstractButton {
         color: "transparent"
         border.width: IKOnboarding.driveSelectionCellFocusBorderWidth
         border.color: IKColors.accentPrimary
-    }
-
-    IKToolTip {
-        visible: root.cellEnabled && cellHover.hovered && root.driveNameContainsMouse() && driveNameText.truncated
-        delay: IKOnboarding.driveSelectionTooltipDelay
-        text: root.driveName
-        padding: IKOnboarding.driveSelectionTooltipPadding
-        maximumTextWidth: IKOnboarding.driveSelectionTooltipMaxWidth
-        foregroundColor: IKColors.onboardingTooltipText
-        surfaceColor: IKColors.onboardingTooltipSurface
-        textLineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
     }
 
     IKToolTip {

--- a/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveCellView.qml
@@ -34,6 +34,12 @@ Item {
 
     signal toggled(int row)
 
+    function toggleFromKeyboard(): void {
+        if (root.cellEnabled) {
+            root.toggled(root.row)
+        }
+    }
+
     function driveNameContainsMouse() {
         const point = cellMouseArea.mapToItem(driveNameText, cellMouseArea.mouseX, cellMouseArea.mouseY)
         return point.x >= 0 && point.x <= driveNameText.width && point.y >= 0 && point.y <= driveNameText.height
@@ -42,6 +48,18 @@ Item {
     implicitWidth: IKOnboarding.driveSelectionListWidth
     implicitHeight: Math.max(IKOnboarding.driveSelectionCellMinHeight,
                              contentRow.implicitHeight + IKOnboarding.driveSelectionCellPadding * 2)
+
+    // A drive is picked with the keyboard as well as with the mouse: the cell is a checkable control, not a
+    // decorated mouse target.
+    activeFocusOnTab: root.cellEnabled
+    Accessible.role: Accessible.CheckBox
+    Accessible.name: root.driveName
+    Accessible.description: root.accountName
+    Accessible.checkable: root.cellEnabled
+    Accessible.checked: root.checked
+    Keys.onSpacePressed: root.toggleFromKeyboard()
+    Keys.onReturnPressed: root.toggleFromKeyboard()
+    Keys.onEnterPressed: root.toggleFromKeyboard()
 
     Rectangle {
         anchors.fill: parent
@@ -136,9 +154,20 @@ Item {
         cursorShape: root.cellEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
         onClicked: {
             if (root.cellEnabled) {
+                root.forceActiveFocus(Qt.MouseFocusReason)
                 root.toggled(root.row)
             }
         }
+    }
+
+    // Drawn above the cell content so the focus ring stays visible over the hover and selection fills.
+    Rectangle {
+        anchors.fill: parent
+        visible: root.activeFocus
+        radius: IKOnboarding.driveSelectionCellRadius
+        color: "transparent"
+        border.width: IKOnboarding.driveSelectionCellFocusBorderWidth
+        border.color: IKColors.accentPrimary
     }
 
     IKToolTip {

--- a/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
@@ -122,6 +122,8 @@ Item {
                     implicitHeight: IKOnboarding.driveSelectionButtonHeight
                     radius: IKOnboarding.buttonCornerRadius
                     color: IKColors.actionPrimary
+                    border.width: retryButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                    border.color: IKColors.actionOnPrimary
                 }
 
                 padding: 0
@@ -229,6 +231,8 @@ Item {
                         implicitHeight: IKOnboarding.driveSelectionButtonHeight
                         radius: IKOnboarding.buttonCornerRadius
                         color: continueButton.enabled ? IKColors.actionPrimary : IKColors.actionDisabled
+                        border.width: continueButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                        border.color: IKColors.actionOnPrimary
                     }
 
                     padding: 0

--- a/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
@@ -219,7 +219,7 @@ Item {
 
                     contentItem: Text {
                         text: continueButton.text
-                        color: continueButton.enabled ? IKColors.actionOnPrimary : IKColors.actionDisabled
+                        color: IKColors.actionOnPrimary
                         font.pixelSize: IKFonts.bodySize
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter

--- a/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
@@ -48,5 +48,11 @@ ListView {
         cellEnabled: model.enabled
         disabledTooltip: model.tooltip
         onToggled: row => root.drivesModel.toggleDrive(row)
+        // Tabbing to a cell that sits below the visible part of the list has to bring it into view.
+        onActiveFocusChanged: {
+            if (activeFocus) {
+                root.positionViewAtIndex(index, ListView.Contain)
+            }
+        }
     }
 }

--- a/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
@@ -47,7 +47,7 @@ ListView {
         checked: model.selected
         cellEnabled: model.enabled
         disabledTooltip: model.tooltip
-        onToggled: row => root.drivesModel.toggleDrive(row)
+        onToggleRequested: row => root.drivesModel.toggleDrive(row)
         // Tabbing to a cell that sits below the visible part of the list has to bring it into view.
         onActiveFocusChanged: {
             if (activeFocus) {

--- a/src/gui4/linux/ui/windows/onboarding/LoginView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/LoginView.qml
@@ -129,7 +129,7 @@ Item {
 
                 contentItem: Text {
                     text: loginButton.text
-                    color: loginButton.enabled ? IKColors.actionOnPrimary : IKColors.actionDisabled
+                    color: IKColors.actionOnPrimary
                     font.pixelSize: IKFonts.bodySize
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter

--- a/src/gui4/linux/ui/windows/onboarding/LoginView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/LoginView.qml
@@ -25,7 +25,7 @@ Item {
 
     // The step opens on its main action so keyboard users start somewhere instead of from nothing.
     Component.onCompleted: Qt.callLater(function() {
-        loginButton.forceActiveFocus(Qt.TabFocusReason)
+        loginButton.forceActiveFocus()
     })
 
     required property var onboardingFlowController

--- a/src/gui4/linux/ui/windows/onboarding/LoginView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/LoginView.qml
@@ -25,7 +25,7 @@ Item {
 
     // The step opens on its main action so keyboard users start somewhere instead of from nothing.
     Component.onCompleted: Qt.callLater(function() {
-        loginButton.forceActiveFocus()
+        loginButton.forceActiveFocus(Qt.TabFocusReason)
     })
 
     required property var onboardingFlowController

--- a/src/gui4/linux/ui/windows/onboarding/LoginView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/LoginView.qml
@@ -23,6 +23,11 @@ import kDrive.UI
 Item {
     id: root
 
+    // The step opens on its main action so keyboard users start somewhere instead of from nothing.
+    Component.onCompleted: Qt.callLater(function() {
+        loginButton.forceActiveFocus()
+    })
+
     required property var onboardingFlowController
 
     readonly property bool compact: width < IKOnboarding.loginCompactBreakpointWidth
@@ -103,6 +108,8 @@ Item {
                     implicitHeight: IKOnboarding.loginButtonHeight
                     radius: IKOnboarding.loginButtonCornerRadius
                     color: "transparent"
+                    border.width: createAccountButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                    border.color: IKColors.accentPrimary
                 }
 
                 padding: 0
@@ -134,6 +141,8 @@ Item {
                     implicitHeight: IKOnboarding.loginButtonHeight
                     radius: IKOnboarding.loginButtonCornerRadius
                     color: loginButton.enabled ? IKColors.actionPrimary : IKColors.actionDisabled
+                    border.width: loginButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                    border.color: IKColors.actionOnPrimary
                 }
 
                 padding: 0

--- a/src/gui4/linux/ui/windows/onboarding/NoDriveAvailableView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/NoDriveAvailableView.qml
@@ -23,6 +23,11 @@ import kDrive.UI
 Column {
     id: root
 
+    // The step opens on its main action so keyboard users start somewhere instead of from nothing.
+    Component.onCompleted: Qt.callLater(function() {
+        startForFreeButton.forceActiveFocus()
+    })
+
     required property var selectionController
 
     width: parent ? parent.width : IKOnboarding.driveSelectionContentMaxWidth
@@ -78,6 +83,8 @@ Column {
                 implicitHeight: IKOnboarding.driveSelectionButtonHeight
                 radius: IKOnboarding.buttonCornerRadius
                 color: "transparent"
+                border.width: showOffersButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                border.color: IKColors.accentPrimary
             }
 
             padding: 0
@@ -108,6 +115,8 @@ Column {
                 implicitHeight: IKOnboarding.driveSelectionButtonHeight
                 radius: IKOnboarding.buttonCornerRadius
                 color: IKColors.actionPrimary
+                border.width: startForFreeButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                border.color: IKColors.actionOnPrimary
             }
 
             padding: 0

--- a/src/gui4/linux/ui/windows/onboarding/NoDriveAvailableView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/NoDriveAvailableView.qml
@@ -27,7 +27,7 @@ Column {
     // appears. Taking it on completion would leave the focus on a hidden button, which still receives key events.
     onVisibleChanged: {
         if (visible) {
-            startForFreeButton.forceActiveFocus(Qt.TabFocusReason)
+            startForFreeButton.forceActiveFocus()
         }
     }
 

--- a/src/gui4/linux/ui/windows/onboarding/NoDriveAvailableView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/NoDriveAvailableView.qml
@@ -23,10 +23,13 @@ import kDrive.UI
 Column {
     id: root
 
-    // The step opens on its main action so keyboard users start somewhere instead of from nothing.
-    Component.onCompleted: Qt.callLater(function() {
-        startForFreeButton.forceActiveFocus()
-    })
+    // The view is always instantiated and only its visibility is bound, so it claims the focus when it actually
+    // appears. Taking it on completion would leave the focus on a hidden button, which still receives key events.
+    onVisibleChanged: {
+        if (visible) {
+            startForFreeButton.forceActiveFocus(Qt.TabFocusReason)
+        }
+    }
 
     required property var selectionController
 

--- a/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
@@ -25,7 +25,7 @@ Item {
 
     // The step opens on its main action so keyboard users start somewhere instead of from nothing.
     Component.onCompleted: Qt.callLater(function() {
-        openButton.forceActiveFocus(Qt.TabFocusReason)
+        openButton.forceActiveFocus()
     })
 
     required property var onboardingFlowController

--- a/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
@@ -75,7 +75,7 @@ Item {
 
             contentItem: Text {
                 text: openButton.text
-                color: openButton.enabled ? IKColors.actionOnPrimary : IKColors.actionDisabled
+                color: IKColors.actionOnPrimary
                 font.pixelSize: IKFonts.bodySize
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter

--- a/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
@@ -25,7 +25,7 @@ Item {
 
     // The step opens on its main action so keyboard users start somewhere instead of from nothing.
     Component.onCompleted: Qt.callLater(function() {
-        openButton.forceActiveFocus()
+        openButton.forceActiveFocus(Qt.TabFocusReason)
     })
 
     required property var onboardingFlowController

--- a/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/ReadyView.qml
@@ -23,6 +23,11 @@ import kDrive.UI
 Item {
     id: root
 
+    // The step opens on its main action so keyboard users start somewhere instead of from nothing.
+    Component.onCompleted: Qt.callLater(function() {
+        openButton.forceActiveFocus()
+    })
+
     required property var onboardingFlowController
 
     readonly property bool compact: width < IKOnboarding.completionCompactBreakpointWidth
@@ -82,6 +87,8 @@ Item {
                 implicitHeight: IKOnboarding.completionButtonHeight
                 radius: IKOnboarding.buttonCornerRadius
                 color: openButton.enabled ? IKColors.actionPrimary : IKColors.actionDisabled
+                border.width: openButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                border.color: IKColors.actionOnPrimary
             }
 
             padding: 0

--- a/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
@@ -70,6 +70,12 @@ Item {
             id: retryButton
 
             visible: root.onboardingFlowController.synchronizationFailed
+            // Retry only exists once the synchronization failed, so it claims the focus when it appears.
+            onVisibleChanged: {
+                if (visible) {
+                    retryButton.forceActiveFocus()
+                }
+            }
             height: IKOnboarding.completionButtonHeight
             text: qsTrId("buttonRetry")
             onClicked: root.onboardingFlowController.retrySynchronization()
@@ -88,6 +94,8 @@ Item {
                 implicitHeight: IKOnboarding.completionButtonHeight
                 radius: IKOnboarding.buttonCornerRadius
                 color: IKColors.actionPrimary
+                border.width: retryButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                border.color: IKColors.actionOnPrimary
             }
 
             padding: 0

--- a/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
@@ -73,7 +73,7 @@ Item {
             // Retry only exists once the synchronization failed, so it claims the focus when it appears.
             onVisibleChanged: {
                 if (visible) {
-                    retryButton.forceActiveFocus()
+                    retryButton.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
             height: IKOnboarding.completionButtonHeight

--- a/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
@@ -73,7 +73,7 @@ Item {
             // Retry only exists once the synchronization failed, so it claims the focus when it appears.
             onVisibleChanged: {
                 if (visible) {
-                    retryButton.forceActiveFocus(Qt.TabFocusReason)
+                    retryButton.forceActiveFocus()
                 }
             }
             height: IKOnboarding.completionButtonHeight


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR est la **2e PR de la pile de 8**. Elle ne fait **pas** partie de la fonctionnalité de configuration de synchronisation avancée : elle corrige l'accessibilité clavier préexistante de l'onboarding Linux v4, qui n'en avait aucune. 

## Changements
- **Sélectionner un kDrive était impossible au clavier.** `DriveCellView` était un `Item` recouvert par une `MouseArea`, qui ne prend jamais le focus clavier et ne porte aucun rôle d'accessibilité : la cellule n'existait ni pour Tab ni pour un lecteur d'écran. C'est désormais un vrai contrôle cochable : `activeFocusOnTab`, `Accessible.role: CheckBox` avec nom/description/checkable/checked, et Espace/Retour/Entrée pour basculer l'état. L'anneau de focus est dessiné au-dessus du contenu de la cellule, sinon les fonds de survol et de sélection le recouvrent. Un clic appelle aussi `forceActiveFocus(Qt.MouseFocusReason)` pour que la navigation clavier reprenne là où la souris s'est arrêtée. `DrivesListView` fait défiler la liste jusqu'à la cellule qui prend le focus (`positionViewAtIndex(index, ListView.Contain)`), sinon tabuler vers une ligne sous la zone visible n'afficherait rien.
- **Le focus était invisible sur tous les boutons.** Tous les boutons de l'onboarding sont des `Button` Qt Quick Controls, qui ont par défaut `focusPolicy: Qt.StrongFocus` (donc déjà atteignables au Tab), mais aucun `background` personnalisé ne testait `visualFocus`. Les utilisateurs tabulaient à l'aveugle. Les fonds dessinent désormais un anneau de focus : `actionOnPrimary` sur les boutons pleins, `accentPrimary` sur le bouton sans bordure. Deux nouveaux tokens dans `IKOnboarding` : `buttonFocusBorderWidth`, `driveSelectionCellFocusBorderWidth`.
- Chaque étape place désormais le focus initial sur son action principale (`LoginView` → Login, `ReadyView` → Ouvrir kDrive, `NoDriveAvailableView` → Démarrer gratuitement), pour que les utilisateurs au clavier partent de quelque part plutôt que de nulle part. Deux cas ont été traités différemment, volontairement :
  - `SynchronizationView` : Réessayer est `visible: synchronizationFailed`, donc invisible à l'ouverture de l'étape. Il ne prend le focus que via `onVisibleChanged`, quand l'échec le fait apparaître, plutôt qu'au chargement.
  - `DriveSelectionView` : Continuer est `enabled: canContinue`, c'est-à-dire désactivé tant qu'aucun kDrive n'est coché, et un `Control` désactivé refuse le focus. Aucun focus initial n'y est forcé ; le Tab démarre naturellement sur la première cellule de drive, qui est de toute façon la première action à faire sur cet écran.

## Détails techniques
`DriveSelectionView.qml` ne reçoit d'anneau de focus que pour **retryButton et continueButton**. Le bouton « Paramètres avancés » reste `enabled: false` sur cette branche (la fonctionnalité qui l'active arrive dans la dernière PR de la pile), et un bouton désactivé ne peut jamais prendre le focus : son anneau de focus arrivera donc en même temps que son activation, plus loin dans la pile. C'est pour cette raison que cette PR se situe tôt dans la pile : la dernière PR restructure entièrement ce bloc de boutons.

Cette PR est indépendante du travail sur la fonctionnalité : elle ne touche que des écrans d'onboarding préexistants et pourrait en principe être relue et fusionnée seule.

</details>

---

## Summary
This is PR 2 of the 8-PR stack. It is **not** part of the advanced sync configuration feature itself: it fixes pre-existing keyboard accessibility in the Linux v4 onboarding, which had none at all.

## Changes
- **Selecting a kDrive was impossible with the keyboard.** `DriveCellView` was an `Item` covered by a `MouseArea`, which never takes keyboard focus and carries no accessibility role, so the cell existed neither for Tab nor for a screen reader. It is now a proper checkable control: `activeFocusOnTab`, `Accessible.role: CheckBox` with name/description/checkable/checked, and Space/Return/Enter toggling it. The focus ring is drawn above the cell content, otherwise the hover and selection fills cover it. A click also calls `forceActiveFocus(Qt.MouseFocusReason)` so keyboard navigation resumes where the mouse left off. `DrivesListView` scrolls to whichever cell takes focus (`positionViewAtIndex(index, ListView.Contain)`), otherwise tabbing to a row below the visible area would show nothing.
- **Focus was invisible on every button.** All onboarding buttons are Qt Quick Controls `Button`, which default to `focusPolicy: Qt.StrongFocus`, so they were already reachable with Tab, but no custom `background` tested `visualFocus`. Users tabbed blind. Backgrounds now draw a focus ring: `actionOnPrimary` on filled buttons, `accentPrimary` on the borderless one. Two new tokens in `IKOnboarding`: `buttonFocusBorderWidth`, `driveSelectionCellFocusBorderWidth`.
- Each step now places initial focus on its main action (`LoginView` → Login, `ReadyView` → Open kDrive, `NoDriveAvailableView` → Start for free), so keyboard users start somewhere instead of nowhere. Two cases were deliberately handled differently:
  - `SynchronizationView`: Retry is `visible: synchronizationFailed`, so it is invisible when the step opens. It claims focus via `onVisibleChanged` when the failure makes it appear, rather than at load time.
  - `DriveSelectionView`: Continue is `enabled: canContinue`, i.e. disabled until a kDrive is checked, and a disabled Control refuses focus. No initial focus is forced there; tabbing naturally starts on the first drive cell, which is the first thing to do on that screen anyway.

## Technical Details
`DriveSelectionView.qml` receives focus rings for retryButton and continueButton only. The "Advanced settings" button is still `enabled: false` on this branch (the feature that activates it lands in the last PR of the stack), and a disabled button can never take focus, so its focus ring ships together with its activation, later in the stack. This is why this PR sits early in the stack: the last PR restructures that whole button block.

## Notes
Depends on #2381
