### PR TITLE
feat(sync-config): add remote folder tree model for selective sync

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -290,6 +290,14 @@
 - `app/syncconfiguration/localpaths.*`: local synchronization-folder rules shared by onboarding and future settings
   work: the `~`-shortened display form used at the QML boundary only, folder overlap detection, and the free-folder
   derivation that appends the attempt count without a separator, as the server does.
+- `app/syncconfiguration/remotefoldertreemodel.*`: reusable lazy `QAbstractItemModel` for selective synchronization. It
+  owns canonical blacklist editing, tri-state propagation, access-denied rows, retryable child loads, and the bounded
+  visible-row size queue. It must remain independent from onboarding state and synchronization database ids. A folder
+  is included or excluded with its complete subtree, as on Windows; the partial state reports that a descendant is
+  excluded and is never a state the user selects, and the drive root itself can never be excluded. A visible row loads
+  its size and its immediate children, so its expand affordance reflects whether the folder really has sub-folders. An
+  initial blacklist whose paths cannot be resolved fails the page instead of displaying ancestors as fully selected;
+  a node the server no longer knows is dropped from the blacklist rather than treated as a failure.
 - `app/services/cachepopulator.*`: two-branch snapshot loader for application parameters and user data. The user-data
   branch remains sequential and parent-first (users, accounts, drives, syncs, then sync errors); completion is emitted
   only after both branches succeed, and overlapping population requests are ignored. It is used at initial connection

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -284,6 +284,9 @@
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.
+- `app/syncconfiguration/remotefolderprovider.*`: injectable asynchronous boundary for remote folder metadata,
+  children, and sizes. The production adapter uses `CommService`; tests and future settings integration can provide the
+  same contract without onboarding dependencies.
 - `app/syncconfiguration/localpaths.*`: local synchronization-folder rules shared by onboarding and future settings
   work: the `~`-shortened display form used at the QML boundary only, folder overlap detection, and the free-folder
   derivation that appends the attempt count without a separator, as the server does.

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -284,6 +284,9 @@
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.
+- `app/syncconfiguration/localpaths.*`: local synchronization-folder rules shared by onboarding and future settings
+  work: the `~`-shortened display form used at the QML boundary only, folder overlap detection, and the free-folder
+  derivation that appends the attempt count without a separator, as the server does.
 - `app/services/cachepopulator.*`: two-branch snapshot loader for application parameters and user data. The user-data
   branch remains sequential and parent-first (users, accounts, drives, syncs, then sync errors); completion is emitted
   only after both branches succeed, and overlapping population requests are ignored. It is used at initial connection

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -84,6 +84,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/onboarding/oauthloginservice.h
         app/syncconfiguration/localpaths.cpp
         app/syncconfiguration/localpaths.h
+        app/syncconfiguration/remotefolderprovider.cpp
+        app/syncconfiguration/remotefolderprovider.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h
         communicationlayer/serversignalsequencer.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -82,6 +82,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/onboarding/onboardingsynccreationcoordinator.h
         app/onboarding/oauthloginservice.cpp
         app/onboarding/oauthloginservice.h
+        app/syncconfiguration/localpaths.cpp
+        app/syncconfiguration/localpaths.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h
         communicationlayer/serversignalsequencer.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -84,6 +84,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/onboarding/oauthloginservice.h
         app/syncconfiguration/localpaths.cpp
         app/syncconfiguration/localpaths.h
+        app/syncconfiguration/remotefoldertreemodel.cpp
+        app/syncconfiguration/remotefoldertreemodel.h
         app/syncconfiguration/remotefolderprovider.cpp
         app/syncconfiguration/remotefolderprovider.h
         communicationlayer/ipcclient.cpp

--- a/src/gui4/linux/app/services/commservice.cpp
+++ b/src/gui4/linux/app/services/commservice.cpp
@@ -652,10 +652,11 @@ void CommService::requestNodePath(const SyncDbId syncDbId, const NodeId &nodeId,
                            });
 }
 
