### PR TITLE
feat(sync-config): add remote folder tree QML and shared checkbox

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -345,7 +345,9 @@
       connection and cache bootstrap complete. It yields to onboarding or the main shell once a product route is ready.
     - `ui/windows/onboarding/`: onboarding window composition and flow screens. Onboarding-only QML stays here unless it
       becomes reusable from another product window.
-    - `ui/features/`: future reusable product features shared by several windows, such as sync configuration.
+    - `ui/features/syncconfiguration/`: reusable advanced-sync presentation. The remote-folder tree is a single tab
+      stop that moves a current row internally, so tabbing never walks through every checkbox of a large folder list;
+      the current row is a navigation cursor drawn as a tint, kept distinct from the keyboard focus ring.
     - `ui/components/`: reusable presentation primitives without product-window ownership. Main-window sidebar
       primitives accept display values and emit interactions; they do not read `AppCache`, own selection, or call
       services directly. `IKModal` and `IKModalButton` provide the styled in-app modal surface and semantic action roles;

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -349,7 +349,8 @@
     - `ui/components/`: reusable presentation primitives without product-window ownership. Main-window sidebar
       primitives accept display values and emit interactions; they do not read `AppCache`, own selection, or call
       services directly. `IKModal` and `IKModalButton` provide the styled in-app modal surface and semantic action roles;
-      feature dialogs supply their own wording, state, and actions.
+      feature dialogs supply their own wording, state, and actions. `IKCheckBox` is the shared tri-state indicator: it
+      renders the state it is given and only reports clicks, so a model owning the selection stays authoritative.
     - `ui/chrome/`: shared window chrome: frameless shell, header bar, controls, resize handles, and shadow wrapper.
       Top-level app-owned QML windows should use `IKShadowedWindow`; its `headerBackgroundData` and `headerData` slots
       accept page-specific header visuals and content while preserving the standard move, resize, minimize, maximize,

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -179,6 +179,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKToolTip.qml
         ui/components/IKTintedIcon.qml
         ui/components/IKErrorBanner.qml
+        ui/features/syncconfiguration/RemoteFolderTree.qml
         ui/dialogs/GlobalModalHost.qml
         ui/dialogs/ManyDeletesDialog.qml
         ui/windows/main/BlockingErrorPlaceholder.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -138,10 +138,12 @@ set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)
         ui/tokens/IKFonts.qml
         ui/tokens/IKIconSizes.qml
         ui/tokens/IKActivities.qml
+        ui/tokens/IKCheckBoxTokens.qml
         ui/tokens/IKOnboarding.qml
         ui/tokens/IKMainWindow.qml
         ui/tokens/IKModalTokens.qml
         ui/tokens/IKStorage.qml
+        ui/tokens/IKSyncConfiguration.qml
         ui/tokens/IKWaiting.qml
 )
 

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -169,6 +169,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/chrome/IKWindowResizeHandles.qml
         ui/components/IKBadge.qml
         ui/components/IKAvatar.qml
+        ui/components/IKCheckBox.qml
         ui/components/IKDriveIcon.qml
         ui/components/IKLoadingSpinner.qml
         ui/components/IKModal.qml

