### PR TITLE
feat(onboarding): resolve default sync folder on drive selection

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -277,6 +277,9 @@
 - `app/onboarding/onboardinglogincoordinator.*`: login workflow coordinator for onboarding. It wires the flow
   controller, OAuth service, comm service, user service, app cache, and onboarding state so `AppClientLinux` does not
   accumulate login-specific workflow logic.
+- `app/onboarding/onboardingdefaultpathresolver.*`: resolves the default local folder of a drive as soon as it is
+  selected, so advanced settings never open on a blocking request. A drive whose folder cannot be resolved is
+  unselected, and drive selection cannot continue while a resolution is in flight.
 - `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It
   derives collision-free local folders, creates selected-drive syncs sequentially with the validated remote blacklist,
   preserves only failed and not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -70,6 +70,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/onboarding/driveselectioncontroller.h
         app/onboarding/onboardingentrydecision.cpp
         app/onboarding/onboardingentrydecision.h
+        app/onboarding/onboardingdefaultpathresolver.cpp
+        app/onboarding/onboardingdefaultpathresolver.h
         app/onboarding/onboardingflowcontroller.cpp
         app/onboarding/onboardingflowcontroller.h
         app/onboarding/onboardinglogincoordinator.cpp

--- a/src/gui4/linux/app/onboarding/driveselectioncontroller.cpp
+++ b/src/gui4/linux/app/onboarding/driveselectioncontroller.cpp
@@ -22,13 +22,19 @@ namespace KDC {
 
 DriveSelectionController::DriveSelectionController(const AppCache &cache, OnboardingState &onboardingState,
                                                    UserService &userService, OnboardingFlowController &flowController,
+                                                   const OnboardingDefaultPathResolver &defaultPathResolver,
                                                    QObject *const parent) :
     QObject(parent),
     _cache(cache),
     _onboardingState(onboardingState),
     _userService(userService),
     _flowController(flowController),
+    _defaultPathResolver(defaultPathResolver),
     _drivesModel(cache, onboardingState, this) {
+    (void) connect(&_defaultPathResolver, &OnboardingDefaultPathResolver::pendingResolutionsChanged, this, [this] {
+        emit canContinueChanged();
+        emit canOpenAdvancedSettingsChanged();
+    });
     (void) connect(&_cache, &AppCache::usersChanged, this, &DriveSelectionController::userChanged);
     (void) connect(&_onboardingState, &OnboardingState::selectedUserDbIdChanged, this, [this] {
         setLoadFailed(false);
@@ -82,11 +88,13 @@ qint32 DriveSelectionController::configuredCount() const {
 }
 
 bool DriveSelectionController::canContinue() const {
+    if (_defaultPathResolver.hasPendingResolutions()) return false;
     return selectedCount() > 0 || configuredCount() > 0;
 }
 
 bool DriveSelectionController::canOpenAdvancedSettings() const {
-    return selectedCount() > 0;
+    // Every selected drive must already own its default folder: the modal never requests one.
+    return selectedCount() > 0 && !loading() && !_defaultPathResolver.hasPendingResolutions();
 }
 
 QString DriveSelectionController::userName() const {

--- a/src/gui4/linux/app/onboarding/driveselectioncontroller.cpp
+++ b/src/gui4/linux/app/onboarding/driveselectioncontroller.cpp
@@ -41,6 +41,7 @@ DriveSelectionController::DriveSelectionController(const AppCache &cache, Onboar
         emit userChanged();
         emit loadingChanged();
         emit emptyChanged();
+        emit canOpenAdvancedSettingsChanged();
     });
     (void) connect(&_drivesModel, &QAbstractItemModel::modelReset, this, &DriveSelectionController::emptyChanged);
     (void) connect(&_drivesModel, &AvailableDrivesModel::selectedCountChanged, this, [this] {
@@ -56,6 +57,8 @@ DriveSelectionController::DriveSelectionController(const AppCache &cache, Onboar
         if (userDbId == selectedUserDbId()) {
             emit loadingChanged();
             emit emptyChanged();
+            // `canOpenAdvancedSettings` reads `loading()`, so its own notifier has to follow it.
+            emit canOpenAdvancedSettingsChanged();
         }
     });
     (void) connect(&_userService, &UserService::availableDrivesLoaded, this, [this](const UserDbId userDbId) {

--- a/src/gui4/linux/app/onboarding/driveselectioncontroller.h
+++ b/src/gui4/linux/app/onboarding/driveselectioncontroller.h
@@ -21,6 +21,7 @@
 #include "app/cache/appcache.h"
 #include "app/cache/onboardingstate.h"
 #include "app/onboarding/availabledrivesmodel.h"
+#include "app/onboarding/onboardingdefaultpathresolver.h"
 #include "app/onboarding/onboardingflowcontroller.h"
 #include "app/services/userservice.h"
 
@@ -52,7 +53,8 @@ class DriveSelectionController final : public QObject {
 
     public:
         explicit DriveSelectionController(const AppCache &cache, OnboardingState &onboardingState, UserService &userService,
-                                          OnboardingFlowController &flowController, QObject *parent = nullptr);
+                                          OnboardingFlowController &flowController,
+                                          const OnboardingDefaultPathResolver &defaultPathResolver, QObject *parent = nullptr);
 
         [[nodiscard]] QAbstractItemModel *drivesModel() { return &_drivesModel; }
         [[nodiscard]] AvailableDrivesModel *availableDrivesModel() { return &_drivesModel; }
@@ -91,6 +93,7 @@ class DriveSelectionController final : public QObject {
         OnboardingState &_onboardingState;
         UserService &_userService;
         OnboardingFlowController &_flowController;
+        const OnboardingDefaultPathResolver &_defaultPathResolver;
         AvailableDrivesModel _drivesModel;
         bool _loadFailed{false};
 };

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "onboardingdefaultpathresolver.h"

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
@@ -25,6 +25,7 @@
 #include "app/syncconfiguration/localpaths.h"
 #include "libcommon/utility/utility.h"
 
+#include <QDir>
 #include <QLoggingCategory>
 #include <QPointer>
 
@@ -92,9 +93,9 @@ void OnboardingDefaultPathResolver::resolveMissingDefaultPaths() {
 void OnboardingDefaultPathResolver::handleGoodPathResult(const AvailableDriveKey &key, const uint64_t generation,
                                                          const ExitInfo &exitInfo, const GoodPathResult &result) {
     if (generation != _generation || !_pendingKeys.contains(key)) return;
-    finishRequest(key);
 
     if (!_onboardingState.isAvailableDriveSelected(key)) {
+        finishRequest(key);
         qCDebug(lcOnboardingDefaultPathResolver)
                 << "Default sync folder dropped: drive unselected meanwhile | driveId:" << key.driveId;
         return;
@@ -105,6 +106,30 @@ void OnboardingDefaultPathResolver::handleGoodPathResult(const AvailableDriveKey
                                                                    return pathTakenByAnotherDrive(candidate, key);
                                                                })
                                          : QString{};
+    if (defaultPath.isEmpty() || defaultPath == QDir::cleanPath(Path2QStr(result.goodPath))) {
+        // Untouched server proposal: it was just vouched for, asking again would only cost a round trip.
+        applyDefaultPath(key, defaultPath, exitInfo);
+        return;
+    }
+
+    // Derived here, so the server has never seen it. Only it can tell a folder free of any sync from one still held
+    // by a sync whose local folder the user deleted by hand, which `QFileInfo::exists()` reports as free.
+    // The key stays pending until the answer comes back: onboarding must keep waiting for it.
+    const QPointer self(this);
+    _commService.requestIsPathValidForNewSync(QStr2Path(defaultPath), SyncConfiguration::Classic,
+                                              [self, key, generation, defaultPath, exitInfo](const ExitInfo &checkInfo,
+                                                                                             const bool valid) {
+                                                  if (!self || generation != self->_generation) return;
+                                                  self->applyDefaultPath(key, checkInfo && valid ? defaultPath : QString{},
+                                                                         exitInfo);
+                                              });
+}
+
+void OnboardingDefaultPathResolver::applyDefaultPath(const AvailableDriveKey &key, const QString &defaultPath,
+                                                     const ExitInfo &exitInfo) {
+    finishRequest(key);
+    if (!_onboardingState.isAvailableDriveSelected(key)) return;
+
     if (defaultPath.isEmpty()) {
         qCWarning(lcOnboardingDefaultPathResolver)
                 << "No default sync folder available, unselecting drive | driveId:" << key.driveId;

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
@@ -56,13 +56,11 @@ void OnboardingDefaultPathResolver::invalidatePendingRequests() {
 }
 
 bool OnboardingDefaultPathResolver::pathTakenByAnotherDrive(const QString &path, const AvailableDriveKey &excludedKey) const {
-    for (const auto &key: _onboardingState.selectedAvailableDriveKeys()) {
-        if (key == excludedKey) continue;
+    return std::ranges::any_of(_onboardingState.selectedAvailableDriveKeys(), [&](const AvailableDriveKey &key) {
+        if (key == excludedKey) return false;
         const auto config = _onboardingState.pendingSyncConfig(key);
-        if (!config || config->localPath.isEmpty()) continue;
-        if (localPathsOverlap(path, config->localPath)) return true;
-    }
-    return false;
+        return config && !config->localPath.isEmpty() && localPathsOverlap(path, config->localPath);
+    });
 }
 
 void OnboardingDefaultPathResolver::resolveMissingDefaultPaths() {

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
@@ -1,0 +1,121 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "onboardingdefaultpathresolver.h"
+
+#include "app/cache/appcache.h"
+#include "app/cache/onboardingstate.h"
+#include "app/services/commservice.h"
+#include "app/services/serviceeventbus.h"
+#include "app/syncconfiguration/localpaths.h"
+#include "libcommon/utility/utility.h"
+
+#include <QLoggingCategory>
+#include <QPointer>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcOnboardingDefaultPathResolver, "gui.v4.onboardingdefaultpathresolver", QtInfoMsg)
+}
+
+OnboardingDefaultPathResolver::OnboardingDefaultPathResolver(const AppCache &appCache, OnboardingState &onboardingState,
+                                                             CommService &commService, ServiceEventBus &serviceEventBus,
+                                                             QObject *const parent) :
+    QObject(parent),
+    _appCache(appCache),
+    _onboardingState(onboardingState),
+    _commService(commService),
+    _serviceEventBus(serviceEventBus) {
+    (void) connect(&_onboardingState, &OnboardingState::selectedAvailableDrivesChanged, this,
+                   &OnboardingDefaultPathResolver::resolveMissingDefaultPaths);
+}
+
+void OnboardingDefaultPathResolver::invalidatePendingRequests() {
+    ++_generation;
+    if (_pendingKeys.empty()) return;
+    _pendingKeys.clear();
+    emit pendingResolutionsChanged();
+}
+
+bool OnboardingDefaultPathResolver::pathTakenByAnotherDrive(const QString &path, const AvailableDriveKey &excludedKey) const {
+    for (const auto &key: _onboardingState.selectedAvailableDriveKeys()) {
+        if (key == excludedKey) continue;
+        const auto config = _onboardingState.pendingSyncConfig(key);
+        if (!config || config->localPath.isEmpty()) continue;
+        if (localPathsOverlap(path, config->localPath)) return true;
+    }
+    return false;
+}
+
+void OnboardingDefaultPathResolver::resolveMissingDefaultPaths() {
+    for (const auto &key: _onboardingState.selectedAvailableDriveKeys()) {
+        if (_pendingKeys.contains(key)) continue;
+        if (const auto config = _onboardingState.pendingSyncConfig(key); config && !config->defaultLocalPath.isEmpty()) continue;
+
+        const auto availableDrive = _appCache.availableDrive(key);
+        if (!availableDrive) continue;
+
+        const bool wasIdle = _pendingKeys.empty();
+        (void) _pendingKeys.insert(key);
+        if (wasIdle) emit pendingResolutionsChanged();
+
+        qCInfo(lcOnboardingDefaultPathResolver)
+                << "Requesting default sync folder | userDbId:" << key.userDbId << "/ driveId:" << key.driveId;
+        const uint64_t generation = _generation;
+        const QPointer self(this);
+        _commService.requestFindGoodPathForNewSync(
+                CommonUtility::str2CommString(availableDrive->name()),
+                [self, key, generation](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                    if (!self) return;
+                    self->handleGoodPathResult(key, generation, exitInfo, result);
+                });
+    }
+}
+
+void OnboardingDefaultPathResolver::handleGoodPathResult(const AvailableDriveKey &key, const uint64_t generation,
+                                                         const ExitInfo &exitInfo, const GoodPathResult &result) {
+    if (generation != _generation || !_pendingKeys.contains(key)) return;
+    finishRequest(key);
+
+    if (!_onboardingState.isAvailableDriveSelected(key)) {
+        qCDebug(lcOnboardingDefaultPathResolver)
+                << "Default sync folder dropped: drive unselected meanwhile | driveId:" << key.driveId;
+        return;
+    }
+
+    const QString defaultPath = exitInfo ? makeUniqueLocalPath(Path2QStr(result.goodPath),
+                                                               [this, &key](const QString &candidate) {
+                                                                   return pathTakenByAnotherDrive(candidate, key);
+                                                               })
+                                         : QString{};
+    if (defaultPath.isEmpty()) {
+        qCWarning(lcOnboardingDefaultPathResolver)
+                << "No default sync folder available, unselecting drive | driveId:" << key.driveId;
+        _onboardingState.unselectAvailableDrive(key);
+        _serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
+        return;
+    }
+
+    PendingSyncConfig config = _onboardingState.pendingSyncConfig(key).value_or(PendingSyncConfig{});
+    config.defaultLocalPath = defaultPath;
+    if (config.localPath.isEmpty() || config.usesDefaultLocalPath) {
+        config.localPath = defaultPath;
+        config.usesDefaultLocalPath = true;
+    }
+    _onboardingState.setPendingSyncConfig(key, config);
+}
+
+void OnboardingDefaultPathResolver::finishRequest(const AvailableDriveKey &key) {
+    if (_pendingKeys.erase(key) == 0) return;
+    if (_pendingKeys.empty()) emit pendingResolutionsChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
@@ -28,6 +28,8 @@
 #include <QLoggingCategory>
 #include <QPointer>
 
+#include <algorithm>
+
 namespace KDC {
 
 namespace {
@@ -48,9 +50,8 @@ OnboardingDefaultPathResolver::OnboardingDefaultPathResolver(const AppCache &app
 
 void OnboardingDefaultPathResolver::invalidatePendingRequests() {
     ++_generation;
-    if (_pendingKeys.empty()) return;
     _pendingKeys.clear();
-    emit pendingResolutionsChanged();
+    updatePendingResolutions();
 }
 
 bool OnboardingDefaultPathResolver::pathTakenByAnotherDrive(const QString &path, const AvailableDriveKey &excludedKey) const {
@@ -71,9 +72,7 @@ void OnboardingDefaultPathResolver::resolveMissingDefaultPaths() {
         const auto availableDrive = _appCache.availableDrive(key);
         if (!availableDrive) continue;
 
-        const bool wasIdle = _pendingKeys.empty();
         (void) _pendingKeys.insert(key);
-        if (wasIdle) emit pendingResolutionsChanged();
 
         qCInfo(lcOnboardingDefaultPathResolver)
                 << "Requesting default sync folder | userDbId:" << key.userDbId << "/ driveId:" << key.driveId;
@@ -86,6 +85,8 @@ void OnboardingDefaultPathResolver::resolveMissingDefaultPaths() {
                     self->handleGoodPathResult(key, generation, exitInfo, result);
                 });
     }
+    // Also covers a plain deselection: its request stays in flight but no longer holds onboarding back.
+    updatePendingResolutions();
 }
 
 void OnboardingDefaultPathResolver::handleGoodPathResult(const AvailableDriveKey &key, const uint64_t generation,
@@ -123,7 +124,16 @@ void OnboardingDefaultPathResolver::handleGoodPathResult(const AvailableDriveKey
 
 void OnboardingDefaultPathResolver::finishRequest(const AvailableDriveKey &key) {
     if (_pendingKeys.erase(key) == 0) return;
-    if (_pendingKeys.empty()) emit pendingResolutionsChanged();
+    updatePendingResolutions();
+}
+
+void OnboardingDefaultPathResolver::updatePendingResolutions() {
+    // Only a request whose drive is still selected blocks onboarding: the folder of an unselected one is never used.
+    const bool pending = std::ranges::any_of(
+            _pendingKeys, [this](const AvailableDriveKey &key) { return _onboardingState.isAvailableDriveSelected(key); });
+    if (pending == _pendingResolutions) return;
+    _pendingResolutions = pending;
+    emit pendingResolutionsChanged();
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.cpp
@@ -56,11 +56,13 @@ void OnboardingDefaultPathResolver::invalidatePendingRequests() {
 }
 
 bool OnboardingDefaultPathResolver::pathTakenByAnotherDrive(const QString &path, const AvailableDriveKey &excludedKey) const {
-    return std::ranges::any_of(_onboardingState.selectedAvailableDriveKeys(), [&](const AvailableDriveKey &key) {
-        if (key == excludedKey) return false;
-        const auto config = _onboardingState.pendingSyncConfig(key);
-        return config && !config->localPath.isEmpty() && localPathsOverlap(path, config->localPath);
-    });
+    return std::ranges::any_of(_onboardingState.selectedAvailableDriveKeys(),
+                               [this, &path, &excludedKey](const AvailableDriveKey &key) {
+                                   if (key == excludedKey) return false;
+                                   const auto config = _onboardingState.pendingSyncConfig(key);
+                                   return config && !config->localPath.isEmpty() &&
+                                          localPathsOverlap(path, config->localPath);
+                               });
 }
 
 void OnboardingDefaultPathResolver::resolveMissingDefaultPaths() {

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
@@ -1,0 +1,66 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "app/cache/cachetypes.h"
+
+#include <QObject>
+#include <QString>
+
+#include <unordered_set>
+
+namespace KDC {
+
+class AppCache;
+class CommService;
+class OnboardingState;
+class ServiceEventBus;
+struct ExitInfo;
+struct GoodPathResult;
+
+/**
+ * Resolves the default local folder of a drive as soon as it is selected.
+ *
+ * Preparing the folder here, rather than when advanced settings open, keeps that modal free of blocking requests and
+ * matches the Windows client. A drive whose folder cannot be resolved is unselected, because onboarding has nothing
+ * to synchronize it into.
+ */
+class OnboardingDefaultPathResolver final : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit OnboardingDefaultPathResolver(const AppCache &appCache, OnboardingState &onboardingState,
+                                               CommService &commService, ServiceEventBus &serviceEventBus,
+                                               QObject *parent = nullptr);
+
+        /** True while at least one selected drive still awaits its default folder. */
+        [[nodiscard]] bool hasPendingResolutions() const { return !_pendingKeys.empty(); }
+        void invalidatePendingRequests();
+
+    signals:
+        void pendingResolutionsChanged();
+
+    private:
+        [[nodiscard]] bool pathTakenByAnotherDrive(const QString &path, const AvailableDriveKey &excludedKey) const;
+        void resolveMissingDefaultPaths();
+        void handleGoodPathResult(const AvailableDriveKey &key, uint64_t generation, const ExitInfo &exitInfo,
+                                  const GoodPathResult &result);
+        void finishRequest(const AvailableDriveKey &key);
+
+        const AppCache &_appCache;
+        OnboardingState &_onboardingState;
+        CommService &_commService;
+        ServiceEventBus &_serviceEventBus;
+        std::unordered_set<AvailableDriveKey> _pendingKeys;
+        uint64_t _generation{0};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
@@ -61,6 +61,7 @@ class OnboardingDefaultPathResolver final : public QObject {
         void resolveMissingDefaultPaths();
         void handleGoodPathResult(const AvailableDriveKey &key, uint64_t generation, const ExitInfo &exitInfo,
                                   const GoodPathResult &result);
+        void applyDefaultPath(const AvailableDriveKey &key, const QString &defaultPath, const ExitInfo &exitInfo);
         void finishRequest(const AvailableDriveKey &key);
         void updatePendingResolutions();
 

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
+++ b/src/gui4/linux/app/onboarding/onboardingdefaultpathresolver.h
@@ -50,7 +50,7 @@ class OnboardingDefaultPathResolver final : public QObject {
                                                QObject *parent = nullptr);
 
         /** True while at least one selected drive still awaits its default folder. */
-        [[nodiscard]] bool hasPendingResolutions() const { return !_pendingKeys.empty(); }
+        [[nodiscard]] bool hasPendingResolutions() const { return _pendingResolutions; }
         void invalidatePendingRequests();
 
     signals:
@@ -62,12 +62,16 @@ class OnboardingDefaultPathResolver final : public QObject {
         void handleGoodPathResult(const AvailableDriveKey &key, uint64_t generation, const ExitInfo &exitInfo,
                                   const GoodPathResult &result);
         void finishRequest(const AvailableDriveKey &key);
+        void updatePendingResolutions();
 
         const AppCache &_appCache;
         OnboardingState &_onboardingState;
         CommService &_commService;
         ServiceEventBus &_serviceEventBus;
+        // Identity of the requests in flight. A key stays here until its callback returns, even once its drive is
+        // unselected, so a late result is still recognised and dropped instead of being applied.
         std::unordered_set<AvailableDriveKey> _pendingKeys;
+        bool _pendingResolutions{false};
         uint64_t _generation{0};
 };
 

--- a/src/gui4/linux/app/onboarding/onboardingsession.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsession.cpp
@@ -40,7 +40,8 @@ OnboardingSession::OnboardingSession(AppCache &appCache, CommService &commServic
     _userService(userService),
     _onboardingState(appCache),
     _loginCoordinator(_flowController, commService, userService, appCache, _onboardingState),
-    _driveSelectionController(appCache, _onboardingState, userService, _flowController),
+    _defaultPathResolver(appCache, _onboardingState, commService, serviceEventBus),
+    _driveSelectionController(appCache, _onboardingState, userService, _flowController, _defaultPathResolver),
     _syncCreationCoordinator(_flowController, _onboardingState, appCache, commService, cachePopulator, serviceEventBus),
     _generation(generation) {
     (void) connect(&_loginCoordinator, &OnboardingLoginCoordinator::openWindowRequested, this,
@@ -65,6 +66,7 @@ AvailableDrivesModel *OnboardingSession::availableDrivesModel() {
 }
 
 void OnboardingSession::invalidatePendingOperations() {
+    _defaultPathResolver.invalidatePendingRequests();
     _userService.invalidateLoginTokenRequest();
     if (const UserDbId selectedUserDbId = _onboardingState.typedSelectedUserDbId(); selectedUserDbId != 0) {
         _userService.invalidateAvailableDrivesRequest(selectedUserDbId);

--- a/src/gui4/linux/app/onboarding/onboardingsession.h
+++ b/src/gui4/linux/app/onboarding/onboardingsession.h
@@ -21,6 +21,7 @@
 #include "app/cache/onboardingstate.h"
 #include "app/onboarding/driveselectioncontroller.h"
 #include "app/onboarding/onboardingflowcontroller.h"
+#include "app/onboarding/onboardingdefaultpathresolver.h"
 #include "app/onboarding/onboardinglogincoordinator.h"
 #include "app/onboarding/onboardingsynccreationcoordinator.h"
 
@@ -74,6 +75,7 @@ class OnboardingSession final : public QObject {
         OnboardingState _onboardingState;
         OnboardingFlowController _flowController;
         OnboardingLoginCoordinator _loginCoordinator;
+        OnboardingDefaultPathResolver _defaultPathResolver;
         DriveSelectionController _driveSelectionController;
         OnboardingSyncCreationCoordinator _syncCreationCoordinator;
         const uint64_t _generation;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR est la 4e d'une pile de 8, à la suite de #2381, #2382 et #2385. Elle déplace la résolution du dossier local par défaut d'un drive au moment où l'utilisateur coche ce drive, au lieu de le faire à l'ouverture de la modale des paramètres avancés. Cela aligne Linux sur le client Windows, où `DriveSelectionPage.xaml.cs` appelle `GetGoodPathForNewSync` depuis le gestionnaire de la case à cocher, afin que la modale ne s'ouvre jamais sur une requête bloquante.

## Changements
- Nouveau `app/onboarding/onboardingdefaultpathresolver.{h,cpp}`, à portée de session, possédé par `OnboardingSession` :
  - Écoute `OnboardingState::selectedAvailableDrivesChanged` et résout le dossier de tout drive sélectionné qui n'en a pas encore, via `UTILITY_FINDGOODPATHFORNEWSYNC`.
  - Utilise `makeUniqueLocalPath()` de #2385 pour réserver un chemin libre par rapport aux drives déjà sélectionnés. C'est ici que la réservation côté client documentée dans #2385 est réellement utilisée.
  - Un drive dont le dossier ne peut pas être résolu est **désélectionné** (comme sur Windows, qui décoche la case en cas d'échec), et l'erreur est reportée via `ServiceEventBus`. L'onboarding n'a sinon rien vers quoi synchroniser ce drive.
  - Ignore les résultats obsolètes grâce à une génération de requête et à `QPointer` ; `invalidatePendingRequests()` est appelé depuis `OnboardingSession::invalidatePendingOperations()`.
- `DriveSelectionController` prend le resolver en dépendance et rapporte désormais `canContinue` et `canOpenAdvancedSettings` à `false` tant qu'une résolution est en cours. Avant ce changement, `canOpenAdvancedSettings()` ne renvoyait que `selectedCount() > 0`, donc la modale pouvait s'ouvrir pendant que la liste des drives était encore en cours de chargement, ce que la clause « et la liste des drives n'est pas occupée » du plan était censée empêcher.
- `OnboardingSession` gagne le resolver comme membre, construit avant `DriveSelectionController` puisque ce dernier prend désormais une référence vers lui.

## Détails techniques
- Cette PR consomme `PendingSyncConfig::defaultLocalPath` / `usesDefaultLocalPath` (ajoutés dans #2381) et `localpaths` (ajouté dans #2385). C'est la première branche qui utilise réellement les deux, ce qui explique sa place dans la pile.
- La modale des paramètres avancés n'existe pas encore ; elle arrive dans les PRs suivantes. Ce que cette PR garantit, c'est qu'à son ouverture, chaque drive sélectionné possède déjà un dossier par défaut résolu, et que la modale n'a besoin d'aucune requête propre.
- `OnboardingSyncCreationCoordinator` conserve son propre repli `prepareSynchronization()` pour un drive qui atteindrait la fin de l'onboarding sans chemin. Il est désormais effectivement inatteignable dans le flux nominal, mais a été laissé en place comme filet de sécurité plutôt que retiré dans cette PR.

</details>

---

## Summary
This is the 4th of an 8-PR stack, following #2381, #2382 and #2385. It moves the resolution of a drive's default local folder to the moment the user checks that drive, instead of doing it when the advanced-settings modal opens. This aligns Linux with the Windows client, where `DriveSelectionPage.xaml.cs` calls `GetGoodPathForNewSync` from the checkbox handler, so the modal never opens on a blocking request.

## Changes
- New `app/onboarding/onboardingdefaultpathresolver.{h,cpp}`, session-scoped, owned by `OnboardingSession`:
  - Listens to `OnboardingState::selectedAvailableDrivesChanged` and resolves the folder of any selected drive that does not have one yet, through `UTILITY_FINDGOODPATHFORNEWSYNC`.
  - Uses `makeUniqueLocalPath()` from #2385 to reserve a free path against the drives already selected. This is where the client-side reservation documented in #2385 actually gets used.
  - A drive whose folder cannot be resolved is unselected (mirroring Windows, which unchecks the box on failure), and the error is reported through `ServiceEventBus`. Onboarding has nothing to synchronize a drive into otherwise.
  - Ignores stale results through a request generation and `QPointer`; `invalidatePendingRequests()` is called from `OnboardingSession::invalidatePendingOperations()`.
- `DriveSelectionController` takes the resolver as a dependency and now reports `canContinue` and `canOpenAdvancedSettings` as false while a resolution is in flight. Before this change, `canOpenAdvancedSettings()` returned only `selectedCount() > 0`, so the modal could be opened while the drive list was still loading, which is what the plan's "and the drive list is not busy" clause was meant to prevent.
- `OnboardingSession` gains the resolver as a member, constructed before `DriveSelectionController` since the latter now takes a reference to it.

## Technical Details
- This PR consumes `PendingSyncConfig::defaultLocalPath` / `usesDefaultLocalPath` (added in #2381) and `localpaths` (added in #2385). It is the first branch that actually uses both, which is why it sits here in the stack.
- The advanced-settings modal itself does not exist yet; it arrives in later PRs. What this PR guarantees is that when it does open, every selected drive already owns a resolved default folder and the modal needs no request of its own.
- `OnboardingSyncCreationCoordinator` still has its own `prepareSynchronization()` fallback for a drive that somehow reaches the end of onboarding without a path. It is now effectively unreachable in the nominal flow, but was left in place as a safety net rather than removed in this PR.

## Notes
Depends on #2385