### PR TITLE
feat(sync-config): add transactional advanced settings controller

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -280,6 +280,12 @@
 - `app/onboarding/onboardingdefaultpathresolver.*`: resolves the default local folder of a drive as soon as it is
   selected, so advanced settings never open on a blocking request. A drive whose folder cannot be resolved is
   unselected, and drive selection cannot continue while a resolution is in flight.
+- `app/onboarding/onboardingsyncconfigurationcontroller.*`: session-scoped transactional editor for advanced onboarding
+  synchronization settings. It owns global and per-drive draft snapshots, validates custom paths against the server and
+  against the other drafts, and commits all selected-drive configs only from the final confirmation. A rejected commit
+  keeps the modal open, because closing would silently drop everything the user configured.
+- `app/onboarding/selectedsyncconfigurationsmodel.*`: flat presentation model for the multi-drive advanced-settings
+  summary. It exposes display values only; stable backend identifiers remain in the controller drafts.
 - `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It
   derives collision-free local folders, creates selected-drive syncs sequentially with the validated remote blacklist,
   preserves only failed and not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -76,12 +76,16 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/onboarding/onboardingflowcontroller.h
         app/onboarding/onboardinglogincoordinator.cpp
         app/onboarding/onboardinglogincoordinator.h
+        app/onboarding/onboardingsyncconfigurationcontroller.cpp
+        app/onboarding/onboardingsyncconfigurationcontroller.h
         app/onboarding/onboardingsession.cpp
         app/onboarding/onboardingsession.h
         app/onboarding/onboardingsessionmanager.cpp
         app/onboarding/onboardingsessionmanager.h
         app/onboarding/onboardingsynccreationcoordinator.cpp
         app/onboarding/onboardingsynccreationcoordinator.h
+        app/onboarding/selectedsyncconfigurationsmodel.cpp
+        app/onboarding/selectedsyncconfigurationsmodel.h
         app/onboarding/oauthloginservice.cpp
         app/onboarding/oauthloginservice.h
         app/syncconfiguration/localpaths.cpp

--- a/src/gui4/linux/app/onboarding/onboardingsession.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsession.cpp
@@ -42,6 +42,7 @@ OnboardingSession::OnboardingSession(AppCache &appCache, CommService &commServic
     _loginCoordinator(_flowController, commService, userService, appCache, _onboardingState),
     _defaultPathResolver(appCache, _onboardingState, commService, serviceEventBus),
     _driveSelectionController(appCache, _onboardingState, userService, _flowController, _defaultPathResolver),
+    _syncConfigurationController(appCache, _onboardingState, _flowController, commService),
     _syncCreationCoordinator(_flowController, _onboardingState, appCache, commService, cachePopulator, serviceEventBus),
     _generation(generation) {
     (void) connect(&_loginCoordinator, &OnboardingLoginCoordinator::openWindowRequested, this,

--- a/src/gui4/linux/app/onboarding/onboardingsession.h
+++ b/src/gui4/linux/app/onboarding/onboardingsession.h
@@ -23,6 +23,7 @@
 #include "app/onboarding/onboardingflowcontroller.h"
 #include "app/onboarding/onboardingdefaultpathresolver.h"
 #include "app/onboarding/onboardinglogincoordinator.h"
+#include "app/onboarding/onboardingsyncconfigurationcontroller.h"
 #include "app/onboarding/onboardingsynccreationcoordinator.h"
 
 #include <QObject>
@@ -50,6 +51,7 @@ class OnboardingSession final : public QObject {
         Q_PROPERTY(OnboardingFlowController *flowController READ flowController CONSTANT)
         Q_PROPERTY(DriveSelectionController *driveSelectionController READ driveSelectionController CONSTANT)
         Q_PROPERTY(AvailableDrivesModel *availableDrivesModel READ availableDrivesModel CONSTANT)
+        Q_PROPERTY(OnboardingSyncConfigurationController *syncConfigurationController READ syncConfigurationController CONSTANT)
 
     public:
         enum class EntryPoint : uint8_t {
@@ -64,6 +66,9 @@ class OnboardingSession final : public QObject {
         [[nodiscard]] OnboardingFlowController *flowController() { return &_flowController; }
         [[nodiscard]] DriveSelectionController *driveSelectionController() { return &_driveSelectionController; }
         [[nodiscard]] AvailableDrivesModel *availableDrivesModel();
+        [[nodiscard]] OnboardingSyncConfigurationController *syncConfigurationController() {
+            return &_syncConfigurationController;
+        }
         [[nodiscard]] uint64_t generation() const { return _generation; }
         void invalidatePendingOperations();
 
@@ -77,6 +82,7 @@ class OnboardingSession final : public QObject {
         OnboardingLoginCoordinator _loginCoordinator;
         OnboardingDefaultPathResolver _defaultPathResolver;
         DriveSelectionController _driveSelectionController;
+        OnboardingSyncConfigurationController _syncConfigurationController;
         OnboardingSyncCreationCoordinator _syncCreationCoordinator;
         const uint64_t _generation;
 };

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
@@ -1,0 +1,341 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "onboardingsyncconfigurationcontroller.h"
+
+#include "app/appconstants.h"
+#include "app/cache/appcache.h"
+#include "app/cache/onboardingstate.h"
+#include "app/onboarding/onboardingflowcontroller.h"
+#include "app/services/commservice.h"
+#include "app/syncconfiguration/localpaths.h"
+#include "libcommon/utility/utility.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QPointer>
+
+#include <algorithm>
+#include <unordered_map>
+
+using namespace Qt::StringLiterals;
+
+namespace KDC {
+
+OnboardingSyncConfigurationController::OnboardingSyncConfigurationController(AppCache &appCache, OnboardingState &onboardingState,
+                                                                             OnboardingFlowController &flowController,
+                                                                             CommService &commService, QObject *const parent) :
+    QObject(parent),
+    _appCache(appCache),
+    _onboardingState(onboardingState),
+    _flowController(flowController),
+    _commService(commService),
+    _selectedDrivesModel(this),
+    _folderProvider(commService),
+    _folderTreeModel(_folderProvider, this) {
+    (void) connect(&_flowController, &OnboardingFlowController::advancedSettingsRequested, this,
+                   &OnboardingSyncConfigurationController::open);
+    (void) connect(&_folderTreeModel, &RemoteFolderTreeModel::stateChanged, this,
+                   &OnboardingSyncConfigurationController::presentationChanged);
+}
+
+bool OnboardingSyncConfigurationController::canValidate() const {
+    if (_busy) return false;
+    if (_page == FolderSelection) return !_folderTreeModel.loading() && !_folderTreeModel.loadFailed();
+    if (_page == DriveConfiguration) return currentDraft() && !currentDraft()->config.localPath.isEmpty();
+    return !_drafts.empty() && std::ranges::all_of(_drafts, [](const Draft &draft) { return !draft.config.localPath.isEmpty(); });
+}
+
+QString OnboardingSyncConfigurationController::currentDriveName() const {
+    return currentDraft() ? currentDraft()->driveName : QString{};
+}
+
+QColor OnboardingSyncConfigurationController::currentDriveColor() const {
+    return currentDraft() ? currentDraft()->driveColor : AppConstants::Drive::defaultColor();
+}
+
+QString OnboardingSyncConfigurationController::currentLocalPath() const {
+    return currentDraft() ? displayLocalPath(currentDraft()->config.localPath) : QString{};
+}
+
+bool OnboardingSyncConfigurationController::currentUsesDefaultFolder() const {
+    return currentDraft() && currentDraft()->config.usesDefaultLocalPath;
+}
+
+bool OnboardingSyncConfigurationController::currentHasCustomSelection() const {
+    return currentDraft() && !currentDraft()->config.blackList.empty();
+}
+
+void OnboardingSyncConfigurationController::open() {
+    if (_visible) return;
+    buildDrafts();
+    if (_drafts.empty()) return;
+
+    ++_requestGeneration;
+    _visible = true;
+    _busy = false;
+    _errorTitle.clear();
+    _errorText.clear();
+    _page = Summary;
+    _currentRow = -1;
+    emit visibleChanged();
+    showInitialPage();
+}
+
+void OnboardingSyncConfigurationController::configureDrive(const int32_t row) {
+    if (_busy || row < 0 || static_cast<std::size_t>(row) >= _drafts.size()) return;
+    openDrive(row);
+}
+
+void OnboardingSyncConfigurationController::cancelCurrentPage() {
+    clearError();
+    if (_page == FolderSelection) {
+        _page = DriveConfiguration;
+        emit presentationChanged();
+        return;
+    }
+    if (_page == DriveConfiguration) {
+        if (_driveSnapshot && currentDraft()) currentDraft()->config = *_driveSnapshot;
+        refreshSummaryModel();
+        if (_drafts.size() == 1) {
+            closeWithoutCommit();
+        } else {
+            _page = Summary;
+            _currentRow = -1;
+            emit presentationChanged();
+        }
+        return;
+    }
+    closeWithoutCommit();
+}
+
+void OnboardingSyncConfigurationController::validateCurrentPage() {
+    clearError();
+    if (!canValidate()) return;
+    if (_page == FolderSelection) {
+        if (Draft *const draft = currentDraft()) draft->config.blackList = _folderTreeModel.blackList();
+        _page = DriveConfiguration;
+        refreshSummaryModel();
+        emit presentationChanged();
+        return;
+    }
+    if (_page == DriveConfiguration) {
+        refreshSummaryModel();
+        if (_drafts.size() == 1) {
+            commitAndClose();
+        } else {
+            _page = Summary;
+            _currentRow = -1;
+            emit presentationChanged();
+        }
+        return;
+    }
+    commitAndClose();
+}
+
+void OnboardingSyncConfigurationController::requestCustomFolder() {
+    if (_busy || !currentDraft()) return;
+    const QFileInfo currentLocation(currentDraft()->config.localPath);
+    emit customFolderRequested(
+            QUrl::fromLocalFile(currentLocation.exists() ? currentLocation.absoluteFilePath() : currentLocation.absolutePath()));
+}
+
+void OnboardingSyncConfigurationController::notifyCustomFolderDialogClosed() {
+    emit customFolderDialogClosed();
+}
+
+void OnboardingSyncConfigurationController::applyCustomFolder(const QUrl &folderUrl) {
+    if (_busy) return;
+    const Draft *const draft = currentDraft();
+    const QString path = QDir::cleanPath(folderUrl.toLocalFile());
+    if (!draft || path.isEmpty()) return;
+    if (conflictsWithAnotherDraft(path, _currentRow)) {
+        setError(qtTrId("teachingTipInvalidFolderTitle"), qtTrId("teachingTipInvalidFolderContent"));
+        return;
+    }
+
+    setBusy(true);
+    clearError();
+    const uint64_t generation = ++_requestGeneration;
+    const QPointer self(this);
+    _commService.requestIsPathValidForNewSync(
+            QStr2Path(path), SyncConfiguration::Classic, [self, generation, path](const ExitInfo &exitInfo, const bool valid) {
+                if (!self || generation != self->_requestGeneration) return;
+                self->setBusy(false);
+                if (!exitInfo || !valid || !self->currentDraft()) {
+                    self->setError(qtTrId("teachingTipInvalidFolderTitle"), qtTrId("teachingTipInvalidFolderContent"));
+                    return;
+                }
+                self->currentDraft()->config.localPath = path;
+                self->currentDraft()->config.usesDefaultLocalPath =
+                        QDir::cleanPath(self->currentDraft()->config.defaultLocalPath) == path;
+                self->refreshSummaryModel();
+                emit self->presentationChanged();
+            });
+}
+
+void OnboardingSyncConfigurationController::returnToDefaultFolder() {
+    if (_busy) return;
+    Draft *const draft = currentDraft();
+    if (!draft || draft->config.defaultLocalPath.isEmpty()) return;
+    draft->config.localPath = draft->config.defaultLocalPath;
+    draft->config.usesDefaultLocalPath = true;
+    clearError();
+    refreshSummaryModel();
+    emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::selectFolders() {
+    const Draft *const draft = currentDraft();
+    if (!draft || _busy) return;
+    _folderTreeModel.configure(draft->key.userDbId, draft->key.driveId, QStr2Str(draft->config.targetNodeId),
+                               draft->config.blackList);
+    _page = FolderSelection;
+    clearError();
+    emit presentationChanged();
+}
+
+OnboardingSyncConfigurationController::Draft *OnboardingSyncConfigurationController::currentDraft() {
+    return _currentRow >= 0 && static_cast<std::size_t>(_currentRow) < _drafts.size()
+                   ? &_drafts[static_cast<std::size_t>(_currentRow)]
+                   : nullptr;
+}
+
+const OnboardingSyncConfigurationController::Draft *OnboardingSyncConfigurationController::currentDraft() const {
+    return _currentRow >= 0 && static_cast<std::size_t>(_currentRow) < _drafts.size()
+                   ? &_drafts[static_cast<std::size_t>(_currentRow)]
+                   : nullptr;
+}
+
+bool OnboardingSyncConfigurationController::conflictsWithAnotherDraft(const QString &path, const int32_t excludedRow) const {
+    for (int32_t row = 0; static_cast<std::size_t>(row) < _drafts.size(); ++row) {
+        if (row == excludedRow || _drafts[static_cast<std::size_t>(row)].config.localPath.isEmpty()) continue;
+        if (localPathsOverlap(path, _drafts[static_cast<std::size_t>(row)].config.localPath)) return true;
+    }
+    return false;
+}
+
+void OnboardingSyncConfigurationController::buildDrafts() {
+    _drafts.clear();
+    for (const auto &key: _onboardingState.selectedAvailableDriveKeys()) {
+        const auto availableDrive = _appCache.availableDrive(key);
+        if (!availableDrive) continue;
+        PendingSyncConfig config = _onboardingState.pendingSyncConfig(key).value_or(PendingSyncConfig{});
+        if (!config.localPath.isEmpty() && config.defaultLocalPath.isEmpty()) config.defaultLocalPath = config.localPath;
+        _drafts.push_back({.key = key,
+                           .driveName = QString::fromStdString(availableDrive->name()),
+                           .driveColor = QColor(QString::fromStdString(availableDrive->color())),
+                           .config = config});
+    }
+    std::ranges::sort(_drafts, [](const Draft &lhs, const Draft &rhs) {
+        if (const int nameComparison = QString::compare(lhs.driveName, rhs.driveName, Qt::CaseInsensitive); nameComparison != 0) {
+            return nameComparison < 0;
+        }
+        if (lhs.key.accountId != rhs.key.accountId) {
+            return lhs.key.accountId < rhs.key.accountId;
+        }
+        return lhs.key.driveId < rhs.key.driveId;
+    });
+    refreshSummaryModel();
+}
+
+void OnboardingSyncConfigurationController::showInitialPage() {
+    if (_drafts.size() == 1) {
+        openDrive(0);
+    } else {
+        _page = Summary;
+        _currentRow = -1;
+        emit presentationChanged();
+    }
+}
+
+void OnboardingSyncConfigurationController::openDrive(const int32_t row) {
+    _currentRow = row;
+    _driveSnapshot = _drafts[static_cast<std::size_t>(row)].config;
+    _page = DriveConfiguration;
+    clearError();
+    emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::refreshSummaryModel() {
+    std::vector<SelectedSyncConfigurationRow> rows;
+    rows.reserve(_drafts.size());
+    for (const auto &draft: _drafts) {
+        rows.push_back({.driveName = draft.driveName,
+                        .driveColor = draft.driveColor.isValid() ? draft.driveColor : AppConstants::Drive::defaultColor(),
+                        .localPath = displayLocalPath(draft.config.localPath),
+                        .customFolder = !draft.config.usesDefaultLocalPath,
+                        .customSelection = !draft.config.blackList.empty()});
+    }
+    _selectedDrivesModel.setRows(std::move(rows));
+}
+
+void OnboardingSyncConfigurationController::setBusy(const bool busy) {
+    if (_busy == busy) return;
+    _busy = busy;
+    emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::clearError() {
+    setError({}, {});
+}
+
+void OnboardingSyncConfigurationController::setError(const QString &title, const QString &text) {
+    if (_errorTitle == title && _errorText == text) return;
+    _errorTitle = title;
+    _errorText = text;
+    emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::closeWithoutCommit() {
+    if (!_visible) return;
+    ++_requestGeneration;
+    _visible = false;
+    _busy = false;
+    _drafts.clear();
+    _driveSnapshot.reset();
+    _currentRow = -1;
+    _page = Summary;
+    _errorTitle.clear();
+    _errorText.clear();
+    emit visibleChanged();
+    emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::commitAndClose() {
+    std::unordered_map<AvailableDriveKey, PendingSyncConfig> configs;
+    configs.reserve(_drafts.size());
+    for (const auto &draft: _drafts) configs.emplace(draft.key, draft.config);
+    if (!_onboardingState.replacePendingSyncConfigs(configs)) {
+        // The selected drives changed under the modal, so the drafts no longer describe them. Closing here would
+        // silently drop everything the user configured.
+        setError({}, qtTrId("onboardingLoginErrorDescription"));
+        buildDrafts();
+        if (_drafts.empty()) {
+            closeWithoutCommit();
+            return;
+        }
+        _page = Summary;
+        _currentRow = -1;
+        emit presentationChanged();
+        return;
+    }
+    closeWithoutCommit();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
@@ -195,6 +195,11 @@ void OnboardingSyncConfigurationController::returnToDefaultFolder() {
     if (_busy) return;
     Draft *const draft = currentDraft();
     if (!draft || draft->config.defaultLocalPath.isEmpty()) return;
+    // Another drive may have taken that folder while this one sat on a custom path.
+    if (conflictsWithAnotherDraft(draft->config.defaultLocalPath, _currentRow)) {
+        setError(qtTrId("teachingTipInvalidFolderTitle"), qtTrId("teachingTipInvalidFolderContent"));
+        return;
+    }
     draft->config.localPath = draft->config.defaultLocalPath;
     draft->config.usesDefaultLocalPath = true;
     clearError();
@@ -233,11 +238,20 @@ bool OnboardingSyncConfigurationController::conflictsWithAnotherDraft(const QStr
 }
 
 void OnboardingSyncConfigurationController::buildDrafts() {
+    // Reconciles the drafts with the selection instead of reloading them: a rejected commit rebuilds them with the
+    // modal still open, and what the user has just configured has to survive that retry.
+    std::unordered_map<AvailableDriveKey, PendingSyncConfig> editedConfigs;
+    editedConfigs.reserve(_drafts.size());
+    for (const auto &draft: _drafts) editedConfigs.emplace(draft.key, draft.config);
+
     _drafts.clear();
     for (const auto &key: _onboardingState.selectedAvailableDriveKeys()) {
         const auto availableDrive = _appCache.availableDrive(key);
         if (!availableDrive) continue;
-        PendingSyncConfig config = _onboardingState.pendingSyncConfig(key).value_or(PendingSyncConfig{});
+        const auto editedConfig = editedConfigs.find(key);
+        PendingSyncConfig config = editedConfig != editedConfigs.cend()
+                                           ? editedConfig->second
+                                           : _onboardingState.pendingSyncConfig(key).value_or(PendingSyncConfig{});
         if (!config.localPath.isEmpty() && config.defaultLocalPath.isEmpty()) config.defaultLocalPath = config.localPath;
         _drafts.push_back({.key = key,
                            .driveName = QString::fromStdString(availableDrive->name()),

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
@@ -242,7 +242,7 @@ void OnboardingSyncConfigurationController::buildDrafts() {
     // modal still open, and what the user has just configured has to survive that retry.
     std::unordered_map<AvailableDriveKey, PendingSyncConfig> editedConfigs;
     editedConfigs.reserve(_drafts.size());
-    for (const auto &draft: _drafts) editedConfigs.emplace(draft.key, draft.config);
+    for (const auto &draft: _drafts) (void) editedConfigs.try_emplace(draft.key, draft.config);
 
     _drafts.clear();
     for (const auto &key: _onboardingState.selectedAvailableDriveKeys()) {
@@ -258,7 +258,7 @@ void OnboardingSyncConfigurationController::buildDrafts() {
                            .driveColor = QColor(QString::fromStdString(availableDrive->color())),
                            .config = config});
     }
-    std::ranges::sort(_drafts, [](const Draft &lhs, const Draft &rhs) {
+    (void) std::ranges::sort(_drafts, [](const Draft &lhs, const Draft &rhs) {
         if (const int nameComparison = QString::compare(lhs.driveName, rhs.driveName, Qt::CaseInsensitive); nameComparison != 0) {
             return nameComparison < 0;
         }
@@ -341,7 +341,7 @@ void OnboardingSyncConfigurationController::closeWithoutCommit() {
 void OnboardingSyncConfigurationController::commitAndClose() {
     std::unordered_map<AvailableDriveKey, PendingSyncConfig> configs;
     configs.reserve(_drafts.size());
-    for (const auto &draft: _drafts) configs.emplace(draft.key, draft.config);
+    for (const auto &draft: _drafts) (void) configs.try_emplace(draft.key, draft.config);
     if (!_onboardingState.replacePendingSyncConfigs(configs)) {
         // The selected drives changed under the modal, so the drafts no longer describe them. Closing here would
         // silently drop everything the user configured.

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
@@ -103,6 +103,8 @@ void OnboardingSyncConfigurationController::configureDrive(const int32_t row) {
 }
 
 void OnboardingSyncConfigurationController::cancelCurrentPage() {
+    // Leaving the page drops the path validation it started: its result would land on a page the user has left.
+    abortPendingRequest();
     clearError();
     if (_page == FolderSelection) {
         _page = DriveConfiguration;
@@ -289,6 +291,11 @@ void OnboardingSyncConfigurationController::setBusy(const bool busy) {
     if (_busy == busy) return;
     _busy = busy;
     emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::abortPendingRequest() {
+    ++_requestGeneration;
+    setBusy(false);
 }
 
 void OnboardingSyncConfigurationController::clearError() {

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
@@ -1,0 +1,143 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/cachetypes.h"
+#include "app/onboarding/selectedsyncconfigurationsmodel.h"
+#include "app/syncconfiguration/remotefolderprovider.h"
+#include "app/syncconfiguration/remotefoldertreemodel.h"
+
+#include <QObject>
+#include <QUrl>
+
+#include <optional>
+#include <vector>
+
+namespace KDC {
+
+class AppCache;
+class CommService;
+class OnboardingFlowController;
+class OnboardingState;
+
+/** Session-scoped transactional editor for onboarding synchronization settings. */
+class OnboardingSyncConfigurationController final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
+        Q_PROPERTY(Page page READ page NOTIFY presentationChanged)
+        Q_PROPERTY(bool driveConfigurationPage READ driveConfigurationPage NOTIFY presentationChanged)
+        Q_PROPERTY(bool folderSelectionPage READ folderSelectionPage NOTIFY presentationChanged)
+        Q_PROPERTY(bool busy READ busy NOTIFY presentationChanged)
+        Q_PROPERTY(bool canValidate READ canValidate NOTIFY presentationChanged)
+        Q_PROPERTY(QString errorTitle READ errorTitle NOTIFY presentationChanged)
+        Q_PROPERTY(QString errorText READ errorText NOTIFY presentationChanged)
+        Q_PROPERTY(QString currentDriveName READ currentDriveName NOTIFY presentationChanged)
+        Q_PROPERTY(QColor currentDriveColor READ currentDriveColor NOTIFY presentationChanged)
+        Q_PROPERTY(QString currentLocalPath READ currentLocalPath NOTIFY presentationChanged)
+        Q_PROPERTY(bool currentUsesDefaultFolder READ currentUsesDefaultFolder NOTIFY presentationChanged)
+        Q_PROPERTY(bool currentHasCustomSelection READ currentHasCustomSelection NOTIFY presentationChanged)
+        Q_PROPERTY(SelectedSyncConfigurationsModel *selectedDrivesModel READ selectedDrivesModel CONSTANT)
+        Q_PROPERTY(RemoteFolderTreeModel *folderTreeModel READ folderTreeModel CONSTANT)
+
+    public:
+        enum Page : uint8_t {
+            Summary,
+            DriveConfiguration,
+            FolderSelection,
+        };
+        Q_ENUM(Page)
+
+        explicit OnboardingSyncConfigurationController(AppCache &appCache, OnboardingState &onboardingState,
+                                                       OnboardingFlowController &flowController, CommService &commService,
+                                                       QObject *parent = nullptr);
+
+        [[nodiscard]] bool visible() const { return _visible; }
+        [[nodiscard]] Page page() const { return _page; }
+        [[nodiscard]] bool driveConfigurationPage() const { return _page == DriveConfiguration; }
+        [[nodiscard]] bool folderSelectionPage() const { return _page == FolderSelection; }
+        [[nodiscard]] bool busy() const { return _busy; }
+        [[nodiscard]] bool canValidate() const;
+        [[nodiscard]] QString errorTitle() const { return _errorTitle; }
+        [[nodiscard]] QString errorText() const { return _errorText; }
+        [[nodiscard]] QString currentDriveName() const;
+        [[nodiscard]] QColor currentDriveColor() const;
+        /** Local folder of the drive being configured, in its `~`-shortened display form. */
+        [[nodiscard]] QString currentLocalPath() const;
+        [[nodiscard]] bool currentUsesDefaultFolder() const;
+        [[nodiscard]] bool currentHasCustomSelection() const;
+        [[nodiscard]] SelectedSyncConfigurationsModel *selectedDrivesModel() { return &_selectedDrivesModel; }
+        [[nodiscard]] RemoteFolderTreeModel *folderTreeModel() { return &_folderTreeModel; }
+
+        Q_INVOKABLE void open();
+        Q_INVOKABLE void configureDrive(int32_t row);
+        Q_INVOKABLE void cancelCurrentPage();
+        Q_INVOKABLE void validateCurrentPage();
+        Q_INVOKABLE void requestCustomFolder();
+        /** Reports that the native folder picker closed, whatever the outcome, so focus can return to its button. */
+        Q_INVOKABLE void notifyCustomFolderDialogClosed();
+        Q_INVOKABLE void applyCustomFolder(const QUrl &folderUrl);
+        Q_INVOKABLE void returnToDefaultFolder();
+        Q_INVOKABLE void selectFolders();
+
+    signals:
+        void visibleChanged();
+        void presentationChanged();
+        void customFolderRequested(const QUrl &initialFolder);
+        void customFolderDialogClosed();
+
+    private:
+        struct Draft {
+                AvailableDriveKey key;
+                QString driveName;
+                QColor driveColor;
+                PendingSyncConfig config;
+        };
+
+        [[nodiscard]] Draft *currentDraft();
+        [[nodiscard]] const Draft *currentDraft() const;
+        [[nodiscard]] bool conflictsWithAnotherDraft(const QString &path, int32_t excludedRow) const;
+        void buildDrafts();
+        void showInitialPage();
+        void openDrive(int32_t row);
+        void refreshSummaryModel();
+        void setBusy(bool busy);
+        void clearError();
+        void setError(const QString &title, const QString &text);
+        void closeWithoutCommit();
+        void commitAndClose();
+
+        AppCache &_appCache;
+        OnboardingState &_onboardingState;
+        OnboardingFlowController &_flowController;
+        CommService &_commService;
+        SelectedSyncConfigurationsModel _selectedDrivesModel;
+        CommRemoteFolderProvider _folderProvider;
+        RemoteFolderTreeModel _folderTreeModel;
+        std::vector<Draft> _drafts;
+        std::optional<PendingSyncConfig> _driveSnapshot;
+        int32_t _currentRow{-1};
+        Page _page{Summary};
+        bool _visible{false};
+        bool _busy{false};
+        QString _errorTitle;
+        QString _errorText;
+        uint64_t _requestGeneration{0};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
@@ -117,6 +117,7 @@ class OnboardingSyncConfigurationController final : public QObject {
         void openDrive(int32_t row);
         void refreshSummaryModel();
         void setBusy(bool busy);
+        void abortPendingRequest();
         void clearError();
         void setError(const QString &title, const QString &text);
         void closeWithoutCommit();

--- a/src/gui4/linux/app/onboarding/selectedsyncconfigurationsmodel.cpp
+++ b/src/gui4/linux/app/onboarding/selectedsyncconfigurationsmodel.cpp
@@ -1,0 +1,64 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "selectedsyncconfigurationsmodel.h"
+
+namespace KDC {
+
+SelectedSyncConfigurationsModel::SelectedSyncConfigurationsModel(QObject *const parent) :
+    QAbstractListModel(parent) {}
+
+int SelectedSyncConfigurationsModel::rowCount(const QModelIndex &parent) const {
+    return parent.isValid() ? 0 : static_cast<int>(_rows.size());
+}
+
+QVariant SelectedSyncConfigurationsModel::data(const QModelIndex &index, const int role) const {
+    if (!index.isValid() || index.row() < 0 || static_cast<std::size_t>(index.row()) >= _rows.size()) return {};
+    const auto &row = _rows[static_cast<std::size_t>(index.row())];
+    switch (role) {
+        case DriveNameRole:
+        case Qt::DisplayRole:
+            return row.driveName;
+        case DriveColorRole:
+            return row.driveColor;
+        case LocalPathRole:
+            return row.localPath;
+        case CustomFolderRole:
+            return row.customFolder;
+        case CustomSelectionRole:
+            return row.customSelection;
+        default:
+            return {};
+    }
+}
+
+QHash<int, QByteArray> SelectedSyncConfigurationsModel::roleNames() const {
+    return {{DriveNameRole, "driveName"},
+            {DriveColorRole, "driveColor"},
+            {LocalPathRole, "localPath"},
+            {CustomFolderRole, "customFolder"},
+            {CustomSelectionRole, "customSelection"}};
+}
+
+void SelectedSyncConfigurationsModel::setRows(std::vector<SelectedSyncConfigurationRow> rows) {
+    beginResetModel();
+    _rows = std::move(rows);
+    endResetModel();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/onboarding/selectedsyncconfigurationsmodel.h
+++ b/src/gui4/linux/app/onboarding/selectedsyncconfigurationsmodel.h
@@ -1,0 +1,62 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QAbstractListModel>
+#include <QColor>
+
+#include <cstdint>
+#include <vector>
+
+namespace KDC {
+
+struct SelectedSyncConfigurationRow {
+        QString driveName;
+        QColor driveColor;
+        /** `~`-shortened display form of the drive local folder. */
+        QString localPath;
+        bool customFolder{false};
+        bool customSelection{false};
+};
+
+class SelectedSyncConfigurationsModel final : public QAbstractListModel {
+        Q_OBJECT
+
+    public:
+        enum Role : int32_t {
+            DriveNameRole = Qt::UserRole + 1,
+            DriveColorRole,
+            LocalPathRole,
+            CustomFolderRole,
+            CustomSelectionRole,
+        };
+        Q_ENUM(Role)
+
+        explicit SelectedSyncConfigurationsModel(QObject *parent = nullptr);
+
+        [[nodiscard]] int rowCount(const QModelIndex &parent = {}) const override;
+        [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
+        [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+        void setRows(std::vector<SelectedSyncConfigurationRow> rows);
+
+    private:
+        std::vector<SelectedSyncConfigurationRow> _rows;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -95,6 +95,9 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
                                                              "ManyDeletesController is owned by AppClientLinux.");
     (void) qmlRegisterUncreatableType<StorageController>("kDrive.UI", 1, 0, "StorageController",
                                                          "StorageController is owned by AppClientLinux.");
+    (void) qmlRegisterUncreatableType<OnboardingSyncConfigurationController>(
+            "kDrive.UI", 1, 0, "OnboardingSyncConfigurationController",
+            "OnboardingSyncConfigurationController is owned by OnboardingSession.");
     (void) qmlRegisterUncreatableMetaObject(AppConstants::WebDrive::staticMetaObject, "kDrive.UI", 1, 0, "WebDrive",
                                             QStringLiteral("WebDrive only exposes enums."));
     _qmlEngine.setOutputWarningsToStandardError(false);


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR ajoute l'éditeur transactionnel derrière les paramètres de synchronisation avancés, ainsi que le modèle de présentation de son résumé multi-drive. Toujours aucune UI : la boîte de dialogue QML et ses pages arrivent dans les PRs suivantes. C'est cette pièce qui décide ce que l'utilisateur peut modifier, ce qui est conservé et ce qui est abandonné. C'est la 5e PR de la pile de 8.

## Changements
- `app/onboarding/onboardingsyncconfigurationcontroller.{h,cpp}`, à portée de session, exposé par `OnboardingSession` :
  - **Travaille sur des brouillons, jamais sur l'état validé.** Il copie les configurations des drives sélectionnés à l'ouverture, édite ces copies, et ne les réécrit qu'à la confirmation finale, via l'opération atomique `OnboardingState::replacePendingSyncConfigs()` ajoutée dans #2381. Annuler à n'importe quel niveau ne peut donc jamais laisser fuiter un drive à moitié édité.
  - **Trois niveaux de transaction** : annuler la sélection de dossiers conserve le brouillon du drive, annuler une page de drive restaure l'instantané pris à l'ouverture de cette page, annuler le résumé abandonne tout.
  - **La navigation correspond à macOS et Windows** : avec un seul drive, le résumé est entièrement sauté et sa page de configuration s'ouvre directement, et valider ou annuler cette page ferme tout le flux. Avec plusieurs drives, valider une page de drive revient au résumé.
  - **Dossier local personnalisé** : rejeté s'il recouvre le chemin d'un autre brouillon (vérifié côté client avec `localPathsOverlap()` de #2385, car le serveur ne connaît que les synchronisations persistées, pas les brouillons en cours dans la modale), puis validé par le serveur via `UTILITY_ISPATHVALIDFORNEWSYNC` avec `SyncConfiguration::Classic`. Le chemin valide précédent est conservé en cas d'échec. Revenir au dossier par défaut réutilise le `defaultLocalPath` résolu dans #2386.
  - **Un commit refusé laisse la modale ouverte** avec une erreur, au lieu de se fermer comme si tout avait fonctionné. Ceci compte : `replacePendingSyncConfigs()` rejette une map incomplète, ce qui arrive si les drives sélectionnés ont changé pendant que la modale était ouverte, et une fermeture silencieuse abandonnerait tout ce que l'utilisateur avait configuré.
  - Les callbacks obsolètes sont ignorés grâce à une génération de requête et à `QPointer`.
- `app/onboarding/selectedsyncconfigurationsmodel.{h,cpp}` : un `QAbstractListModel` plat pour le résumé, n'exposant que des valeurs d'affichage (nom du drive, couleur, chemin raccourci, par défaut ou personnalisé, sélection totale ou personnalisée). Les identifiants backend restent dans les brouillons du contrôleur, si bien que QML ne peut pas adresser un drive directement ; chaque action est revalidée par le contrôleur à partir d'un index de ligne.
- `appclientlinux.cpp` enregistre le contrôleur comme type QML non créable, puisqu'il est possédé par `OnboardingSession`.

## Détails techniques
- Le contrôleur pilote `RemoteFolderTreeModel` (de #2385) pour la sélection de dossiers, et relit sa liste noire à la validation.
- Aucun QML ne consomme encore rien de tout cela ; la boîte de dialogue et ses pages arrivent dans les PRs suivantes de la pile.
- Le modèle de résumé est délibérément dépourvu de logique : il ne porte aucune identité, seulement ce qui est affiché.

</details>

---

## Summary
This PR adds the transactional editor behind the advanced synchronization settings, plus the presentation model for its multi-drive summary. Still no UI: the QML dialog and pages arrive in the following PRs. This is the piece that decides what the user can change, what gets kept, and what gets discarded. It is the 5th of an 8-PR stack.

## Changes
- `app/onboarding/onboardingsyncconfigurationcontroller.{h,cpp}`, session-scoped, exposed by `OnboardingSession`:
  - **Works on drafts, never on committed state.** It copies the selected drives' configs on open, edits those copies, and writes them back only from the final confirmation, through the atomic `OnboardingState::replacePendingSyncConfigs()` added in #2381. Cancelling at any level therefore cannot leak a half-edited drive.
  - **Three transaction levels**: cancelling folder selection keeps the drive draft, cancelling a drive page restores the snapshot taken when that page opened, cancelling the summary discards everything.
  - **Navigation matches macOS and Windows**: with a single drive the summary is skipped entirely and its configuration page opens directly, and validating or cancelling that page closes the whole flow. With several drives, validating a drive page returns to the summary.
  - **Custom local folder**: rejected if it overlaps another draft's path (checked client-side with `localPathsOverlap()` from #2385, because the server only knows persisted syncs, not the current modal drafts), then validated by the server through `UTILITY_ISPATHVALIDFORNEWSYNC` with `SyncConfiguration::Classic`. The previous valid path is kept on failure. Returning to the default folder reuses the `defaultLocalPath` resolved in #2386.
  - **A refused commit keeps the modal open** with an error, instead of closing as if it had worked. This matters: `replacePendingSyncConfigs()` rejects an incomplete map, which happens if the selected drives changed while the modal was open, and silently closing would drop everything the user configured.
  - Stale callbacks are ignored through a request generation and `QPointer`.
- `app/onboarding/selectedsyncconfigurationsmodel.{h,cpp}`: a flat `QAbstractListModel` for the summary, exposing display values only (drive name, color, shortened path, default-or-custom, all-or-custom selection). Backend identifiers stay in the controller's drafts, so QML cannot address a drive directly; every action is revalidated by the controller from a row index.
- `appclientlinux.cpp` registers the controller as an uncreatable QML type, since it is owned by `OnboardingSession`.

## Technical Details
- The controller drives `RemoteFolderTreeModel` (from #2385) for folder selection, and reads back its blacklist on validation.
- No QML consumes any of this yet; the dialog and its pages land in the next PRs of the stack.
- The summary model is deliberately dumb: it holds no identity, only what is displayed.

## Notes
Depends on #2386.