--- a/src/gui4/linux/ui/components/IKCheckBox.qml
+++ b/src/gui4/linux/ui/components/IKCheckBox.qml
@@ -1,0 +1,120 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Shapes
+import kDrive.UI
+
+// Tri-state checkbox indicator. It reports clicks and renders the state it is given; the owner decides how a click
+// advances the state, so a model-driven cycle stays authoritative.
+AbstractButton {
+    id: root
+
+    property int checkState: Qt.Unchecked
+
+    readonly property bool selected: checkState !== Qt.Unchecked
+    readonly property color indicatorColor: {
+        if (!enabled) {
+            return IKColors.checkboxDisabledSurface
+        }
+        return selected ? IKColors.checkboxSelectedSurface : IKColors.checkboxSurface
+    }
+    readonly property color indicatorBorderColor: {
+        if (!enabled) {
+            return IKColors.checkboxDisabledBorder
+        }
+        if (selected) {
+            return IKColors.checkboxSelectedSurface
+        }
+        return hovered ? IKColors.checkboxHoverBorder : IKColors.checkboxBorder
+    }
+
+    implicitWidth: IKCheckBoxTokens.hitAreaSize
+    implicitHeight: IKCheckBoxTokens.hitAreaSize
+    padding: 0
+    focusPolicy: Qt.StrongFocus
+    hoverEnabled: true
+    opacity: enabled ? 1 : IKCheckBoxTokens.disabledOpacity
+    Accessible.role: Accessible.CheckBox
+    Accessible.checked: checkState === Qt.Checked
+    Accessible.checkStateMixed: checkState === Qt.PartiallyChecked
+
+    // The control sizes background and contentItem itself, so neither is anchored here.
+    background: Rectangle {
+        radius: IKCheckBoxTokens.focusRingRadius
+        color: "transparent"
+        border.width: root.visualFocus ? IKCheckBoxTokens.focusRingWidth : 0
+        border.color: IKColors.accentPrimary
+    }
+
+    contentItem: Item {
+        Rectangle {
+            id: indicator
+
+            anchors.centerIn: parent
+            width: IKCheckBoxTokens.indicatorSize
+            height: IKCheckBoxTokens.indicatorSize
+            radius: IKCheckBoxTokens.indicatorRadius
+            color: root.indicatorColor
+            border.width: IKCheckBoxTokens.borderWidth
+            border.color: root.indicatorBorderColor
+
+            Shape {
+                id: checkMark
+
+                readonly property real unit: width / IKCheckBoxTokens.markReferenceSize
+
+                anchors.fill: parent
+                visible: root.checkState === Qt.Checked
+                preferredRendererType: Shape.CurveRenderer
+
+                ShapePath {
+                    strokeColor: IKColors.checkboxMark
+                    strokeWidth: IKCheckBoxTokens.markStrokeWidth
+                    fillColor: "transparent"
+                    capStyle: ShapePath.RoundCap
+                    joinStyle: ShapePath.RoundJoin
+                    startX: checkMark.unit * 3.8
+                    startY: checkMark.unit * 8.4
+
+                    PathLine {
+                        x: checkMark.unit * 6.6
+                        y: checkMark.unit * 11.2
+                    }
+
+                    PathLine {
+                        x: checkMark.unit * 12.2
+                        y: checkMark.unit * 5
+                    }
+                }
+            }
+
+            Rectangle {
+                anchors.centerIn: parent
+                visible: root.checkState === Qt.PartiallyChecked
+                width: IKCheckBoxTokens.partialMarkWidth
+                height: IKCheckBoxTokens.partialMarkHeight
+                radius: IKCheckBoxTokens.partialMarkRadius
+                color: IKColors.checkboxMark
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/components/IKCheckBox.qml
+++ b/src/gui4/linux/ui/components/IKCheckBox.qml
@@ -54,8 +54,12 @@ AbstractButton {
     hoverEnabled: true
     opacity: enabled ? 1 : IKCheckBoxTokens.disabledOpacity
     Accessible.role: Accessible.CheckBox
+    Accessible.checkable: enabled
     Accessible.checked: checkState === Qt.Checked
     Accessible.checkStateMixed: checkState === Qt.PartiallyChecked
+    // The state belongs to the owner, so an assistive activation reports a click like the pointer and the keyboard do.
+    Accessible.onPressAction: root.clicked()
+    Accessible.onToggleAction: root.clicked()
 
     // The control sizes background and contentItem itself, so neither is anchored here.
     background: Rectangle {

--- a/src/gui4/linux/ui/features/syncconfiguration/RemoteFolderTree.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/RemoteFolderTree.qml
@@ -1,0 +1,420 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQml.Models
+import kDrive.UI
+
+Rectangle {
+    id: root
+
+    required property var treeModel
+
+    // The tree itself takes the keyboard focus; the surrounding frame is decoration.
+    readonly property Item keyboardFocusItem: treeView
+    readonly property bool contentVisible: !treeModel.loading && !treeModel.loadFailed && !treeModel.empty
+
+    implicitHeight: IKSyncConfiguration.treeHeight
+    radius: IKSyncConfiguration.treeRadius
+    color: IKColors.syncConfigurationTreeSurface
+    border.width: IKSyncConfiguration.treeBorderWidth
+    border.color: IKColors.syncConfigurationDivider
+
+    Rectangle {
+        id: header
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: IKSyncConfiguration.treeHeaderHeight
+        radius: root.radius
+        color: IKColors.syncConfigurationTreeHeaderSurface
+
+        // Squares off the bottom corners that the shared radius would otherwise round inside the container.
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: parent.radius
+            color: parent.color
+        }
+
+        IKCheckBox {
+            id: rootCheckBox
+
+            anchors.left: parent.left
+            anchors.leftMargin: IKSyncConfiguration.treeContentPadding
+            anchors.verticalCenter: parent.verticalCenter
+            checkState: root.treeModel.rootCheckState
+            enabled: root.contentVisible
+            Accessible.name: qsTrId("labelAllFolders")
+            onClicked: root.treeModel.toggleRootSelection()
+        }
+
+        Text {
+            // Aligned with the folder icon of a root-level row rather than with its checkbox.
+            anchors.left: rootCheckBox.right
+            anchors.leftMargin: IKSyncConfiguration.treeDisclosureSize + IKSpacing.s4
+            anchors.right: headerSizeLabel.left
+            anchors.rightMargin: IKSyncConfiguration.treeRowSpacing
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTrId("labelName")
+            color: IKColors.textSecondary
+            font.pixelSize: IKFonts.subheadlineSize
+            font.weight: IKFonts.emphasized
+            elide: Text.ElideRight
+        }
+
+        Text {
+            id: headerSizeLabel
+
+            width: IKSyncConfiguration.treeSizeColumnWidth
+            anchors.right: parent.right
+            anchors.rightMargin: IKSyncConfiguration.treeStateSpacing
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTrId("labelSize")
+            color: IKColors.textSecondary
+            font.pixelSize: IKFonts.subheadlineSize
+            font.weight: IKFonts.emphasized
+            horizontalAlignment: Text.AlignRight
+        }
+    }
+
+    Rectangle {
+        id: headerSeparator
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: header.bottom
+        height: IKSyncConfiguration.treeBorderWidth
+        color: IKColors.syncConfigurationDivider
+    }
+
+    Item {
+        id: body
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: headerSeparator.bottom
+        anchors.bottom: parent.bottom
+
+        IKLoadingSpinner {
+            anchors.centerIn: parent
+            visible: root.treeModel.loading
+            width: IKIconSizes.large
+            height: width
+            color: IKColors.actionPrimary
+        }
+
+        Column {
+            anchors.centerIn: parent
+            width: parent.width - 2 * IKSpacing.s24
+            spacing: IKSyncConfiguration.treeStateSpacing
+            visible: root.treeModel.loadFailed
+
+            Text {
+                width: parent.width
+                text: qsTrId("onboardingLoginErrorDescription")
+                color: IKColors.textSecondary
+                font.pixelSize: IKFonts.bodySize
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+            }
+
+            IKModalButton {
+                anchors.horizontalCenter: parent.horizontalCenter
+                role: IKModalButton.Secondary
+                text: qsTrId("buttonRetry")
+                onClicked: root.treeModel.retryRoot()
+            }
+        }
+
+        Column {
+            anchors.centerIn: parent
+            width: parent.width - 2 * IKSpacing.s24
+            spacing: IKSyncConfiguration.treeStateSpacing
+            visible: root.treeModel.empty
+
+            Text {
+                width: parent.width
+                text: qsTrId("labelSyncExclusionEmptyTitle")
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.bodySize
+                font.weight: IKFonts.emphasized
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+            }
+
+            Text {
+                width: parent.width
+                text: qsTrId("labelSyncExclusionEmptyDescription")
+                color: IKColors.textSecondary
+                font.pixelSize: IKFonts.subheadlineSize
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        TreeView {
+            id: treeView
+
+            // The tree is a single tab stop that moves a current row internally, like a native tree: tabbing through
+            // every checkbox of a large folder list would make the page unusable from the keyboard. TableView already
+            // tracks that row as `currentRow`, driven by the selection model below.
+            function moveCurrentToRow(targetRow: int): void {
+                if (targetRow < 0 || targetRow >= treeView.rows) {
+                    return
+                }
+                treeSelection.setCurrentIndex(treeView.index(targetRow, 0), ItemSelectionModel.NoUpdate)
+                treeView.positionViewAtRow(targetRow, TableView.Contain)
+            }
+
+            anchors.fill: parent
+            anchors.margins: IKSyncConfiguration.treeContentPadding
+            visible: root.contentVisible
+            clip: true
+            model: root.treeModel
+            boundsBehavior: Flickable.StopAtBounds
+            activeFocusOnTab: true
+            // Arrow keys are handled below so collapsing and expanding behave the same on every Qt version.
+            keyNavigationEnabled: false
+            selectionModel: ItemSelectionModel {
+                id: treeSelection
+
+                model: root.treeModel
+            }
+
+            onActiveFocusChanged: {
+                if (treeView.activeFocus && treeView.currentRow < 0) {
+                    treeView.moveCurrentToRow(0)
+                }
+            }
+
+            Keys.onUpPressed: treeView.moveCurrentToRow(treeView.currentRow - 1)
+            Keys.onDownPressed: treeView.moveCurrentToRow(treeView.currentRow + 1)
+            Keys.onLeftPressed: {
+                const row = treeView.currentRow
+                if (row < 0) {
+                    return
+                }
+                if (treeView.isExpanded(row)) {
+                    treeView.collapse(row)
+                    return
+                }
+                treeView.moveCurrentToRow(treeView.rowAtIndex(root.treeModel.parentIndex(treeSelection.currentIndex)))
+            }
+            Keys.onRightPressed: {
+                const row = treeView.currentRow
+                if (row < 0) {
+                    return
+                }
+                if (!treeView.isExpanded(row)) {
+                    treeView.expand(row)
+                    return
+                }
+                treeView.moveCurrentToRow(row + 1)
+            }
+            Keys.onSpacePressed: root.treeModel.toggleSelection(treeSelection.currentIndex)
+            Keys.onReturnPressed: root.treeModel.toggleSelection(treeSelection.currentIndex)
+            Keys.onEnterPressed: root.treeModel.toggleSelection(treeSelection.currentIndex)
+
+            ScrollBar.vertical: ScrollBar {
+                policy: treeView.contentHeight > treeView.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+            }
+
+            delegate: Item {
+                id: folderRow
+
+                required property TreeView treeView
+                required property bool isTreeNode
+                required property bool expanded
+                required property bool hasChildren
+                required property int depth
+                required property int row
+                required property int column
+                required property string folderName
+                required property int checkState
+                required property bool accessDenied
+                required property string sizeText
+                required property bool childrenLoading
+                required property bool childrenLoadFailed
+                required property bool current
+
+                readonly property var treeIndex: folderRow.treeView.index(folderRow.row, folderRow.column)
+                readonly property bool disclosureVisible: folderRow.isTreeNode && folderRow.hasChildren
+
+                implicitWidth: folderRow.treeView.width
+                implicitHeight: IKSyncConfiguration.treeRowHeight
+
+                // The row carries the accessible state; its checkbox and disclosure are decorations of that state
+                // rather than separate controls, so a screen reader announces one folder instead of three items.
+                Accessible.role: Accessible.TreeItem
+                Accessible.name: folderRow.folderName
+                Accessible.description: folderRow.sizeText
+                Accessible.checkable: !folderRow.accessDenied
+                Accessible.checked: folderRow.checkState === Qt.Checked
+                Accessible.checkStateMixed: folderRow.checkState === Qt.PartiallyChecked
+                Accessible.readOnly: folderRow.accessDenied
+
+                Component.onCompleted: root.treeModel.setRowVisible(folderRow.treeIndex, true)
+                Component.onDestruction: root.treeModel.setRowVisible(folderRow.treeIndex, false)
+                TableView.onPooled: root.treeModel.setRowVisible(folderRow.treeIndex, false)
+                TableView.onReused: root.treeModel.setRowVisible(folderRow.treeIndex, true)
+
+                Rectangle {
+                    anchors.fill: parent
+                    radius: IKSyncConfiguration.treeRowRadius
+    // The current row is a navigation cursor, not a focus ring: TreeView is a Flickable and has no
+                    // `visualFocus`, so a border here would also show on a plain mouse click. A tint keeps the two
+                    // meanings apart while staying useful to mouse users.
+                    color: {
+                        if (folderRow.current && folderRow.treeView.activeFocus) {
+                            return IKColors.syncConfigurationRowCurrent
+                        }
+                        if (rowHover.hovered) {
+                            return IKColors.syncConfigurationRowHover
+                        }
+                        return folderRow.checkState === Qt.Unchecked ? "transparent"
+                                                                     : IKColors.syncConfigurationRowSelectedSurface
+                    }
+                }
+
+                HoverHandler {
+                    id: rowHover
+                }
+
+                IKCheckBox {
+                    id: rowCheckBox
+
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    checkState: folderRow.checkState
+                    enabled: !folderRow.accessDenied
+                    focusPolicy: Qt.NoFocus
+                    Accessible.ignored: true
+                    onClicked: {
+                        treeView.moveCurrentToRow(folderRow.row)
+                        root.treeModel.toggleSelection(folderRow.treeIndex)
+                    }
+                }
+
+                Item {
+                    id: disclosure
+
+                    anchors.left: rowCheckBox.right
+                    anchors.leftMargin: folderRow.depth * IKSyncConfiguration.treeIndent
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: IKSyncConfiguration.treeDisclosureSize
+                    height: width
+
+                    IKLoadingSpinner {
+                        anchors.centerIn: parent
+                        visible: folderRow.childrenLoading
+                        width: IKSyncConfiguration.treeSpinnerSize
+                        height: width
+                        strokeWidth: 2
+                        color: IKColors.syncConfigurationDisclosureIcon
+                    }
+
+                    AbstractButton {
+                        anchors.fill: parent
+                        visible: folderRow.disclosureVisible && !folderRow.childrenLoading
+                        focusPolicy: Qt.NoFocus
+                        Accessible.ignored: true
+                        onClicked: {
+                            if (folderRow.childrenLoadFailed) {
+                                root.treeModel.retryChildren(folderRow.treeIndex)
+                            } else {
+                                folderRow.treeView.toggleExpanded(folderRow.row)
+                            }
+                        }
+
+                        contentItem: Item {
+                            IKTintedIcon {
+                                anchors.centerIn: parent
+                                visible: !folderRow.childrenLoadFailed
+                                width: IKSyncConfiguration.treeChevronSize
+                                height: width
+                                rotation: folderRow.expanded ? 0 : -90
+                                source: "qrc:/assets/main/chevron-down.svg"
+                                color: IKColors.syncConfigurationDisclosureIcon
+                            }
+
+                            IKTintedIcon {
+                                anchors.centerIn: parent
+                                visible: folderRow.childrenLoadFailed
+                                width: IKSyncConfiguration.treeRowIconSize
+                                height: width
+                                source: "qrc:/assets/main/triangle-alert.svg"
+                                color: IKColors.statusMediumWarning
+                            }
+                        }
+                    }
+                }
+
+                IKTintedIcon {
+                    id: folderIcon
+
+                    anchors.left: disclosure.right
+                    anchors.leftMargin: IKSpacing.s4
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: IKSyncConfiguration.treeRowIconSize
+                    height: width
+                    source: "qrc:/assets/main/folder.svg"
+                    color: folderRow.accessDenied ? IKColors.actionDisabled : IKColors.syncConfigurationFolderIcon
+                }
+
+                Text {
+                    id: folderNameText
+
+                    anchors.left: folderIcon.right
+                    anchors.leftMargin: IKSyncConfiguration.treeRowSpacing
+                    anchors.right: sizeTextLabel.left
+                    anchors.rightMargin: IKSyncConfiguration.treeRowSpacing
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: folderRow.folderName
+                    color: folderRow.accessDenied ? IKColors.actionDisabled : IKColors.textPrimary
+                    font.pixelSize: IKFonts.bodySize
+                    elide: Text.ElideRight
+
+                    IKToolTip {
+                        visible: rowHover.hovered && folderNameText.truncated
+                        text: folderRow.folderName
+                        maximumTextWidth: IKSyncConfiguration.tooltipMaximumWidth
+                    }
+                }
+
+                Text {
+                    id: sizeTextLabel
+
+                    width: IKSyncConfiguration.treeSizeColumnWidth
+                    anchors.right: parent.right
+                    anchors.rightMargin: IKSyncConfiguration.treeStateSpacing
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: folderRow.sizeText
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.subheadlineSize
+                    horizontalAlignment: Text.AlignRight
+                }
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/features/syncconfiguration/RemoteFolderTree.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/RemoteFolderTree.qml
@@ -88,7 +88,9 @@ Rectangle {
 
             width: IKSyncConfiguration.treeSizeColumnWidth
             anchors.right: parent.right
-            anchors.rightMargin: IKSyncConfiguration.treeStateSpacing
+            // The values sit inside the TreeView, which the header does not share: its padding is added here so the
+            // two right edges line up.
+            anchors.rightMargin: IKSyncConfiguration.treeStateSpacing + IKSyncConfiguration.treeContentPadding
             anchors.verticalCenter: parent.verticalCenter
             text: qsTrId("labelSize")
             color: IKColors.textSecondary
@@ -187,6 +189,14 @@ Rectangle {
                 treeView.positionViewAtRow(targetRow, TableView.Contain)
             }
 
+            // The tree is usually still empty when it takes the focus, so the cursor is also placed once the rows
+            // arrive: without it Space and Enter stay inert until an arrow key moves the cursor.
+            function placeInitialCurrentRow(): void {
+                if (treeView.activeFocus && treeView.currentRow < 0) {
+                    treeView.moveCurrentToRow(0)
+                }
+            }
+
             anchors.fill: parent
             anchors.margins: IKSyncConfiguration.treeContentPadding
             visible: root.contentVisible
@@ -202,11 +212,8 @@ Rectangle {
                 model: root.treeModel
             }
 
-            onActiveFocusChanged: {
-                if (treeView.activeFocus && treeView.currentRow < 0) {
-                    treeView.moveCurrentToRow(0)
-                }
-            }
+            onActiveFocusChanged: treeView.placeInitialCurrentRow()
+            onRowsChanged: treeView.placeInitialCurrentRow()
 
             Keys.onUpPressed: treeView.moveCurrentToRow(treeView.currentRow - 1)
             Keys.onDownPressed: treeView.moveCurrentToRow(treeView.currentRow + 1)
@@ -261,6 +268,14 @@ Rectangle {
                 readonly property var treeIndex: folderRow.treeView.index(folderRow.row, folderRow.column)
                 readonly property bool disclosureVisible: folderRow.isTreeNode && folderRow.hasChildren
 
+                function requestToggle(): void {
+                    if (folderRow.accessDenied) {
+                        return
+                    }
+                    treeView.moveCurrentToRow(folderRow.row)
+                    root.treeModel.toggleSelection(folderRow.treeIndex)
+                }
+
                 implicitWidth: folderRow.treeView.width
                 implicitHeight: IKSyncConfiguration.treeRowHeight
 
@@ -273,6 +288,8 @@ Rectangle {
                 Accessible.checked: folderRow.checkState === Qt.Checked
                 Accessible.checkStateMixed: folderRow.checkState === Qt.PartiallyChecked
                 Accessible.readOnly: folderRow.accessDenied
+                // The row carries the check state, so it carries its action too: the checkbox is ignored above.
+                Accessible.onToggleAction: folderRow.requestToggle()
 
                 Component.onCompleted: root.treeModel.setRowVisible(folderRow.treeIndex, true)
                 Component.onDestruction: root.treeModel.setRowVisible(folderRow.treeIndex, false)
@@ -310,10 +327,7 @@ Rectangle {
                     enabled: !folderRow.accessDenied
                     focusPolicy: Qt.NoFocus
                     Accessible.ignored: true
-                    onClicked: {
-                        treeView.moveCurrentToRow(folderRow.row)
-                        root.treeModel.toggleSelection(folderRow.treeIndex)
-                    }
+                    onClicked: folderRow.requestToggle()
                 }
 
                 Item {

--- a/src/gui4/linux/ui/tokens/IKCheckBoxTokens.qml
+++ b/src/gui4/linux/ui/tokens/IKCheckBoxTokens.qml
@@ -1,0 +1,37 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma Singleton
+import QtQuick
+
+QtObject {
+    readonly property real indicatorSize: 16
+    readonly property real indicatorRadius: 5
+    readonly property real borderWidth: 1
+    readonly property real focusRingWidth: 2
+    readonly property real focusRingRadius: IKRadius.r8
+    // Pointer and keyboard target around the smaller drawn indicator.
+    readonly property real hitAreaSize: 24
+    // Coordinate space the check mark path is authored in; scaled to indicatorSize at paint time.
+    readonly property real markReferenceSize: 16
+    readonly property real markStrokeWidth: 1.6
+    readonly property real partialMarkWidth: 8
+    readonly property real partialMarkHeight: 2
+    readonly property real partialMarkRadius: 1
+    readonly property real disabledOpacity: 0.45
+}

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -206,4 +206,19 @@ QtObject {
     readonly property color modalScrim: _p.neutralBlack35
     readonly property color modalSecondaryActionHover: surfaceTertiary
     readonly property color modalHardWarningIcon: actionDestructive
+    readonly property color checkboxSurface: surfaceTertiary
+    readonly property color checkboxSelectedSurface: actionPrimary
+    readonly property color checkboxMark: actionOnPrimary
+    readonly property color checkboxBorder: surfaceTertiary
+    readonly property color checkboxHoverBorder: textTertiary
+    readonly property color checkboxDisabledSurface: surfaceSecondary
+    readonly property color checkboxDisabledBorder: actionDisabled
+    readonly property color syncConfigurationTreeSurface: modalSurface
+    readonly property color syncConfigurationTreeHeaderSurface: surfaceSecondary
+    readonly property color syncConfigurationRowCurrent: surfaceTertiary
+    readonly property color syncConfigurationRowSelectedSurface: surfaceSecondary
+    readonly property color syncConfigurationRowHover: surfaceTertiary
+    readonly property color syncConfigurationDivider: surfaceTertiary
+    readonly property color syncConfigurationFolderIcon: textTertiary
+    readonly property color syncConfigurationDisclosureIcon: textSecondary
 }

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -206,11 +206,11 @@ QtObject {
     readonly property color modalScrim: _p.neutralBlack35
     readonly property color modalSecondaryActionHover: surfaceTertiary
     readonly property color modalHardWarningIcon: actionDestructive
-    readonly property color checkboxSurface: surfaceTertiary
+    readonly property color checkboxSurface: "transparent"
     readonly property color checkboxSelectedSurface: actionPrimary
     readonly property color checkboxMark: actionOnPrimary
-    readonly property color checkboxBorder: surfaceTertiary
-    readonly property color checkboxHoverBorder: textTertiary
+    readonly property color checkboxBorder: textTertiary
+    readonly property color checkboxHoverBorder: textSecondary
     readonly property color checkboxDisabledSurface: surfaceSecondary
     readonly property color checkboxDisabledBorder: actionDisabled
     readonly property color syncConfigurationTreeSurface: modalSurface

--- a/src/gui4/linux/ui/tokens/IKSyncConfiguration.qml
+++ b/src/gui4/linux/ui/tokens/IKSyncConfiguration.qml
@@ -1,0 +1,71 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma Singleton
+import QtQuick
+
+QtObject {
+    // Modal shell
+    readonly property real modalWidth: 600
+    readonly property real sectionSpacing: IKSpacing.s16
+    readonly property real tooltipMaximumWidth: 320
+
+    // Selected-drive summary
+    readonly property real summaryDescriptionWidth: 430
+    readonly property real summaryListMaximumHeight: 276
+    readonly property real summaryListSpacing: IKSpacing.s8
+    readonly property real summaryRowRadius: IKRadius.r8
+    readonly property real summaryRowPadding: IKSpacing.s16
+    readonly property real summaryRowSpacing: IKSpacing.s12
+    readonly property real summaryRowTextSpacing: IKSpacing.s2
+
+    // Per-drive configuration
+    readonly property real driveIconSize: 20
+    readonly property real driveBadgeRadius: IKRadius.r8
+    readonly property real driveBadgePadding: IKSpacing.s8
+    readonly property real driveBadgeSpacing: IKSpacing.s8
+    readonly property real cardRadius: IKRadius.r8
+    readonly property real cardPadding: IKSpacing.s16
+    readonly property real cardSpacing: IKSpacing.s12
+    readonly property real cardTitleSpacing: IKSpacing.s4
+    readonly property real fieldSpacing: IKSpacing.s8
+    readonly property real fieldRadius: IKRadius.r6
+    readonly property real fieldBorderWidth: 1
+    readonly property real fieldHorizontalPadding: IKSpacing.s8
+    readonly property real fieldVerticalPadding: IKSpacing.s4
+    readonly property real folderIconSize: 16
+    readonly property real statusIconSize: 14
+    readonly property real statusSpacing: IKSpacing.s8
+
+    // Remote folder tree
+    readonly property real treeHeight: 330
+    readonly property real treeRadius: IKRadius.r8
+    readonly property real treeBorderWidth: 1
+    readonly property real treeHeaderHeight: 32
+    readonly property real treeRowHeight: 32
+    readonly property real treeRowRadius: IKRadius.r4
+    readonly property real treeContentPadding: IKSpacing.s4
+    readonly property real treeIndent: 20
+    readonly property real treeDisclosureSize: 20
+    readonly property real treeChevronSize: 10
+    readonly property real treeRowIconSize: 16
+    readonly property real treeRowSpacing: IKSpacing.s8
+    readonly property real treeSizeColumnWidth: 88
+    readonly property real treeStateSpacing: IKSpacing.s12
+    readonly property real treeSpinnerSize: 12
+}


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Première pièce QML des paramètres de synchronisation avancés : l'arbre de dossiers distants dans lequel l'utilisateur choisit ses dossiers, ainsi que la case à cocher tri-état partagée dont il a besoin. Rien ne l'instancie encore ; les pages de la boîte de dialogue qui l'hébergent arrivent dans les PRs suivantes.

## Changements
Fichiers : `ui/features/syncconfiguration/RemoteFolderTree.qml` (420 lignes), `ui/components/IKCheckBox.qml`, `ui/tokens/IKCheckBoxTokens.qml`, `ui/tokens/IKSyncConfiguration.qml`, plus 15 couleurs dans `IKColors.qml`, 4 entrées dans `CMakeLists.txt`, et deux paragraphes d'`AGENTS.md`.

Points à signaler :
- **L'arbre est un seul arrêt de tabulation.** Tabuler à travers chaque case d'une longue liste de dossiers rendrait la page inutilisable, donc le `TreeView` prend le focus une seule fois et déplace une ligne courante en interne, comme un arbre natif. Haut et Bas déplacent la ligne, Gauche réduit ou va au dossier parent, Droite étend ou va au premier enfant, Espace et Entrée incluent ou excluent le dossier. `keyNavigationEnabled` est désactivé pour que réduire et étendre se comportent de façon identique quelle que soit la version de Qt, et le modèle expose `parentIndex()` car `QAbstractItemModel::parent()` n'est pas appelable depuis QML.
- **La ligne courante est un curseur de navigation, pas un anneau de focus.** `TreeView` est un `Flickable` et n'a pas de `visualFocus`, donc une bordure dessinée à partir d'`activeFocus` apparaîtrait aussi lors d'un simple clic de souris. Elle est dessinée comme une teinte de fond à la place, ce qui garde les deux significations séparées et reste utile aux utilisateurs à la souris.
- **L'accessibilité vit sur la ligne.** Le délégué porte `Accessible.role: TreeItem` avec le nom, la taille comme description, et les états checkable et checked ; sa case à cocher et son disclosure sont marqués `Accessible.ignored` car ils représentent l'état de la ligne plutôt que d'être des contrôles séparés. Un lecteur d'écran annonce donc un dossier plutôt que trois éléments.
- **`IKCheckBox` rend l'état qu'on lui donne et ne fait que rapporter les clics.** Il ne décide jamais de son prochain état lui-même, si bien que le modèle propriétaire de la sélection reste seul autoritaire. Il expose les états checked et mixed aux API d'accessibilité.
- **Les lignes rapportent leur visibilité au modèle**, ce qui pilote le chargement paresseux et la file de tailles bornée ajoutés dans #2385 : une ligne entrant dans la zone visible charge la taille de son dossier et ses enfants immédiats.
- Le chargement, l'échec de chargement de la racine avec bouton de réessai, et l'état de kDrive vide sont gérés dans le corps de l'arbre.

</details>

---

## Summary
First QML piece of the advanced synchronization settings: the remote folder tree the user picks folders in, plus the shared tri-state checkbox it needs. Nothing instantiates it yet; the dialog pages that host it come in the following PRs.

## Changes
Files: `ui/features/syncconfiguration/RemoteFolderTree.qml` (420 lines), `ui/components/IKCheckBox.qml`, `ui/tokens/IKCheckBoxTokens.qml`, `ui/tokens/IKSyncConfiguration.qml`, plus 15 colors in `IKColors.qml`, 4 entries in `CMakeLists.txt`, and two `AGENTS.md` paragraphs.

Points worth stating:
- **The tree is a single tab stop.** Tabbing through every checkbox of a large folder list would make the page unusable, so the `TreeView` takes the focus once and moves a current row internally, like a native tree. Up and Down move the row, Left collapses or goes to the parent folder, Right expands or goes to the first child, Space and Enter include or exclude the folder. `keyNavigationEnabled` is off so collapse and expand behave identically whatever the Qt version, and the model exposes `parentIndex()` because `QAbstractItemModel::parent()` is not callable from QML.
- **The current row is a navigation cursor, not a focus ring.** `TreeView` is a `Flickable` and has no `visualFocus`, so a border drawn from `activeFocus` would also appear on a plain mouse click. It is drawn as a background tint instead, which keeps the two meanings apart and stays useful to mouse users.
- **Accessibility lives on the row.** The delegate carries `Accessible.role: TreeItem` with name, size as description, and the checkable and checked states; its checkbox and disclosure are marked `Accessible.ignored` because they represent the row's state rather than being separate controls. A screen reader therefore announces one folder instead of three items.
- **`IKCheckBox` renders the state it is given and only reports clicks.** It never decides its own next state, so the model owning the selection stays authoritative. It exposes checked and mixed states to accessibility APIs.
- **Rows report their visibility to the model**, which is what drives the lazy loading and the bounded size queue added in #2385: a row entering the viewport loads its folder size and its immediate children.
- Loading, root-load failure with retry, and the empty-kDrive state are handled in the body of the tree.

## Notes
Depends on #2387.


# Screenshots

||**Light**|**Dark**|
|---|---|---|
|**Tree Errors**|<img width="1075" height="775" alt="tree-error-light" src="https://github.com/user-attachments/assets/29cf0983-e6b4-47c5-a9a7-a37eccacd19d" />|<img width="1075" height="775" alt="tree-error-dark" src="https://github.com/user-attachments/assets/68d8a3d6-9d58-4e24-92a5-7fb0c0a3092c" />|
|**Tree Variants**|<img width="1075" height="775" alt="tree-variants-light" src="https://github.com/user-attachments/assets/786b97b3-2f71-42f0-b756-63ab0d930874" />|<img width="1075" height="775" alt="tree-variants-dark" src="https://github.com/user-attachments/assets/01e47bfa-9d1d-4d7a-bfef-b747a1a256f3" />|