-void CommService::requestNodeSubfolders(const DriveDbId driveDbId, const NodeId &nodeId, const bool withPath,
+void CommService::requestNodeSubfolders(const UserDbId userDbId, const DriveId driveId, const NodeId &nodeId, const bool withPath,
                                         const NodeInfoListCallback &callback) const {
     Poco::DynamicStruct params;
-    CommonUtility::writeValueToStruct(params, msgParamDriveDbId, driveDbId);
+    CommonUtility::writeValueToStruct(params, msgParamUserDbId, userDbId);
+    CommonUtility::writeValueToStruct(params, msgParamDriveId, driveId);
     CommonUtility::writeValueToStruct(params, msgParamNodeId, nodeId);
     CommonUtility::writeValueToStruct(params, msgParamWithPath, withPath);
     _ipcClient.sendRequest(

--- a/src/gui4/linux/app/services/commservice.h
+++ b/src/gui4/linux/app/services/commservice.h
@@ -186,7 +186,7 @@ class CommService : public QObject {
         void requestNodeConflictInfo(SyncDbId syncDbId, const SyncPath &relativePath, ReplicaSide replicaSide,
                                      const NodeConflictInfoCallback &callback) const;
         void requestNodePath(SyncDbId syncDbId, const NodeId &nodeId, const StringCallback &callback) const;
-        void requestNodeSubfolders(DriveDbId driveDbId, const NodeId &nodeId, bool withPath,
+        void requestNodeSubfolders(UserDbId userDbId, DriveId driveId, const NodeId &nodeId, bool withPath,
                                    const NodeInfoListCallback &callback) const;
         void requestNodeSubfolders2(DriveDbId driveDbId, const NodeId &nodeId, bool withPath,
                                     const NodeInfoListCallback &callback) const;

--- a/src/gui4/linux/app/syncconfiguration/localpaths.cpp
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.cpp
@@ -29,6 +29,11 @@ namespace {
 const auto homeShorthand = u"~"_s;
 // Mirrors the give-up threshold of ServerRequests::findGoodPathForNewSync() in src/server/requests/serverrequests.cpp.
 constexpr uint32_t maxUniqueLocalPathAttempts = 100;
+
+// The filesystem root already ends with its separator: appending a second one would build "//" and never match.
+bool containsPath(const QString &ancestor, const QString &path) {
+    return path.startsWith(ancestor.endsWith(u'/') ? ancestor : ancestor + u'/');
+}
 } // namespace
 
 QString displayLocalPath(const QString &localPath) {
@@ -46,7 +51,7 @@ bool localPathsOverlap(const QString &lhs, const QString &rhs) {
     const QString cleanLhs = QDir::cleanPath(lhs);
     const QString cleanRhs = QDir::cleanPath(rhs);
     if (cleanLhs == cleanRhs) return true;
-    return cleanLhs.startsWith(cleanRhs + u'/') || cleanRhs.startsWith(cleanLhs + u'/');
+    return containsPath(cleanRhs, cleanLhs) || containsPath(cleanLhs, cleanRhs);
 }
 
 QString makeUniqueLocalPath(const QString &path, const std::function<bool(const QString &)> &taken) {

--- a/src/gui4/linux/app/syncconfiguration/localpaths.cpp
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.cpp
@@ -1,0 +1,60 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "localpaths.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+using namespace Qt::StringLiterals;
+
+namespace KDC {
+
+namespace {
+const auto homeShorthand = u"~"_s;
+// Mirrors the give-up threshold of ServerRequests::findGoodPathForNewSync() in src/server/requests/serverrequests.cpp.
+constexpr uint32_t maxUniqueLocalPathAttempts = 100;
+} // namespace
+
+QString displayLocalPath(const QString &localPath) {
+    if (localPath.isEmpty()) return {};
+
+    const QString cleanPath = QDir::cleanPath(localPath);
+    const QString homePath = QDir::cleanPath(QDir::homePath());
+    if (homePath.isEmpty() || homePath == u"/"_s) return cleanPath;
+    if (cleanPath == homePath) return homeShorthand;
+    if (cleanPath.startsWith(homePath + u'/')) return homeShorthand + cleanPath.mid(homePath.size());
+    return cleanPath;
+}
+
+bool localPathsOverlap(const QString &lhs, const QString &rhs) {
+    const QString cleanLhs = QDir::cleanPath(lhs);
+    const QString cleanRhs = QDir::cleanPath(rhs);
+    if (cleanLhs == cleanRhs) return true;
+    return cleanLhs.startsWith(cleanRhs + u'/') || cleanRhs.startsWith(cleanLhs + u'/');
+}
+
+QString makeUniqueLocalPath(const QString &path, const std::function<bool(const QString &)> &taken) {
+    const QString cleanPath = QDir::cleanPath(path);
+    if (cleanPath.isEmpty() || !taken(cleanPath)) return cleanPath;
+
+    // Existence on disk is checked here too: the server vouched for the path it proposed, not for the ones derived
+    // from it, and a folder named like the candidate may well already sit next to it.
+    for (uint32_t attempt = 2; attempt <= maxUniqueLocalPathAttempts; ++attempt) {
+        // Same suffix as ServerRequests::findGoodPathForNewSync(): the attempt count appended to the folder name,
+        // with no separator. Keep both sides in step, see the contract documented on this function.
+        if (const QString candidate = cleanPath + QString::number(attempt); !taken(candidate) && !QFileInfo::exists(candidate)) {
+            return candidate;
+        }
+    }
+    return {};
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/localpaths.cpp
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.cpp
@@ -26,7 +26,7 @@ using namespace Qt::StringLiterals;
 namespace KDC {
 
 namespace {
-const auto homeShorthand = u"~"_s;
+constexpr auto homeShorthand = "~"_L1;
 // Mirrors the give-up threshold of ServerRequests::findGoodPathForNewSync() in src/server/requests/serverrequests.cpp.
 constexpr uint32_t maxUniqueLocalPathAttempts = 100;
 

--- a/src/gui4/linux/app/syncconfiguration/localpaths.cpp
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.cpp
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "localpaths.h"

--- a/src/gui4/linux/app/syncconfiguration/localpaths.h
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.h
@@ -1,0 +1,44 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <QString>
+
+#include <functional>
+
+namespace KDC {
+
+/**
+ * Converts a local path to its display form.
+ *
+ * The user home prefix is replaced with the `~` shorthand Linux users expect. The returned value is presentation only:
+ * every filesystem operation and every validation must keep using the original absolute path.
+ */
+[[nodiscard]] QString displayLocalPath(const QString &localPath);
+
+/** Reports whether two synchronization folders would collide, either by being equal or by containing each other. */
+[[nodiscard]] bool localPathsOverlap(const QString &lhs, const QString &rhs);
+
+/**
+ * Derives a free synchronization folder from a path the server proposed.
+ *
+ * DUPLICATED LOGIC, ON PURPOSE. `ServerRequests::findGoodPathForNewSync()` already derives a free folder, but it can
+ * only see what exists on disk and the synchronizations stored in its database. During onboarding neither exists yet:
+ * no `SYNC_ADD` has run, so no folder has been created and no sync has been persisted. Two drives sharing a name
+ * therefore receive the very same path from the server, and the collision only surfaces at the end of onboarding when
+ * the second `SYNC_ADD` is rejected. The macOS and Windows clients have that bug. Reserving the path client-side is
+ * what prevents it, because only the client knows what the current selection has already claimed.
+ *
+ * `taken` reports the paths already reserved by the caller. Returns an empty string when no free path was found.
+ */
+[[nodiscard]] QString makeUniqueLocalPath(const QString &path, const std::function<bool(const QString &)> &taken);
+
+} // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/localpaths.h
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.h
@@ -38,14 +38,18 @@ namespace KDC {
 /**
  * Derives a free synchronization folder from a path the server proposed.
  *
- * DUPLICATED LOGIC, ON PURPOSE. `ServerRequests::findGoodPathForNewSync()` already derives a free folder, but it can
- * only see what exists on disk and the synchronizations stored in its database. During onboarding neither exists yet:
- * no `SYNC_ADD` has run, so no folder has been created and no sync has been persisted. Two drives sharing a name
- * therefore receive the very same path from the server, and the collision only surfaces at the end of onboarding when
- * the second `SYNC_ADD` is rejected. The macOS and Windows clients have that bug. Reserving the path client-side is
- * what prevents it, because only the client knows what the current selection has already claimed.
+ * Two selected drives never contend for the same proposed path: the server names the folder after the drive, and the
+ * backend keeps drive names unique by suffixing the most recent one, so `kDrive Foo` and `kDrive Foo (1)` land in
+ * distinct folders. What this guards against is a drive whose folder the user has already moved by hand to the very
+ * place another selected drive is about to be given by default. `ServerRequests::findGoodPathForNewSync()` cannot see
+ * that: during onboarding no `SYNC_ADD` has run, so the folder exists nowhere on disk and no sync has been persisted.
+ * Only the client knows what the current selection has already claimed.
  *
- * `taken` reports the paths already reserved by the caller. Returns an empty string when no free path was found.
+ * `taken` reports the paths already reserved by the caller. Existence on disk is enough to rule a derived candidate
+ * out here, because the resolver only runs with no sync configured at all: no persisted sync can hold a folder the
+ * user has since deleted. Should the settings ever reuse this flow with syncs already in place, each derived
+ * candidate would have to go through `IS_PATH_VALID_FOR_NEW_SYNC` instead. Returns an empty string when no free path
+ * was found.
  */
 [[nodiscard]] QString makeUniqueLocalPath(const QString &path, const std::function<bool(const QString &)> &taken);
 

--- a/src/gui4/linux/app/syncconfiguration/localpaths.h
+++ b/src/gui4/linux/app/syncconfiguration/localpaths.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/gui4/linux/app/syncconfiguration/remotefolderprovider.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefolderprovider.cpp
@@ -1,0 +1,35 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "remotefolderprovider.h"
+
+#include "app/services/commservice.h"
+
+namespace KDC {
+
+CommRemoteFolderProvider::CommRemoteFolderProvider(CommService &commService) :
+    _commService(commService) {}
+
+void CommRemoteFolderProvider::requestNodeInfo(const UserDbId userDbId, const DriveId driveId, const NodeId &nodeId,
+                                               const NodeInfoCallback &callback) const {
+    _commService.requestNodeInfo(userDbId, driveId, nodeId, true, callback);
+}
+
+void CommRemoteFolderProvider::requestChildren(const UserDbId userDbId, const DriveId driveId, const NodeId &nodeId,
+                                               const ChildrenCallback &callback) const {
+    _commService.requestNodeSubfolders(userDbId, driveId, nodeId, true, callback);
+}
+
+void CommRemoteFolderProvider::requestSize(const UserDbId userDbId, const DriveId driveId, const NodeId &nodeId,
+                                           const SizeCallback &callback) const {
+    _commService.requestNodeFolderSize(userDbId, driveId, nodeId, callback);
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/remotefolderprovider.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefolderprovider.cpp
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "remotefolderprovider.h"

--- a/src/gui4/linux/app/syncconfiguration/remotefolderprovider.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefolderprovider.h
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "libcommon/info/nodeinfo.h"
+#include "libcommon/utility/types.h"
+
+#include <functional>
+#include <vector>
+
+namespace KDC {
+
+class CommService;
+
+/** Asynchronous remote-folder data boundary shared by onboarding today and synchronization settings in the future. */
+class AbstractRemoteFolderProvider {
+    public:
+        using NodeInfoCallback = std::function<void(const ExitInfo &, const NodeInfo &)>;
+        using ChildrenCallback = std::function<void(const ExitInfo &, const std::vector<NodeInfo> &)>;
+        using SizeCallback = std::function<void(const ExitInfo &, int64_t)>;
+
+        virtual ~AbstractRemoteFolderProvider() = default;
+        virtual void requestNodeInfo(UserDbId userDbId, DriveId driveId, const NodeId &nodeId,
+                                     const NodeInfoCallback &callback) const = 0;
+        virtual void requestChildren(UserDbId userDbId, DriveId driveId, const NodeId &nodeId,
+                                     const ChildrenCallback &callback) const = 0;
+        virtual void requestSize(UserDbId userDbId, DriveId driveId, const NodeId &nodeId,
+                                 const SizeCallback &callback) const = 0;
+};
+
+/** Production adapter from the reusable tree contract to the GUI/server IPC service. */
+class CommRemoteFolderProvider final : public AbstractRemoteFolderProvider {
+    public:
+        explicit CommRemoteFolderProvider(CommService &commService);
+
+        void requestNodeInfo(UserDbId userDbId, DriveId driveId, const NodeId &nodeId,
+                             const NodeInfoCallback &callback) const override;
+        void requestChildren(UserDbId userDbId, DriveId driveId, const NodeId &nodeId,
+                             const ChildrenCallback &callback) const override;
+        void requestSize(UserDbId userDbId, DriveId driveId, const NodeId &nodeId, const SizeCallback &callback) const override;
+
+    private:
+        CommService &_commService;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/remotefolderprovider.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefolderprovider.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -147,7 +147,8 @@ void RemoteFolderTreeModel::configure(const UserDbId userDbId, const DriveId dri
     _excludedNodeIds.clear();
     _excludedPaths.clear();
     _sizeQueue.clear();
-    _activeSizeRequests = 0;
+    // `_activeSizeRequests` is deliberately kept: the requests of the previous generation are still in flight and
+    // still occupy the provider, so resetting it here would let this generation start as many again.
     _pendingInitialPathRequests = 0;
     _initialPathsFailed = false;
     for (const auto &nodeId: initialBlackList) _excludedNodeIds.insert(QString::fromStdString(nodeId));
@@ -432,7 +433,7 @@ void RemoteFolderTreeModel::processSizeQueue() {
         const QPointer self(this);
         _provider.requestSize(_userDbId, _driveId, QStr2Str(nodeId),
                               [self, nodeId, generation](const bool success, const int64_t size) {
-                                  if (!self || generation != self->_generation) return;
+                                  if (!self) return;
                                   self->handleSizeResult(nodeId, generation, success, size);
                               });
     }
@@ -440,12 +441,15 @@ void RemoteFolderTreeModel::processSizeQueue() {
 
 void RemoteFolderTreeModel::handleSizeResult(const QString &nodeId, const uint64_t generation, const bool success,
                                              const qint64 size) {
-    if (generation != _generation) return;
+    // The counter tracks every request in flight, whatever its generation: a result of a previous configuration
+    // frees a slot on the provider just the same, and only its payload is dropped.
     if (_activeSizeRequests > 0) --_activeSizeRequests;
-    if (TreeNode *const node = _nodesById.value(nodeId, nullptr)) {
-        node->sizeState = success ? SizeState::Loaded : SizeState::Failed;
-        node->size = size;
-        emit dataChanged(indexForNode(node), indexForNode(node), {SizeTextRole});
+    if (generation == _generation) {
+        if (TreeNode *const node = _nodesById.value(nodeId, nullptr)) {
+            node->sizeState = success ? SizeState::Loaded : SizeState::Failed;
+            node->size = size;
+            emit dataChanged(indexForNode(node), indexForNode(node), {SizeTextRole});
+        }
     }
     processSizeQueue();
 }

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -34,13 +34,12 @@ namespace KDC {
 
 namespace {
 constexpr uint8_t maxConcurrentSizeRequests = 4;
-const auto unavailableSize = u"—"_s;
+constexpr QStringView unavailableSize = u"—";
 } // namespace
 
 RemoteFolderTreeModel::RemoteFolderTreeModel(AbstractRemoteFolderProvider &remoteFolderProvider, QObject *const parent) :
     QAbstractItemModel(parent),
-    _remoteFolderProvider(remoteFolderProvider),
-    _root(std::make_unique<TreeNode>()) {}
+    _remoteFolderProvider(remoteFolderProvider) {}
 
 QModelIndex RemoteFolderTreeModel::index(const int row, const int column, const QModelIndex &parentIndex) const {
     if (row < 0 || column != 0) return {};
@@ -84,7 +83,7 @@ QVariant RemoteFolderTreeModel::data(const QModelIndex &index, const int role) c
             // A dash until the size is known, whether it is still loading or failed to load: the column then keeps a
             // steady shape while sizes arrive, instead of filling up cell by cell from an empty state.
             return node->sizeState == SizeState::Loaded ? QLocale{}.formattedDataSize(node->size, 1, QLocale::DataSizeSIFormat)
-                                                        : unavailableSize;
+                                                        : unavailableSize.toString();
         case ChildrenLoadingRole:
             return node->childrenState == LoadState::Loading;
         case ChildrenLoadFailedRole:
@@ -151,7 +150,7 @@ void RemoteFolderTreeModel::configure(const UserDbId userDbId, const DriveId dri
     // still occupy the provider, so resetting it here would let this generation start as many again.
     _pendingInitialPathRequests = 0;
     _initialPathsFailed = false;
-    for (const auto &nodeId: initialBlackList) _excludedNodeIds.insert(QString::fromStdString(nodeId));
+    for (const auto &nodeId: initialBlackList) (void) _excludedNodeIds.insert(QString::fromStdString(nodeId));
     endResetModel();
     emit selectionChanged();
     resolveInitialExclusionPaths();
@@ -216,7 +215,7 @@ RemoteFolderTreeModel::TreeNode *RemoteFolderTreeModel::nodeForIndex(const QMode
     return modelIndex.isValid() ? static_cast<TreeNode *>(modelIndex.internalPointer()) : _root.get();
 }
 
-QModelIndex RemoteFolderTreeModel::indexForNode(const TreeNode *node) const {
+QModelIndex RemoteFolderTreeModel::indexForNode(const TreeNode *const node) const {
     if (!node || !node->parent || node == _root.get()) return {};
     const auto &siblings = node->parent->children;
     const auto it = std::ranges::find_if(siblings, [node](const auto &candidate) { return candidate.get() == node; });
@@ -224,19 +223,19 @@ QModelIndex RemoteFolderTreeModel::indexForNode(const TreeNode *node) const {
     return createIndex(static_cast<int>(std::distance(siblings.begin(), it)), 0, node);
 }
 
-Qt::CheckState RemoteFolderTreeModel::checkState(const TreeNode *node) const {
+Qt::CheckState RemoteFolderTreeModel::checkState(const TreeNode *const node) const {
     if (isExcluded(node)) return Qt::Unchecked;
     return hasExcludedDescendant(node) ? Qt::PartiallyChecked : Qt::Checked;
 }
 
-bool RemoteFolderTreeModel::isExcluded(const TreeNode *node) const {
+bool RemoteFolderTreeModel::isExcluded(const TreeNode *const node) const {
     for (const TreeNode *cursor = node; cursor && cursor != _root.get(); cursor = cursor->parent) {
         if (_excludedNodeIds.contains(cursor->nodeId)) return true;
     }
     return false;
 }
 
-bool RemoteFolderTreeModel::hasExcludedDescendant(const TreeNode *node) const {
+bool RemoteFolderTreeModel::hasExcludedDescendant(const TreeNode *const node) const {
     for (auto it = _excludedPaths.cbegin(); it != _excludedPaths.cend(); ++it) {
         if (pathContains(node->path, it.value()) && node->path != it.value()) return true;
     }
@@ -251,7 +250,7 @@ bool RemoteFolderTreeModel::pathContains(const QString &ancestorPath, const QStr
     return descendantPath.startsWith(prefix);
 }
 
-QString RemoteFolderTreeModel::effectivePath(const NodeInfo &info, const TreeNode *parentNode) const {
+QString RemoteFolderTreeModel::effectivePath(const NodeInfo &info, const TreeNode *const parentNode) const {
     if (!info.path().isEmpty()) return info.path();
     if (!parentNode || parentNode == _root.get() || parentNode->path.isEmpty()) return u"/"_s + info.name();
     return parentNode->path + u'/' + info.name();
@@ -283,11 +282,11 @@ void RemoteFolderTreeModel::handleInitialExclusionPathResult(const QString &node
     if (_pendingInitialPathRequests > 0) --_pendingInitialPathRequests;
 
     if (exitInfo && !info.path().isEmpty()) {
-        _excludedPaths.insert(nodeId, info.path());
+        (void) _excludedPaths.insert(nodeId, info.path());
     } else if (!exitInfo && exitInfo.cause() == ExitCause::NotFound) {
         // The folder was deleted remotely since it was blacklisted: dropping it keeps the blacklist canonical.
-        _excludedNodeIds.remove(nodeId);
-        _excludedPaths.remove(nodeId);
+        (void) _excludedNodeIds.remove(nodeId);
+        (void) _excludedPaths.remove(nodeId);
     } else {
         _initialPathsFailed = true;
     }
@@ -303,7 +302,7 @@ void RemoteFolderTreeModel::handleInitialExclusionPathResult(const QString &node
     requestChildren(_root.get());
 }
 
-void RemoteFolderTreeModel::requestChildren(TreeNode *node) {
+void RemoteFolderTreeModel::requestChildren(TreeNode *const node) {
     if (!node || node->childrenState == LoadState::Loading || node->accessDenied) return;
     node->childrenState = LoadState::Loading;
     if (node == _root.get())
@@ -320,7 +319,7 @@ void RemoteFolderTreeModel::requestChildren(TreeNode *node) {
                               });
 }
 
-void RemoteFolderTreeModel::handleChildrenResult(TreeNode *node, const uint64_t generation, const bool success,
+void RemoteFolderTreeModel::handleChildrenResult(TreeNode *const node, const uint64_t generation, const bool success,
                                                  const std::vector<NodeInfo> &children) {
     if (generation != _generation || !node) return;
     if (!success) {
@@ -333,7 +332,7 @@ void RemoteFolderTreeModel::handleChildrenResult(TreeNode *node, const uint64_t 
     }
 
     std::vector<NodeInfo> sortedChildren = children;
-    std::ranges::sort(sortedChildren, [](const NodeInfo &lhs, const NodeInfo &rhs) {
+    (void) std::ranges::sort(sortedChildren, [](const NodeInfo &lhs, const NodeInfo &rhs) {
         return QString::localeAwareCompare(lhs.name(), rhs.name()) < 0;
     });
     const QModelIndex parentIndex = indexForNode(node);
@@ -345,8 +344,8 @@ void RemoteFolderTreeModel::handleChildrenResult(TreeNode *node, const uint64_t 
         child->path = effectivePath(info, node);
         child->parent = node;
         child->accessDenied = info.accessDenied();
-        if (_excludedNodeIds.contains(child->nodeId)) _excludedPaths.insert(child->nodeId, child->path);
-        _nodesById.insert(child->nodeId, child.get());
+        if (_excludedNodeIds.contains(child->nodeId)) (void) _excludedPaths.insert(child->nodeId, child->path);
+        (void) _nodesById.insert(child->nodeId, child.get());
         node->children.push_back(std::move(child));
     }
     if (!sortedChildren.empty()) endInsertRows();
@@ -359,14 +358,14 @@ void RemoteFolderTreeModel::handleChildrenResult(TreeNode *node, const uint64_t 
     notifySelectionDataChanged();
 }
 
-void RemoteFolderTreeModel::excludeNode(TreeNode *node) {
+void RemoteFolderTreeModel::excludeNode(const TreeNode *const node) {
     removeExclusionsAtOrBelow(node);
-    _excludedNodeIds.insert(node->nodeId);
-    _excludedPaths.insert(node->nodeId, node->path);
+    (void) _excludedNodeIds.insert(node->nodeId);
+    (void) _excludedPaths.insert(node->nodeId, node->path);
 }
 
-void RemoteFolderTreeModel::includeNode(TreeNode *node) {
-    TreeNode *excludedAncestor = nullptr;
+void RemoteFolderTreeModel::includeNode(TreeNode *const node) {
+    const TreeNode *excludedAncestor = nullptr;
     for (TreeNode *cursor = node; cursor && cursor != _root.get(); cursor = cursor->parent) {
         if (_excludedNodeIds.contains(cursor->nodeId)) {
             excludedAncestor = cursor;
@@ -377,9 +376,10 @@ void RemoteFolderTreeModel::includeNode(TreeNode *node) {
     removeExclusionsAtOrBelow(node);
 }
 
-void RemoteFolderTreeModel::includeNodeUnderExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor) {
-    _excludedNodeIds.remove(excludedAncestor->nodeId);
-    _excludedPaths.remove(excludedAncestor->nodeId);
+void RemoteFolderTreeModel::includeNodeUnderExcludedAncestor(const TreeNode *const node,
+                                                             const TreeNode *const excludedAncestor) {
+    (void) _excludedNodeIds.remove(excludedAncestor->nodeId);
+    (void) _excludedPaths.remove(excludedAncestor->nodeId);
     const TreeNode *cursor = node;
     while (cursor && cursor != excludedAncestor) {
         const TreeNode *const parentNode = cursor->parent;
@@ -391,7 +391,7 @@ void RemoteFolderTreeModel::includeNodeUnderExcludedAncestor(const TreeNode *nod
     }
 }
 
-void RemoteFolderTreeModel::removeExclusionsAtOrBelow(const TreeNode *node) {
+void RemoteFolderTreeModel::removeExclusionsAtOrBelow(const TreeNode *const node) {
     QList<QString> idsToRemove;
     for (auto it = _excludedNodeIds.cbegin(); it != _excludedNodeIds.cend(); ++it) {
         if (const QString path = _excludedPaths.value(*it);
@@ -399,8 +399,8 @@ void RemoteFolderTreeModel::removeExclusionsAtOrBelow(const TreeNode *node) {
             idsToRemove.push_back(*it);
     }
     for (const auto &id: idsToRemove) {
-        _excludedNodeIds.remove(id);
-        _excludedPaths.remove(id);
+        (void) _excludedNodeIds.remove(id);
+        (void) _excludedPaths.remove(id);
     }
 }
 
@@ -408,14 +408,14 @@ void RemoteFolderTreeModel::notifySelectionDataChanged() {
     notifySelectionDataChanged(_root.get());
 }
 
-void RemoteFolderTreeModel::notifySelectionDataChanged(const TreeNode *parentNode) {
+void RemoteFolderTreeModel::notifySelectionDataChanged(const TreeNode *const parentNode) {
     if (!parentNode || parentNode->children.empty()) return;
-    emit dataChanged(indexForNode(parentNode->children.front().get()), indexForNode(parentNode->children.back().get()),
-                     {CheckStateRole});
+    emit dataChanged(indexForNode(parentNode->children.front().get()),
+                     indexForNode(parentNode->children.back().get()), {CheckStateRole});
     for (const auto &child: parentNode->children) notifySelectionDataChanged(child.get());
 }
 
-void RemoteFolderTreeModel::queueSize(TreeNode *node) {
+void RemoteFolderTreeModel::queueSize(TreeNode *const node) {
     if (!node || node->sizeState != SizeState::NotRequested) return;
     node->sizeState = SizeState::Queued;
     _sizeQueue.enqueue(node->nodeId);

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "remotefoldertreemodel.h"

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -37,9 +37,9 @@ constexpr uint8_t maxConcurrentSizeRequests = 4;
 const auto unavailableSize = u"—"_s;
 } // namespace
 
-RemoteFolderTreeModel::RemoteFolderTreeModel(AbstractRemoteFolderProvider &provider, QObject *const parent) :
+RemoteFolderTreeModel::RemoteFolderTreeModel(AbstractRemoteFolderProvider &remoteFolderProvider, QObject *const parent) :
     QAbstractItemModel(parent),
-    _provider(provider),
+    _remoteFolderProvider(remoteFolderProvider),
     _root(std::make_unique<TreeNode>()) {}
 
 QModelIndex RemoteFolderTreeModel::index(const int row, const int column, const QModelIndex &parentIndex) const {
@@ -270,7 +270,7 @@ void RemoteFolderTreeModel::resolveInitialExclusionPaths() {
     const uint64_t generation = _generation;
     const QPointer self(this);
     for (const auto &nodeId: QStringList(_excludedNodeIds.cbegin(), _excludedNodeIds.cend())) {
-        _provider.requestNodeInfo(_userDbId, _driveId, QStr2Str(nodeId),
+        _remoteFolderProvider.requestNodeInfo(_userDbId, _driveId, QStr2Str(nodeId),
                                   [self, generation, nodeId](const ExitInfo &exitInfo, const NodeInfo &info) {
                                       if (!self || generation != self->_generation) return;
                                       self->handleInitialExclusionPathResult(nodeId, exitInfo, info);
@@ -313,7 +313,7 @@ void RemoteFolderTreeModel::requestChildren(TreeNode *node) {
 
     const uint64_t generation = _generation;
     const QPointer self(this);
-    _provider.requestChildren(_userDbId, _driveId, QStr2Str(node->nodeId),
+    _remoteFolderProvider.requestChildren(_userDbId, _driveId, QStr2Str(node->nodeId),
                               [self, node, generation](const bool success, const std::vector<NodeInfo> &children) {
                                   if (!self || generation != self->_generation) return;
                                   self->handleChildrenResult(node, generation, success, children);
@@ -373,11 +373,11 @@ void RemoteFolderTreeModel::includeNode(TreeNode *node) {
             break;
         }
     }
-    if (excludedAncestor && excludedAncestor != node) includeFromExcludedAncestor(node, excludedAncestor);
+    if (excludedAncestor && excludedAncestor != node) includeNodeUnderExcludedAncestor(node, excludedAncestor);
     removeExclusionsAtOrBelow(node);
 }
 
-void RemoteFolderTreeModel::includeFromExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor) {
+void RemoteFolderTreeModel::includeNodeUnderExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor) {
     _excludedNodeIds.remove(excludedAncestor->nodeId);
     _excludedPaths.remove(excludedAncestor->nodeId);
     const TreeNode *cursor = node;
@@ -431,7 +431,7 @@ void RemoteFolderTreeModel::processSizeQueue() {
         ++_activeSizeRequests;
         const uint64_t generation = _generation;
         const QPointer self(this);
-        _provider.requestSize(_userDbId, _driveId, QStr2Str(nodeId),
+        _remoteFolderProvider.requestSize(_userDbId, _driveId, QStr2Str(nodeId),
                               [self, nodeId, generation](const bool success, const int64_t size) {
                                   if (!self) return;
                                   self->handleSizeResult(nodeId, generation, success, size);

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -1,0 +1,445 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "remotefoldertreemodel.h"
+
+#include "app/syncconfiguration/remotefolderprovider.h"
+#include "libcommon/info/nodeinfo.h"
+#include "libcommon/utility/utility.h"
+
+#include <QLocale>
+#include <QPointer>
+
+#include <algorithm>
+#include <utility>
+
+using namespace Qt::StringLiterals;
+
+namespace KDC {
+
+namespace {
+constexpr uint8_t maxConcurrentSizeRequests = 4;
+const auto unavailableSize = u"—"_s;
+} // namespace
+
+RemoteFolderTreeModel::RemoteFolderTreeModel(AbstractRemoteFolderProvider &provider, QObject *const parent) :
+    QAbstractItemModel(parent),
+    _provider(provider),
+    _root(std::make_unique<TreeNode>()) {}
+
+QModelIndex RemoteFolderTreeModel::index(const int row, const int column, const QModelIndex &parentIndex) const {
+    if (row < 0 || column != 0) return {};
+    const TreeNode *const parentNode = nodeForIndex(parentIndex);
+    if (!parentNode || static_cast<std::size_t>(row) >= parentNode->children.size()) return {};
+    return createIndex(row, column, parentNode->children[static_cast<std::size_t>(row)].get());
+}
+
+QModelIndex RemoteFolderTreeModel::parent(const QModelIndex &child) const {
+    if (!child.isValid()) return {};
+    const auto *const node = static_cast<TreeNode *>(child.internalPointer());
+    if (!node || !node->parent || node->parent == _root.get()) return {};
+    return indexForNode(node->parent);
+}
+
+int RemoteFolderTreeModel::rowCount(const QModelIndex &parentIndex) const {
+    if (parentIndex.column() > 0) return 0;
+    const TreeNode *const node = nodeForIndex(parentIndex);
+    return node ? static_cast<int>(node->children.size()) : 0;
+}
+
+int RemoteFolderTreeModel::columnCount(const QModelIndex &) const {
+    return 1;
+}
+
+QVariant RemoteFolderTreeModel::data(const QModelIndex &index, const int role) const {
+    if (!index.isValid()) return {};
+    const auto *const node = static_cast<TreeNode *>(index.internalPointer());
+    if (!node) return {};
+
+    switch (role) {
+        case NameRole:
+            return node->name;
+        case NodeIdRole:
+            return node->nodeId;
+        case CheckStateRole:
+            return static_cast<int>(checkState(node));
+        case AccessDeniedRole:
+            return node->accessDenied;
+        case SizeTextRole:
+            // A dash until the size is known, whether it is still loading or failed to load: the column then keeps a
+            // steady shape while sizes arrive, instead of filling up cell by cell from an empty state.
+            return node->sizeState == SizeState::Loaded ? QLocale{}.formattedDataSize(node->size, 1, QLocale::DataSizeSIFormat)
+                                                        : unavailableSize;
+        case ChildrenLoadingRole:
+            return node->childrenState == LoadState::Loading;
+        case ChildrenLoadFailedRole:
+            return node->childrenState == LoadState::Failed;
+        default:
+            return {};
+    }
+}
+
+QHash<int, QByteArray> RemoteFolderTreeModel::roleNames() const {
+    return {{NameRole, "folderName"},
+            {NodeIdRole, "nodeId"},
+            {CheckStateRole, "checkState"},
+            {AccessDeniedRole, "accessDenied"},
+            {SizeTextRole, "sizeText"},
+            {ChildrenLoadingRole, "childrenLoading"},
+            {ChildrenLoadFailedRole, "childrenLoadFailed"}};
+}
+
+bool RemoteFolderTreeModel::hasChildren(const QModelIndex &parentIndex) const {
+    const TreeNode *const node = nodeForIndex(parentIndex);
+    return node && !node->accessDenied && (node->childrenState != LoadState::Loaded || !node->children.empty());
+}
+
+bool RemoteFolderTreeModel::canFetchMore(const QModelIndex &parentIndex) const {
+    const TreeNode *const node = nodeForIndex(parentIndex);
+    return node && !node->accessDenied &&
+           (node->childrenState == LoadState::NotLoaded || node->childrenState == LoadState::Failed);
+}
+
+void RemoteFolderTreeModel::fetchMore(const QModelIndex &parentIndex) {
+    requestChildren(nodeForIndex(parentIndex));
+}
+
+bool RemoteFolderTreeModel::loading() const {
+    return _pendingInitialPathRequests > 0 || _root->childrenState == LoadState::Loading;
+}
+
+bool RemoteFolderTreeModel::loadFailed() const {
+    return _initialPathsFailed || _root->childrenState == LoadState::Failed;
+}
+
+bool RemoteFolderTreeModel::empty() const {
+    return _root->childrenState == LoadState::Loaded && _root->children.empty();
+}
+
+int RemoteFolderTreeModel::rootCheckState() const {
+    return static_cast<int>(_excludedNodeIds.isEmpty() ? Qt::Checked : Qt::PartiallyChecked);
+}
+
+void RemoteFolderTreeModel::configure(const UserDbId userDbId, const DriveId driveId, const NodeId &rootNodeId,
+                                      const std::vector<NodeId> &initialBlackList) {
+    beginResetModel();
+    ++_generation;
+    _userDbId = userDbId;
+    _driveId = driveId;
+    _root = std::make_unique<TreeNode>();
+    _root->nodeId = QString::fromStdString(rootNodeId);
+    _nodesById.clear();
+    _excludedNodeIds.clear();
+    _excludedPaths.clear();
+    _sizeQueue.clear();
+    _activeSizeRequests = 0;
+    _pendingInitialPathRequests = 0;
+    _initialPathsFailed = false;
+    for (const auto &nodeId: initialBlackList) _excludedNodeIds.insert(QString::fromStdString(nodeId));
+    endResetModel();
+    emit selectionChanged();
+    resolveInitialExclusionPaths();
+}
+
+std::vector<NodeId> RemoteFolderTreeModel::blackList() const {
+    QStringList sortedIds(_excludedNodeIds.cbegin(), _excludedNodeIds.cend());
+    sortedIds.sort(Qt::CaseSensitive);
+    std::vector<NodeId> result;
+    result.reserve(static_cast<std::size_t>(sortedIds.size()));
+    for (const auto &nodeId: sortedIds) result.push_back(QStr2Str(nodeId));
+    return result;
+}
+
+void RemoteFolderTreeModel::retryRoot() {
+    if (_initialPathsFailed) {
+        _initialPathsFailed = false;
+        emit stateChanged();
+        resolveInitialExclusionPaths();
+        return;
+    }
+    if (_root->childrenState == LoadState::Failed) requestChildren(_root.get());
+}
+
+void RemoteFolderTreeModel::retryChildren(const QModelIndex &modelIndex) {
+    if (TreeNode *const node = nodeForIndex(modelIndex); node && node->childrenState == LoadState::Failed) requestChildren(node);
+}
+
+void RemoteFolderTreeModel::toggleSelection(const QModelIndex &modelIndex) {
+    TreeNode *const node = nodeForIndex(modelIndex);
+    if (!node || node == _root.get() || node->accessDenied) return;
+    if (checkState(node) == Qt::Unchecked) {
+        includeNode(node);
+    } else {
+        excludeNode(node);
+    }
+    notifySelectionDataChanged();
+    emit selectionChanged();
+}
+
+void RemoteFolderTreeModel::toggleRootSelection() {
+    if (_excludedNodeIds.isEmpty()) return;
+    _excludedNodeIds.clear();
+    _excludedPaths.clear();
+    notifySelectionDataChanged();
+    emit selectionChanged();
+}
+
+void RemoteFolderTreeModel::setRowVisible(const QModelIndex &modelIndex, const bool visible) {
+    TreeNode *const node = nodeForIndex(modelIndex);
+    if (!node || node == _root.get()) return;
+    node->sizeRequested = visible;
+    if (!visible) {
+        if (node->sizeState == SizeState::Queued) node->sizeState = SizeState::NotRequested;
+        return;
+    }
+    queueSize(node);
+    if (node->childrenState == LoadState::NotLoaded) requestChildren(node);
+}
+
+RemoteFolderTreeModel::TreeNode *RemoteFolderTreeModel::nodeForIndex(const QModelIndex &modelIndex) const {
+    return modelIndex.isValid() ? static_cast<TreeNode *>(modelIndex.internalPointer()) : _root.get();
+}
+
+QModelIndex RemoteFolderTreeModel::indexForNode(const TreeNode *node) const {
+    if (!node || !node->parent || node == _root.get()) return {};
+    const auto &siblings = node->parent->children;
+    const auto it = std::ranges::find_if(siblings, [node](const auto &candidate) { return candidate.get() == node; });
+    if (it == siblings.end()) return {};
+    return createIndex(static_cast<int>(std::distance(siblings.begin(), it)), 0, node);
+}
+
+Qt::CheckState RemoteFolderTreeModel::checkState(const TreeNode *node) const {
+    if (isExcluded(node)) return Qt::Unchecked;
+    return hasExcludedDescendant(node) ? Qt::PartiallyChecked : Qt::Checked;
+}
+
+bool RemoteFolderTreeModel::isExcluded(const TreeNode *node) const {
+    for (const TreeNode *cursor = node; cursor && cursor != _root.get(); cursor = cursor->parent) {
+        if (_excludedNodeIds.contains(cursor->nodeId)) return true;
+    }
+    return false;
+}
+
+bool RemoteFolderTreeModel::hasExcludedDescendant(const TreeNode *node) const {
+    for (auto it = _excludedPaths.cbegin(); it != _excludedPaths.cend(); ++it) {
+        if (pathContains(node->path, it.value()) && node->path != it.value()) return true;
+    }
+    return false;
+}
+
+bool RemoteFolderTreeModel::pathContains(const QString &ancestorPath, const QString &descendantPath) {
+    if (ancestorPath.isEmpty()) return !descendantPath.isEmpty();
+    if (ancestorPath == descendantPath) return true;
+    QString prefix = ancestorPath;
+    if (!prefix.endsWith(u'/')) prefix += u'/';
+    return descendantPath.startsWith(prefix);
+}
+
+QString RemoteFolderTreeModel::effectivePath(const NodeInfo &info, const TreeNode *parentNode) const {
+    if (!info.path().isEmpty()) return info.path();
+    if (!parentNode || parentNode == _root.get() || parentNode->path.isEmpty()) return u"/"_s + info.name();
+    return parentNode->path + u'/' + info.name();
+}
+
+// An unresolved path would make every ancestor of the excluded folder look completely selected, so a failure here
+// fails the whole page instead of displaying a selection that does not match what will be synchronized.
+void RemoteFolderTreeModel::resolveInitialExclusionPaths() {
+    if (_excludedNodeIds.isEmpty()) {
+        requestChildren(_root.get());
+        return;
+    }
+
+    _pendingInitialPathRequests = static_cast<uint32_t>(_excludedNodeIds.size());
+    emit stateChanged();
+    const uint64_t generation = _generation;
+    const QPointer self(this);
+    for (const auto &nodeId: QStringList(_excludedNodeIds.cbegin(), _excludedNodeIds.cend())) {
+        _provider.requestNodeInfo(_userDbId, _driveId, QStr2Str(nodeId),
+                                  [self, generation, nodeId](const ExitInfo &exitInfo, const NodeInfo &info) {
+                                      if (!self || generation != self->_generation) return;
+                                      self->handleInitialExclusionPathResult(nodeId, exitInfo, info);
+                                  });
+    }
+}
+
+void RemoteFolderTreeModel::handleInitialExclusionPathResult(const QString &nodeId, const ExitInfo &exitInfo,
+                                                             const NodeInfo &info) {
+    if (_pendingInitialPathRequests > 0) --_pendingInitialPathRequests;
+
+    if (exitInfo && !info.path().isEmpty()) {
+        _excludedPaths.insert(nodeId, info.path());
+    } else if (!exitInfo && exitInfo.cause() == ExitCause::NotFound) {
+        // The folder was deleted remotely since it was blacklisted: dropping it keeps the blacklist canonical.
+        _excludedNodeIds.remove(nodeId);
+        _excludedPaths.remove(nodeId);
+    } else {
+        _initialPathsFailed = true;
+    }
+
+    if (_pendingInitialPathRequests > 0) return;
+    if (_initialPathsFailed) {
+        _excludedPaths.clear();
+        emit stateChanged();
+        return;
+    }
+    emit stateChanged();
+    emit selectionChanged();
+    requestChildren(_root.get());
+}
+
+void RemoteFolderTreeModel::requestChildren(TreeNode *node) {
+    if (!node || node->childrenState == LoadState::Loading || node->accessDenied) return;
+    node->childrenState = LoadState::Loading;
+    if (node == _root.get())
+        emit stateChanged();
+    else
+        emit dataChanged(indexForNode(node), indexForNode(node), {ChildrenLoadingRole, ChildrenLoadFailedRole});
+
+    const uint64_t generation = _generation;
+    const QPointer self(this);
+    _provider.requestChildren(_userDbId, _driveId, QStr2Str(node->nodeId),
+                              [self, node, generation](const bool success, const std::vector<NodeInfo> &children) {
+                                  if (!self || generation != self->_generation) return;
+                                  self->handleChildrenResult(node, generation, success, children);
+                              });
+}
+
+void RemoteFolderTreeModel::handleChildrenResult(TreeNode *node, const uint64_t generation, const bool success,
+                                                 const std::vector<NodeInfo> &children) {
+    if (generation != _generation || !node) return;
+    if (!success) {
+        node->childrenState = LoadState::Failed;
+        if (node == _root.get())
+            emit stateChanged();
+        else
+            emit dataChanged(indexForNode(node), indexForNode(node), {ChildrenLoadingRole, ChildrenLoadFailedRole});
+        return;
+    }
+
+    std::vector<NodeInfo> sortedChildren = children;
+    std::ranges::sort(sortedChildren, [](const NodeInfo &lhs, const NodeInfo &rhs) {
+        return QString::localeAwareCompare(lhs.name(), rhs.name()) < 0;
+    });
+    const QModelIndex parentIndex = indexForNode(node);
+    if (!sortedChildren.empty()) beginInsertRows(parentIndex, 0, static_cast<int>(sortedChildren.size()) - 1);
+    for (const auto &info: sortedChildren) {
+        auto child = std::make_unique<TreeNode>();
+        child->nodeId = info.nodeId();
+        child->name = info.name();
+        child->path = effectivePath(info, node);
+        child->parent = node;
+        child->accessDenied = info.accessDenied();
+        if (_excludedNodeIds.contains(child->nodeId)) _excludedPaths.insert(child->nodeId, child->path);
+        _nodesById.insert(child->nodeId, child.get());
+        node->children.push_back(std::move(child));
+    }
+    if (!sortedChildren.empty()) endInsertRows();
+    node->childrenState = LoadState::Loaded;
+    if (node == _root.get())
+        emit stateChanged();
+    else
+        emit dataChanged(indexForNode(node), indexForNode(node), {ChildrenLoadingRole, ChildrenLoadFailedRole});
+
+    notifySelectionDataChanged();
+}
+
+void RemoteFolderTreeModel::excludeNode(TreeNode *node) {
+    removeExclusionsAtOrBelow(node);
+    _excludedNodeIds.insert(node->nodeId);
+    _excludedPaths.insert(node->nodeId, node->path);
+}
+
+void RemoteFolderTreeModel::includeNode(TreeNode *node) {
+    TreeNode *excludedAncestor = nullptr;
+    for (TreeNode *cursor = node; cursor && cursor != _root.get(); cursor = cursor->parent) {
+        if (_excludedNodeIds.contains(cursor->nodeId)) {
+            excludedAncestor = cursor;
+            break;
+        }
+    }
+    if (excludedAncestor && excludedAncestor != node) includeFromExcludedAncestor(node, excludedAncestor);
+    removeExclusionsAtOrBelow(node);
+}
+
+void RemoteFolderTreeModel::includeFromExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor) {
+    _excludedNodeIds.remove(excludedAncestor->nodeId);
+    _excludedPaths.remove(excludedAncestor->nodeId);
+    const TreeNode *cursor = node;
+    while (cursor && cursor != excludedAncestor) {
+        const TreeNode *const parentNode = cursor->parent;
+        if (!parentNode) break;
+        for (const auto &sibling: parentNode->children) {
+            if (sibling.get() != cursor) excludeNode(sibling.get());
+        }
+        cursor = parentNode;
+    }
+}
+
+void RemoteFolderTreeModel::removeExclusionsAtOrBelow(const TreeNode *node) {
+    QList<QString> idsToRemove;
+    for (auto it = _excludedNodeIds.cbegin(); it != _excludedNodeIds.cend(); ++it) {
+        if (const QString path = _excludedPaths.value(*it);
+            *it == node->nodeId || (!path.isEmpty() && pathContains(node->path, path)))
+            idsToRemove.push_back(*it);
+    }
+    for (const auto &id: idsToRemove) {
+        _excludedNodeIds.remove(id);
+        _excludedPaths.remove(id);
+    }
+}
+
+void RemoteFolderTreeModel::notifySelectionDataChanged() {
+    notifySelectionDataChanged(_root.get());
+}
+
+void RemoteFolderTreeModel::notifySelectionDataChanged(const TreeNode *parentNode) {
+    if (!parentNode || parentNode->children.empty()) return;
+    emit dataChanged(indexForNode(parentNode->children.front().get()), indexForNode(parentNode->children.back().get()),
+                     {CheckStateRole});
+    for (const auto &child: parentNode->children) notifySelectionDataChanged(child.get());
+}
+
+void RemoteFolderTreeModel::queueSize(TreeNode *node) {
+    if (!node || node->sizeState != SizeState::NotRequested) return;
+    node->sizeState = SizeState::Queued;
+    _sizeQueue.enqueue(node->nodeId);
+    processSizeQueue();
+}
+
+void RemoteFolderTreeModel::processSizeQueue() {
+    while (_activeSizeRequests < maxConcurrentSizeRequests && !_sizeQueue.isEmpty()) {
+        const QString nodeId = _sizeQueue.dequeue();
+        TreeNode *const node = _nodesById.value(nodeId, nullptr);
+        if (!node || node->sizeState != SizeState::Queued || !node->sizeRequested) continue;
+        node->sizeState = SizeState::Loading;
+        ++_activeSizeRequests;
+        const uint64_t generation = _generation;
+        const QPointer self(this);
+        _provider.requestSize(_userDbId, _driveId, QStr2Str(nodeId),
+                              [self, nodeId, generation](const bool success, const int64_t size) {
+                                  if (!self || generation != self->_generation) return;
+                                  self->handleSizeResult(nodeId, generation, success, size);
+                              });
+    }
+}
+
+void RemoteFolderTreeModel::handleSizeResult(const QString &nodeId, const uint64_t generation, const bool success,
+                                             const qint64 size) {
+    if (generation != _generation) return;
+    if (_activeSizeRequests > 0) --_activeSizeRequests;
+    if (TreeNode *const node = _nodesById.value(nodeId, nullptr)) {
+        node->sizeState = success ? SizeState::Loaded : SizeState::Failed;
+        node->size = size;
+        emit dataChanged(indexForNode(node), indexForNode(node), {SizeTextRole});
+    }
+    processSizeQueue();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
@@ -60,13 +60,13 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
 
         explicit RemoteFolderTreeModel(AbstractRemoteFolderProvider &remoteFolderProvider, QObject *parent = nullptr);
 
-        [[nodiscard]] QModelIndex index(int row, int column, const QModelIndex &parentIndex = {}) const override;
+        [[nodiscard]] QModelIndex index(int row, int column, const QModelIndex &parentIndex = QModelIndex()) const override;
         [[nodiscard]] QModelIndex parent(const QModelIndex &child) const override;
-        [[nodiscard]] int rowCount(const QModelIndex &parentIndex = {}) const override;
-        [[nodiscard]] int columnCount(const QModelIndex &parent = {}) const override;
+        [[nodiscard]] int rowCount(const QModelIndex &parentIndex = QModelIndex()) const override;
+        [[nodiscard]] int columnCount(const QModelIndex &parent = QModelIndex()) const override;
         [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
         [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
-        [[nodiscard]] bool hasChildren(const QModelIndex &parentIndex = {}) const override;
+        [[nodiscard]] bool hasChildren(const QModelIndex &parentIndex = QModelIndex()) const override;
         [[nodiscard]] bool canFetchMore(const QModelIndex &parentIndex) const override;
         void fetchMore(const QModelIndex &parentIndex) override;
 
@@ -144,7 +144,7 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
         void handleInitialExclusionPathResult(const QString &nodeId, const ExitInfo &exitInfo, const NodeInfo &info);
         void requestChildren(TreeNode *node);
         void handleChildrenResult(TreeNode *node, uint64_t generation, bool success, const std::vector<NodeInfo> &children);
-        void excludeNode(TreeNode *node);
+        void excludeNode(const TreeNode *node);
         void includeNode(TreeNode *node);
         void includeNodeUnderExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor);
         void removeExclusionsAtOrBelow(const TreeNode *node);
@@ -155,7 +155,7 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
         void handleSizeResult(const QString &nodeId, uint64_t generation, bool success, qint64 size);
 
         AbstractRemoteFolderProvider &_remoteFolderProvider;
-        std::unique_ptr<TreeNode> _root;
+        std::unique_ptr<TreeNode> _root{std::make_unique<TreeNode>()};
         QHash<QString, TreeNode *> _nodesById;
         QSet<QString> _excludedNodeIds;
         QHash<QString, QString> _excludedPaths;

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
@@ -1,0 +1,163 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "libcommon/utility/types.h"
+
+#include <QAbstractItemModel>
+#include <QHash>
+#include <QQueue>
+#include <QSet>
+
+#include <memory>
+#include <vector>
+
+namespace KDC {
+
+class AbstractRemoteFolderProvider;
+class NodeInfo;
+
+/**
+ * Reusable remote-folder tree for selective synchronization.
+ *
+ * The model owns no onboarding state. A caller configures it with remote identifiers and an initial canonical
+ * blacklist, then reads the resulting blacklist after the user validates the editor.
+ */
+class RemoteFolderTreeModel final : public QAbstractItemModel {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY stateChanged)
+        Q_PROPERTY(bool loadFailed READ loadFailed NOTIFY stateChanged)
+        Q_PROPERTY(bool empty READ empty NOTIFY stateChanged)
+        Q_PROPERTY(int rootCheckState READ rootCheckState NOTIFY selectionChanged)
+
+    public:
+        enum Role : int32_t {
+            NameRole = Qt::UserRole + 1,
+            NodeIdRole,
+            CheckStateRole,
+            AccessDeniedRole,
+            SizeTextRole,
+            ChildrenLoadingRole,
+            ChildrenLoadFailedRole,
+        };
+        Q_ENUM(Role)
+
+        explicit RemoteFolderTreeModel(AbstractRemoteFolderProvider &provider, QObject *parent = nullptr);
+
+        [[nodiscard]] QModelIndex index(int row, int column, const QModelIndex &parentIndex = {}) const override;
+        [[nodiscard]] QModelIndex parent(const QModelIndex &child) const override;
+        [[nodiscard]] int rowCount(const QModelIndex &parentIndex = {}) const override;
+        [[nodiscard]] int columnCount(const QModelIndex &parent = {}) const override;
+        [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
+        [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+        [[nodiscard]] bool hasChildren(const QModelIndex &parentIndex = {}) const override;
+        [[nodiscard]] bool canFetchMore(const QModelIndex &parentIndex) const override;
+        void fetchMore(const QModelIndex &parentIndex) override;
+
+        [[nodiscard]] bool loading() const;
+        [[nodiscard]] bool loadFailed() const;
+        [[nodiscard]] bool empty() const;
+        [[nodiscard]] int rootCheckState() const;
+
+        void configure(UserDbId userDbId, DriveId driveId, const NodeId &rootNodeId, const std::vector<NodeId> &initialBlackList);
+        [[nodiscard]] std::vector<NodeId> blackList() const;
+
+        /** Parent of a row, for keyboard navigation: QAbstractItemModel::parent() is not callable from QML. */
+        Q_INVOKABLE [[nodiscard]] QModelIndex parentIndex(const QModelIndex &modelIndex) const { return parent(modelIndex); }
+
+        Q_INVOKABLE void retryRoot();
+        Q_INVOKABLE void retryChildren(const QModelIndex &modelIndex);
+        /**
+         * Includes a folder with its complete subtree, or excludes it with its complete subtree.
+         *
+         * A partially checked folder is excluded as a whole, like an included one: the partial state reports that a
+         * descendant is excluded, it is never a state the user selects.
+         */
+        Q_INVOKABLE void toggleSelection(const QModelIndex &modelIndex);
+        /** Restores a complete selection. The drive root itself can never be excluded. */
+        Q_INVOKABLE void toggleRootSelection();
+        /**
+         * Reports that a row entered or left the viewport.
+         *
+         * A visible row loads its folder size and its immediate children, so its expand affordance reflects whether
+         * the folder really has sub-folders instead of assuming it does.
+         */
+        Q_INVOKABLE void setRowVisible(const QModelIndex &modelIndex, bool visible);
+
+    signals:
+        void stateChanged();
+        void selectionChanged();
+
+    private:
+        enum class LoadState : uint8_t {
+            NotLoaded,
+            Loading,
+            Loaded,
+            Failed,
+        };
+
+        enum class SizeState : uint8_t {
+            NotRequested,
+            Queued,
+            Loading,
+            Loaded,
+            Failed,
+        };
+
+        struct TreeNode {
+                QString nodeId;
+                QString name;
+                QString path;
+                TreeNode *parent{nullptr};
+                std::vector<std::unique_ptr<TreeNode>> children;
+                LoadState childrenState{LoadState::NotLoaded};
+                SizeState sizeState{SizeState::NotRequested};
+                qint64 size{0};
+                bool accessDenied{false};
+                bool sizeRequested{false};
+        };
+
+        [[nodiscard]] TreeNode *nodeForIndex(const QModelIndex &modelIndex) const;
+        [[nodiscard]] QModelIndex indexForNode(const TreeNode *node) const;
+        [[nodiscard]] Qt::CheckState checkState(const TreeNode *node) const;
+        [[nodiscard]] bool isExcluded(const TreeNode *node) const;
+        [[nodiscard]] bool hasExcludedDescendant(const TreeNode *node) const;
+        [[nodiscard]] static bool pathContains(const QString &ancestorPath, const QString &descendantPath);
+        [[nodiscard]] QString effectivePath(const NodeInfo &info, const TreeNode *parentNode) const;
+        void resolveInitialExclusionPaths();
+        void handleInitialExclusionPathResult(const QString &nodeId, const ExitInfo &exitInfo, const NodeInfo &info);
+        void requestChildren(TreeNode *node);
+        void handleChildrenResult(TreeNode *node, uint64_t generation, bool success, const std::vector<NodeInfo> &children);
+        void excludeNode(TreeNode *node);
+        void includeNode(TreeNode *node);
+        void includeFromExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor);
+        void removeExclusionsAtOrBelow(const TreeNode *node);
+        void notifySelectionDataChanged();
+        void notifySelectionDataChanged(const TreeNode *parentNode);
+        void queueSize(TreeNode *node);
+        void processSizeQueue();
+        void handleSizeResult(const QString &nodeId, uint64_t generation, bool success, qint64 size);
+
+        AbstractRemoteFolderProvider &_provider;
+        std::unique_ptr<TreeNode> _root;
+        QHash<QString, TreeNode *> _nodesById;
+        QSet<QString> _excludedNodeIds;
+        QHash<QString, QString> _excludedPaths;
+        QQueue<QString> _sizeQueue;
+        UserDbId _userDbId{0};
+        DriveId _driveId{0};
+        uint64_t _generation{0};
+        uint8_t _activeSizeRequests{0};
+        uint32_t _pendingInitialPathRequests{0};
+        bool _initialPathsFailed{false};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
@@ -58,7 +58,7 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
         };
         Q_ENUM(Role)
 
-        explicit RemoteFolderTreeModel(AbstractRemoteFolderProvider &provider, QObject *parent = nullptr);
+        explicit RemoteFolderTreeModel(AbstractRemoteFolderProvider &remoteFolderProvider, QObject *parent = nullptr);
 
         [[nodiscard]] QModelIndex index(int row, int column, const QModelIndex &parentIndex = {}) const override;
         [[nodiscard]] QModelIndex parent(const QModelIndex &child) const override;
@@ -146,7 +146,7 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
         void handleChildrenResult(TreeNode *node, uint64_t generation, bool success, const std::vector<NodeInfo> &children);
         void excludeNode(TreeNode *node);
         void includeNode(TreeNode *node);
-        void includeFromExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor);
+        void includeNodeUnderExcludedAncestor(const TreeNode *node, const TreeNode *excludedAncestor);
         void removeExclusionsAtOrBelow(const TreeNode *node);
         void notifySelectionDataChanged();
         void notifySelectionDataChanged(const TreeNode *parentNode);
@@ -154,7 +154,7 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
         void processSizeQueue();
         void handleSizeResult(const QString &nodeId, uint64_t generation, bool success, qint64 size);
 
-        AbstractRemoteFolderProvider &_provider;
+        AbstractRemoteFolderProvider &_remoteFolderProvider;
         std::unique_ptr<TreeNode> _root;
         QHash<QString, TreeNode *> _nodesById;
         QSet<QString> _excludedNodeIds;

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR ajoute la base réutilisable pour la synchronisation sélective : choisir quels dossiers distants d'un kDrive sont synchronisés localement. C'est la PR 3 de la pile de 8, et la plus volumineuse. Elle ne livre aucune UI et n'est pas encore reliée à l'onboarding : ses consommateurs arrivent dans les PRs suivantes de la pile. Elle est délibérément neutre vis-à-vis de la fonctionnalité pour que la future intégration dans les Paramètres puisse réutiliser l'arbre, la propagation de sélection, le chargement paresseux et la gestion d'erreurs sans les réécrire.

## Changements
- **Correction du contrat IPC de `CommService::requestNodeSubfolders()`** (`commservice.{h,cpp}`). Le client sérialisait un `DriveDbId`, alors que le job serveur `NodeSubFoldersJob` lit `userDbId`, `driveId`, `nodeId` et `withPath`. La signature et les champs sérialisés sont corrigés. Ceci compte spécifiquement pour l'onboarding : un drive disponible qui n'a pas encore été persisté comme drive configuré n'a pas de `DriveDbId` du tout. `NODE_SUBFOLDERS2`, la variante pour drive configuré, reste inchangée. Cet appel n'avait aucun autre appelant dans la base de code, donc rien d'autre n'est affecté.
- **`app/syncconfiguration/localpaths.{h,cpp}`** : règles du dossier de synchronisation local : la forme d'affichage raccourcie avec `~` (présentation uniquement ; le travail sur le système de fichiers et la validation gardent le chemin absolu), la détection de recouvrement entre dossiers (égalité ou inclusion dans un sens ou dans l'autre), et la dérivation de dossier libre. Cette dernière ajoute le compteur de tentative au nom du dossier sans séparateur, à l'image de `ServerRequests::findGoodPathForNewSync()`, pour que l'utilisateur ne voie jamais deux conventions de nommage différentes pour la même situation. Elle vérifie aussi que le chemin n'existe pas déjà sur le disque, car un chemin dérivé côté client n'est pas couvert par les garanties du serveur.
- **`app/syncconfiguration/remotefolderprovider.{h,cpp}`** : une frontière asynchrone injectable au-dessus de `CommService` pour les informations de nœud, les enfants et la taille des dossiers. Le contrat abstrait porte un `ExitInfo` pour que les appelants puissent distinguer un nœud manquant d'un échec de transport. Les tests et la future intégration dans les Paramètres peuvent l'implémenter sans aucune dépendance à l'onboarding.
- **`app/syncconfiguration/remotefoldertreemodel.{h,cpp}`** : un `QAbstractItemModel` paresseux (445 lignes) qui porte la liste noire canonique. Points à signaler aux relecteurs :
  - **La sémantique tri-état correspond au client Windows** : un dossier est inclus ou exclu avec tout son sous-arbre. L'état partiel signale qu'un descendant est exclu ; ce n'est jamais un état sélectionnable par l'utilisateur. La racine du drive ne peut jamais être exclue, donc la case globale ne fait jamais que restaurer une sélection complète.
  - **Liste noire canonique** : exclure un nœud supprime toute exclusion redondante d'un descendant ; réinclure un nœud sous un ancêtre exclu redescend l'exclusion vers les branches sœurs, en préservant la sémantique précédente sans charger tout le sous-arbre.
  - **Chargement paresseux** : une ligne qui devient visible charge à la fois la taille de son dossier et ses enfants immédiats, pour que son affordance d'expansion reflète si le dossier a réellement des sous-dossiers plutôt que de le supposer. Les échecs de chargement des enfants sont réessayables par nœud et ne perdent jamais la sélection en cours.
  - **Ordonnancement des tailles** : limité à 4 requêtes `NODE_FOLDER_SIZE` concurrentes pour qu'un défilement rapide ne sature pas la file IPC. Une taille non chargée affiche un tiret, qu'elle soit encore en attente ou en échec, la colonne garde ainsi une forme stable pendant l'arrivée des valeurs. Un échec de taille ne bloque jamais la sélection ni la validation.
  - **Liste noire initiale** : quand une liste noire non vide est fournie (cas futur des Paramètres), les chemins des nœuds sont résolus via `NODE_INFO_REMOTE` avant que l'arbre ne soit construit. Si un chemin ne peut pas être résolu, la page échoue, plutôt que d'afficher des ancêtres comme entièrement sélectionnés alors que leur descendant est en réalité exclu. Un nœud que le serveur ne connaît plus (`ExitCause::NotFound`) est retiré de la liste noire plutôt que traité comme un échec.
  - Les résultats obsolètes d'un drive remplacé ou d'une session fermée sont ignorés grâce aux générations de requêtes et à `QPointer`.

## Détails techniques
Aucun des trois nouveaux composants ne référence `PendingSyncConfig`, `OnboardingState` ou `AppCache`, vérifié par grep. Cette indépendance est le point central : le modèle est configuré avec `UserDbId`, un `DriveId` distant, un `NodeId` racine logique et une liste noire initiale, et renvoie une liste noire. Rien ici ne connaît l'onboarding.

Par conséquent, cette PR ajoute du code sans appelant pour l'instant. Les consommateurs arrivent dans les PRs suivantes de la pile (le contrôleur de configuration de synchronisation, puis l'arbre QML).

### Pourquoi cette logique est dupliquée côté client
- **Le serveur ne peut pas le faire pendant l'onboarding.** `findGoodPathForNewSync()` ne décide qu'à partir de deux sources : ce qui existe sur le disque (`checkIfPathExists`) et les synchronisations persistées en base (`selectAllSyncs`). Pendant l'onboarding, ni l'une ni l'autre n'est peuplée : aucun `SYNC_ADD` n'a encore tourné, donc aucun dossier n'existe et aucune synchronisation n'est stockée. Deux kDrive portant le même nom reçoivent donc exactement le même chemin du serveur, dont la requête ne porte d'ailleurs qu'un seul paramètre, `driveName`, sans moyen de savoir ce que la sélection en cours a déjà réservé.
- **Conséquence sans la réservation côté client** : la collision ne se révèle qu'à la toute fin de l'onboarding, quand le second `SYNC_ADD` est rejeté, loin de l'écran où l'utilisateur pourrait agir.
- **Le coût accepté** : la convention de nommage vit désormais à deux endroits. Si le suffixe côté serveur change, le client continuera de produire l'ancien, et l'utilisateur verra deux conventions dans la même liste de drives. C'est documenté dans le contrat de la fonction, qui nomme explicitement `serverrequests.cpp`.
- **Le vrai correctif, volontairement pas fait ici** : faire porter par la requête les chemins déjà réservés par le client, pour que le serveur reste seul propriétaire de la règle. Cela suppose de modifier un contrat IPC partagé avec macOS et Windows, hors du périmètre Linux de cette pile. Cela mérite un ticket de suivi, puisque cela corrigerait aussi les autres plateformes.

## Notes
Depends on #2382.

</details>

---

## Summary
This PR adds the reusable foundation for selective synchronization: choosing which remote folders of a kDrive are synced locally. It is PR 3 of the 8-PR stack, and the largest one. It ships no UI and is not wired to onboarding yet, its consumers land in later PRs of the stack. It is deliberately feature-neutral so the future Settings integration can reuse the tree, the selection propagation, the lazy loading, and the error handling without rewriting them.

## Changes
- **`CommService::requestNodeSubfolders()` contract fix** (`commservice.{h,cpp}`). The client serialized a `DriveDbId`, while the server job `NodeSubFoldersJob` reads `userDbId`, `driveId`, `nodeId` and `withPath`. The signature and the serialized fields are corrected. This matters for onboarding specifically: an available drive that has not been persisted as a configured drive has no `DriveDbId` at all. `NODE_SUBFOLDERS2` remains the configured-drive variant and is untouched. The call had no other caller in the codebase, so nothing else is affected.
- **`app/syncconfiguration/localpaths.{h,cpp}`**: local synchronization-folder rules: the `~`-shortened display form (presentation only; filesystem work and validation keep the absolute path), folder overlap detection (equality or containment either way), and free-folder derivation. That last one appends the attempt count to the folder name without a separator, mirroring `ServerRequests::findGoodPathForNewSync()`, so the user never sees two naming conventions for the same situation. It also checks the path does not already exist on disk, because a client-derived path is not covered by the server's own guarantees.
- **`app/syncconfiguration/remotefolderprovider.{h,cpp}`**: an injectable asynchronous boundary over `CommService` for node info, children and folder size. The abstract contract carries `ExitInfo` so callers can tell a missing node from a transport failure. Tests and the future Settings integration can implement it without any onboarding dependency.
- **`app/syncconfiguration/remotefoldertreemodel.{h,cpp}`**: a lazy `QAbstractItemModel` (445 lines) owning the canonical blacklist. Points worth stating for reviewers:
  - **Tri-state semantics match the Windows client**: a folder is included or excluded with its whole subtree. The partial state reports that some descendant is excluded; it is never a state the user can select. The drive root itself can never be excluded, so the global checkbox only ever restores a complete selection.
  - **Canonical blacklist**: excluding a node removes any redundant descendant exclusion; re-including a node under an excluded ancestor pushes the exclusion down to the sibling branches, preserving prior semantics without loading the whole subtree.
  - **Lazy loading**: a row that becomes visible loads both its folder size and its immediate children, so its expand affordance reflects whether the folder really has sub-folders instead of assuming it does. Child-load failures are retryable per node and never discard the current selection.
  - **Size scheduling**: bounded to 4 concurrent `NODE_FOLDER_SIZE` requests so fast scrolling cannot flood the IPC queue. A size that is not loaded shows a dash, whether it is still pending or failed, the column then keeps a steady shape while values arrive. A size failure never blocks selection or validation.
  - **Initial blacklist**: when a non-empty blacklist is supplied (the future Settings case), node paths are resolved with `NODE_INFO_REMOTE` before the tree is built. If any path cannot be resolved the page fails, rather than displaying ancestors as fully selected while their descendant is in fact excluded. A node the server no longer knows (`ExitCause::NotFound`) is dropped from the blacklist instead of being treated as a failure.
  - Stale results from a replaced drive or a closed session are ignored through request generations and `QPointer`.

## Technical Details
None of the three new components reference `PendingSyncConfig`, `OnboardingState` or `AppCache`, verified by grep. That independence is the point: the model is configured with `UserDbId`, remote `DriveId`, a logical root `NodeId` and an initial blacklist, and hands back a blacklist. Nothing here knows about onboarding.

Consequently this PR adds code with no caller yet. The consumers arrive in the following stack PRs (the sync-configuration controller, then the QML tree).

### Why this logic is duplicated on the client
- **The server cannot do it during onboarding.** `findGoodPathForNewSync()` decides from two sources only: what exists on disk (`checkIfPathExists`) and the synchronizations persisted in its database (`selectAllSyncs`). While onboarding, neither is populated: no `SYNC_ADD` has run, so no folder exists and no sync is stored. Two kDrive sharing a name therefore receive the exact same path from the server, whose request also carries a single parameter, `driveName`, giving it no way to learn what the current selection already claimed.
- **The consequence without the client-side reservation**: the collision only surfaces at the very end of onboarding, when the second `SYNC_ADD` is rejected, far from the screen where the user could act on it.
- **The accepted cost**: the naming convention now lives in two places. If the server-side suffix changes, the client keeps producing the old one and the user sees two conventions in the same drive list. This is documented in the function's contract, which names `serverrequests.cpp` explicitly.
- **The proper fix, deliberately not done here**: let the request carry the paths the client has already reserved, so the server remains the single owner of the rule. That means changing an IPC contract shared with macOS and Windows, outside this stack's Linux-only scope. Worth a follow-up ticket, since it would fix the other platforms too.

## Notes
Depends on #2382.