### PR TITLE
feat(sync-config): add advanced settings pages and shared controls

### DIFF
--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -182,6 +182,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKTintedIcon.qml
         ui/components/IKErrorBanner.qml
         ui/features/syncconfiguration/RemoteFolderTree.qml
+        ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
         ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
         ui/dialogs/GlobalModalHost.qml
         ui/dialogs/ManyDeletesDialog.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -139,6 +139,7 @@ set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)
         ui/tokens/IKIconSizes.qml
         ui/tokens/IKActivities.qml
         ui/tokens/IKCheckBoxTokens.qml
+        ui/tokens/IKLinkTokens.qml
         ui/tokens/IKOnboarding.qml
         ui/tokens/IKMainWindow.qml
         ui/tokens/IKModalTokens.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -185,6 +185,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
         ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
         ui/features/syncconfiguration/SyncConfigurationFolderPage.qml
+        ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
         ui/dialogs/GlobalModalHost.qml
         ui/dialogs/ManyDeletesDialog.qml
         ui/windows/main/BlockingErrorPlaceholder.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -172,6 +172,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKAvatar.qml
         ui/components/IKCheckBox.qml
         ui/components/IKDriveIcon.qml
+        ui/components/IKLinkButton.qml
         ui/components/IKLoadingSpinner.qml
         ui/components/IKModal.qml
         ui/components/IKModalButton.qml
@@ -181,6 +182,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKTintedIcon.qml
         ui/components/IKErrorBanner.qml
         ui/features/syncconfiguration/RemoteFolderTree.qml
+        ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
         ui/dialogs/GlobalModalHost.qml
         ui/dialogs/ManyDeletesDialog.qml
         ui/windows/main/BlockingErrorPlaceholder.qml

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -184,6 +184,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/features/syncconfiguration/RemoteFolderTree.qml
         ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
         ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
+        ui/features/syncconfiguration/SyncConfigurationFolderPage.qml
         ui/dialogs/GlobalModalHost.qml
         ui/dialogs/ManyDeletesDialog.qml
         ui/windows/main/BlockingErrorPlaceholder.qml

--- a/src/gui4/linux/ui/components/IKLinkButton.qml
+++ b/src/gui4/linux/ui/components/IKLinkButton.qml
@@ -1,0 +1,60 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+// Inline textual action. It carries no surface of its own so it can sit directly on a card without competing with the
+// card background, unlike IKModalButton which owns a filled or outlined shape.
+Button {
+    id: root
+
+    property bool actionEnabled: true
+
+    enabled: actionEnabled
+    padding: 0
+    implicitWidth: linkText.implicitWidth
+    implicitHeight: Math.max(linkText.implicitHeight, IKLinkTokens.minimumHeight)
+    focusPolicy: Qt.StrongFocus
+    hoverEnabled: true
+    Accessible.role: Accessible.Button
+    Accessible.name: text
+
+    // The control sizes background and contentItem itself, so neither is anchored here.
+    background: Rectangle {
+        radius: IKRadius.r4
+        color: "transparent"
+        border.width: root.visualFocus ? IKLinkTokens.focusRingWidth : 0
+        border.color: IKColors.accentPrimary
+    }
+
+    contentItem: Text {
+        id: linkText
+
+        text: root.text
+        color: root.enabled ? IKColors.actionPrimary : IKColors.actionDisabled
+        font.pixelSize: IKFonts.bodySize
+        font.underline: root.hovered || root.down
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
+        elide: Text.ElideRight
+    }
+}

--- a/src/gui4/linux/ui/components/IKModalButton.qml
+++ b/src/gui4/linux/ui/components/IKModalButton.qml
@@ -40,13 +40,19 @@ Button {
         if (!actionEnabled && !busy) {
             return IKColors.actionDisabled
         }
-        if (role === IKModalButton.Secondary || role === IKModalButton.Tonal) {
+        if (role === IKModalButton.Tonal) {
+            return IKColors.actionOnTonal
+        }
+        if (role === IKModalButton.Secondary) {
             return IKColors.actionPrimary
         }
         return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary
     }
     readonly property color focusBorderColor: {
-        if (role === IKModalButton.Secondary || role === IKModalButton.Tonal) {
+        if (role === IKModalButton.Tonal) {
+            return IKColors.actionOnTonal
+        }
+        if (role === IKModalButton.Secondary) {
             return IKColors.accentPrimary
         }
         return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary

--- a/src/gui4/linux/ui/components/IKModalButton.qml
+++ b/src/gui4/linux/ui/components/IKModalButton.qml
@@ -28,8 +28,7 @@ Button {
     enum Role {
         Primary,
         Secondary,
-        Destructive,
-        Tonal
+        Destructive
     }
 
     property int role: IKModalButton.Primary
@@ -40,18 +39,12 @@ Button {
         if (!actionEnabled && !busy) {
             return IKColors.actionDisabled
         }
-        if (role === IKModalButton.Tonal) {
-            return IKColors.actionOnTonal
-        }
         if (role === IKModalButton.Secondary) {
             return IKColors.actionPrimary
         }
         return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary
     }
     readonly property color focusBorderColor: {
-        if (role === IKModalButton.Tonal) {
-            return IKColors.actionOnTonal
-        }
         if (role === IKModalButton.Secondary) {
             return IKColors.accentPrimary
         }
@@ -101,9 +94,6 @@ Button {
         color: {
             if (root.role === IKModalButton.Secondary) {
                 return root.hovered || root.down ? IKColors.modalSecondaryActionHover : "transparent"
-            }
-            if (root.role === IKModalButton.Tonal) {
-                return IKColors.actionTonalSurface
             }
             if (root.role === IKModalButton.Destructive) {
                 return root.down ? IKColors.actionDestructivePressed : IKColors.actionDestructive

--- a/src/gui4/linux/ui/components/IKModalButton.qml
+++ b/src/gui4/linux/ui/components/IKModalButton.qml
@@ -28,7 +28,8 @@ Button {
     enum Role {
         Primary,
         Secondary,
-        Destructive
+        Destructive,
+        Tonal
     }
 
     property int role: IKModalButton.Primary
@@ -39,13 +40,13 @@ Button {
         if (!actionEnabled && !busy) {
             return IKColors.actionDisabled
         }
-        if (role === IKModalButton.Secondary) {
+        if (role === IKModalButton.Secondary || role === IKModalButton.Tonal) {
             return IKColors.actionPrimary
         }
         return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary
     }
     readonly property color focusBorderColor: {
-        if (role === IKModalButton.Secondary) {
+        if (role === IKModalButton.Secondary || role === IKModalButton.Tonal) {
             return IKColors.accentPrimary
         }
         return role === IKModalButton.Destructive ? IKColors.actionOnDestructive : IKColors.actionOnPrimary
@@ -59,6 +60,8 @@ Button {
     leftPadding: IKModalTokens.buttonHorizontalPadding
     rightPadding: IKModalTokens.buttonHorizontalPadding
     focusPolicy: Qt.StrongFocus
+    Accessible.role: Accessible.Button
+    Accessible.name: text
     hoverEnabled: true
     opacity: actionEnabled || busy ? 1 : IKModalTokens.disabledOpacity
 
@@ -92,6 +95,9 @@ Button {
         color: {
             if (root.role === IKModalButton.Secondary) {
                 return root.hovered || root.down ? IKColors.modalSecondaryActionHover : "transparent"
+            }
+            if (root.role === IKModalButton.Tonal) {
+                return IKColors.actionTonalSurface
             }
             if (root.role === IKModalButton.Destructive) {
                 return root.down ? IKColors.actionDestructivePressed : IKColors.actionDestructive

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
@@ -32,7 +32,7 @@ Column {
     // The page claims the focus itself: the modal loads it dynamically, so it cannot reach into the page to place it.
     // It lands on the first thing the user can change rather than on the confirmation button.
     Component.onCompleted: Qt.callLater(function() {
-        changeFolderButton.forceActiveFocus(Qt.TabFocusReason)
+        changeFolderButton.forceActiveFocus()
     })
 
     Connections {
@@ -40,7 +40,7 @@ Column {
 
         // Returning from the native picker leaves focus nowhere otherwise, since the dialog is a separate window.
         function onCustomFolderDialogClosed() {
-            changeFolderButton.forceActiveFocus(Qt.TabFocusReason)
+            changeFolderButton.forceActiveFocus()
         }
     }
 

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
@@ -1,0 +1,314 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Column {
+    id: root
+
+    required property var controller
+
+    width: parent ? parent.width : implicitWidth
+    spacing: IKSyncConfiguration.sectionSpacing
+
+    // The page claims the focus itself: the modal loads it dynamically, so it cannot reach into the page to place it.
+    // It lands on the first thing the user can change rather than on the confirmation button.
+    Component.onCompleted: Qt.callLater(function() {
+        changeFolderButton.forceActiveFocus(Qt.TabFocusReason)
+    })
+
+    Connections {
+        target: root.controller
+
+        // Returning from the native picker leaves focus nowhere otherwise, since the dialog is a separate window.
+        function onCustomFolderDialogClosed() {
+            changeFolderButton.forceActiveFocus(Qt.TabFocusReason)
+        }
+    }
+
+    Rectangle {
+        // Sized from its content so the badge hugs the drive name, as in the reference design.
+        width: driveBadgeContent.width + 2 * IKSyncConfiguration.driveBadgePadding
+        implicitHeight: driveBadgeContent.implicitHeight + 2 * IKSyncConfiguration.driveBadgePadding
+        radius: IKSyncConfiguration.driveBadgeRadius
+        color: IKColors.syncConfigurationCardSurface
+
+        Row {
+            id: driveBadgeContent
+
+            anchors.left: parent.left
+            anchors.leftMargin: IKSyncConfiguration.driveBadgePadding
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: IKSyncConfiguration.driveBadgeSpacing
+
+            DriveIconView {
+                width: IKSyncConfiguration.driveIconSize
+                height: width
+                anchors.verticalCenter: parent.verticalCenter
+                iconColor: root.controller.currentDriveColor
+            }
+
+            Text {
+                id: driveNameText
+
+                width: Math.min(implicitWidth,
+                                Math.max(0, root.width - IKSyncConfiguration.driveIconSize - parent.spacing
+                                         - 2 * IKSyncConfiguration.driveBadgePadding))
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.controller.currentDriveName
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.bodySize
+                font.weight: IKFonts.emphasized
+                elide: Text.ElideRight
+
+                HoverHandler {
+                    id: driveNameHover
+                }
+
+                IKToolTip {
+                    visible: driveNameHover.hovered && driveNameText.truncated
+                    text: root.controller.currentDriveName
+                    maximumTextWidth: IKSyncConfiguration.tooltipMaximumWidth
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        width: parent.width
+        implicitHeight: locationContent.implicitHeight + 2 * IKSyncConfiguration.cardPadding
+        radius: IKSyncConfiguration.cardRadius
+        color: IKColors.syncConfigurationCardSurface
+
+        Column {
+            id: locationContent
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: IKSyncConfiguration.cardPadding
+            spacing: IKSyncConfiguration.cardSpacing
+
+            Column {
+                width: parent.width
+                spacing: IKSyncConfiguration.cardTitleSpacing
+
+                Text {
+                    width: parent.width
+                    text: qsTrId("labelSyncLocation")
+                    color: IKColors.textPrimary
+                    font.pixelSize: IKFonts.bodySize
+                    font.weight: IKFonts.emphasized
+                }
+
+                Text {
+                    width: parent.width
+                    text: qsTrId("onboardingAdvancedSettingsDriveCustomizeLocation")
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.subheadlineSize
+                    wrapMode: Text.WordWrap
+                }
+            }
+
+            Row {
+                width: parent.width
+                spacing: IKSyncConfiguration.fieldSpacing
+
+                Rectangle {
+                    id: locationKindField
+
+                    width: locationKindContent.implicitWidth + 2 * IKSyncConfiguration.fieldHorizontalPadding
+                    height: locationKindContent.implicitHeight + 2 * IKSyncConfiguration.fieldVerticalPadding
+                    anchors.verticalCenter: parent.verticalCenter
+                    radius: IKSyncConfiguration.fieldRadius
+                    color: IKColors.syncConfigurationFieldSurface
+                    border.width: IKSyncConfiguration.fieldBorderWidth
+                    border.color: IKColors.syncConfigurationFieldBorder
+
+                    Row {
+                        id: locationKindContent
+
+                        anchors.centerIn: parent
+                        spacing: IKSpacing.s4
+
+                        IKTintedIcon {
+                            width: IKSyncConfiguration.folderIconSize
+                            height: width
+                            anchors.verticalCenter: parent.verticalCenter
+                            source: "qrc:/assets/main/folder.svg"
+                            color: IKColors.syncConfigurationFolderIcon
+                        }
+
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: root.controller.currentUsesDefaultFolder ? qsTrId("syncFolderDefaultLocation")
+                                                                           : qsTrId("syncFolderCustomLocation")
+                            color: IKColors.textPrimary
+                            font.pixelSize: IKFonts.bodySize
+                            font.weight: IKFonts.emphasized
+                        }
+                    }
+                }
+
+                Text {
+                    id: pathText
+
+                    width: Math.max(0, parent.width - locationKindField.width - parent.spacing)
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: root.controller.currentLocalPath
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.bodySize
+                    elide: Text.ElideMiddle
+
+                    HoverHandler {
+                        id: pathHover
+                    }
+
+                    IKToolTip {
+                        visible: pathHover.hovered && pathText.truncated
+                        text: root.controller.currentLocalPath
+                        maximumTextWidth: IKSyncConfiguration.tooltipMaximumWidth
+                    }
+                }
+            }
+
+            Row {
+                spacing: IKSyncConfiguration.fieldSpacing
+
+                IKModalButton {
+                    id: changeFolderButton
+
+                    role: IKModalButton.Tonal
+                    text: qsTrId("buttonChangeFolder")
+                    actionEnabled: !root.controller.busy
+                    onClicked: root.controller.requestCustomFolder()
+                }
+
+                IKModalButton {
+                    visible: !root.controller.currentUsesDefaultFolder
+                    role: IKModalButton.Tonal
+                    text: qsTrId("buttonReturnToDefaultFolder")
+                    actionEnabled: !root.controller.busy
+                    onClicked: root.controller.returnToDefaultFolder()
+                }
+            }
+
+            Text {
+                width: parent.width
+                text: qsTrId("onboardingAdvancedSettingsDriveCustomizeLocationTip")
+                color: IKColors.textTertiary
+                font.pixelSize: IKFonts.subheadlineSize
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    Rectangle {
+        width: parent.width
+        implicitHeight: exclusionContent.implicitHeight + 2 * IKSyncConfiguration.cardPadding
+        radius: IKSyncConfiguration.cardRadius
+        color: IKColors.syncConfigurationCardSurface
+
+        Column {
+            id: exclusionContent
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: IKSyncConfiguration.cardPadding
+            spacing: IKSyncConfiguration.cardSpacing
+
+            Column {
+                width: parent.width
+                spacing: IKSyncConfiguration.cardTitleSpacing
+
+                Text {
+                    width: parent.width
+                    text: qsTrId("onboardingAdvancedSettingsDriveExclusionTitle")
+                    color: IKColors.textPrimary
+                    font.pixelSize: IKFonts.bodySize
+                    font.weight: IKFonts.emphasized
+                }
+
+                Text {
+                    width: parent.width
+                    text: qsTrId("onboardingAdvancedSettingsDriveExclusionDescription")
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.subheadlineSize
+                    wrapMode: Text.WordWrap
+                }
+            }
+
+            Row {
+                width: parent.width
+                spacing: IKSyncConfiguration.statusSpacing
+
+                IKModalButton {
+                    id: selectFoldersButton
+
+                    anchors.verticalCenter: parent.verticalCenter
+                    role: IKModalButton.Tonal
+                    text: qsTrId("buttonSelectFolders")
+                    actionEnabled: !root.controller.busy
+                    onClicked: root.controller.selectFolders()
+                }
+
+                Row {
+                    width: Math.max(0, parent.width - selectFoldersButton.width - parent.spacing)
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: IKSpacing.s4
+
+                    IKTintedIcon {
+                        width: IKSyncConfiguration.statusIconSize
+                        height: width
+                        anchors.verticalCenter: parent.verticalCenter
+                        source: "qrc:/assets/main/activities/status-synchronized-outline.svg"
+                        color: IKColors.syncConfigurationConfirmationIcon
+                    }
+
+                    Text {
+                        width: Math.max(0, parent.width - IKSyncConfiguration.statusIconSize - parent.spacing)
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: root.controller.currentHasCustomSelection ? qsTrId("onboardingExclusionSummarySome")
+                                                                        : qsTrId("onboardingExclusionSummaryNone")
+                        color: IKColors.textSecondary
+                        font.pixelSize: IKFonts.bodySize
+                        elide: Text.ElideRight
+                    }
+                }
+            }
+
+            Text {
+                width: parent.width
+                text: qsTrId("selectFoldersToSyncDescription")
+                color: IKColors.textTertiary
+                font.pixelSize: IKFonts.subheadlineSize
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    SyncConfigurationErrorBlock {
+        width: parent.width
+        errorTitle: root.controller.errorTitle
+        errorText: root.controller.errorText
+    }
+}

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
@@ -207,7 +207,7 @@ Column {
                 IKModalButton {
                     id: changeFolderButton
 
-                    role: IKModalButton.Tonal
+                    role: IKModalButton.Primary
                     text: qsTrId("buttonChangeFolder")
                     actionEnabled: !root.controller.busy
                     onClicked: root.controller.requestCustomFolder()
@@ -220,7 +220,7 @@ Column {
 
                 IKModalButton {
                     visible: !root.controller.currentUsesDefaultFolder
-                    role: IKModalButton.Tonal
+                    role: IKModalButton.Primary
                     text: qsTrId("buttonReturnToDefaultFolder")
                     actionEnabled: !root.controller.busy
                     onClicked: root.controller.returnToDefaultFolder()
@@ -281,7 +281,7 @@ Column {
                     id: selectFoldersButton
 
                     anchors.verticalCenter: parent.verticalCenter
-                    role: IKModalButton.Tonal
+                    role: IKModalButton.Primary
                     text: qsTrId("buttonSelectFolders")
                     actionEnabled: !root.controller.busy
                     onClicked: root.controller.selectFolders()

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
@@ -26,6 +26,17 @@ Column {
 
     required property var controller
 
+    // Set when the picker returns a path that still has to be validated: the button is disabled meanwhile, so it
+    // cannot take the focus back before the controller goes idle again.
+    property bool focusRestorePending: false
+
+    function restoreFocus(): void {
+        root.focusRestorePending = !changeFolderButton.enabled
+        if (changeFolderButton.enabled) {
+            changeFolderButton.forceActiveFocus()
+        }
+    }
+
     width: parent ? parent.width : implicitWidth
     spacing: IKSyncConfiguration.sectionSpacing
 
@@ -40,7 +51,7 @@ Column {
 
         // Returning from the native picker leaves focus nowhere otherwise, since the dialog is a separate window.
         function onCustomFolderDialogClosed() {
-            changeFolderButton.forceActiveFocus()
+            root.restoreFocus()
         }
     }
 
@@ -200,6 +211,11 @@ Column {
                     text: qsTrId("buttonChangeFolder")
                     actionEnabled: !root.controller.busy
                     onClicked: root.controller.requestCustomFolder()
+                    onEnabledChanged: {
+                        if (enabled && root.focusRestorePending) {
+                            root.restoreFocus()
+                        }
+                    }
                 }
 
                 IKModalButton {

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
@@ -1,0 +1,56 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+// Inline failure report for the sync-configuration pages. It states what cannot be done and why, so a rejected folder
+// explains the rule it broke instead of only saying that it was refused.
+Column {
+    id: root
+
+    property string errorTitle: ""
+    property string errorText: ""
+
+    visible: errorTitle.length > 0 || errorText.length > 0
+    spacing: IKSyncConfiguration.cardTitleSpacing
+    // Announced as an alert so a failure is reported without moving the focus away from what the user was doing.
+    Accessible.role: Accessible.AlertMessage
+    Accessible.name: [root.errorTitle, root.errorText].filter(part => part.length > 0).join(". ")
+
+    Text {
+        width: parent.width
+        visible: text.length > 0
+        text: root.errorTitle
+        color: IKColors.syncConfigurationError
+        font.pixelSize: IKFonts.subheadlineSize
+        font.weight: IKFonts.emphasized
+        wrapMode: Text.WordWrap
+    }
+
+    Text {
+        width: parent.width
+        visible: text.length > 0
+        text: root.errorText
+        color: IKColors.syncConfigurationError
+        font.pixelSize: IKFonts.subheadlineSize
+        wrapMode: Text.WordWrap
+    }
+}

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationFolderPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationFolderPage.qml
@@ -1,0 +1,51 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Column {
+    id: root
+
+    required property var controller
+
+    width: parent ? parent.width : implicitWidth
+    spacing: IKSyncConfiguration.sectionSpacing
+
+    // The tree is the only control of this page, so it takes the focus as soon as the page is loaded.
+    Component.onCompleted: Qt.callLater(function() {
+        folderTree.keyboardFocusItem.forceActiveFocus(Qt.TabFocusReason)
+    })
+
+    Text {
+        width: parent.width
+        text: qsTrId("selectFoldersToSyncDescription")
+        color: IKColors.textSecondary
+        font.pixelSize: IKFonts.bodySize
+        wrapMode: Text.WordWrap
+    }
+
+    RemoteFolderTree {
+        id: folderTree
+
+        width: parent.width
+        treeModel: root.controller.folderTreeModel
+    }
+}

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationFolderPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationFolderPage.qml
@@ -31,7 +31,7 @@ Column {
 
     // The tree is the only control of this page, so it takes the focus as soon as the page is loaded.
     Component.onCompleted: Qt.callLater(function() {
-        folderTree.keyboardFocusItem.forceActiveFocus(Qt.TabFocusReason)
+        folderTree.keyboardFocusItem.forceActiveFocus()
     })
 
     Text {

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
@@ -1,0 +1,164 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+Column {
+    id: root
+
+    required property var controller
+
+    width: parent ? parent.width : implicitWidth
+    spacing: IKSyncConfiguration.sectionSpacing
+
+    Text {
+        width: Math.min(parent.width, IKSyncConfiguration.summaryDescriptionWidth)
+        text: qsTrId("onboardingAdvancedSettingsDriveSelectionDescription")
+        color: IKColors.textSecondary
+        font.pixelSize: IKFonts.bodySize
+        wrapMode: Text.WordWrap
+    }
+
+    SyncConfigurationErrorBlock {
+        width: parent.width
+        errorTitle: root.controller.errorTitle
+        errorText: root.controller.errorText
+    }
+
+    ListView {
+        id: drivesList
+
+        width: parent.width
+        height: Math.min(contentHeight, IKSyncConfiguration.summaryListMaximumHeight)
+        model: root.controller.selectedDrivesModel
+        spacing: IKSyncConfiguration.summaryListSpacing
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+
+        ScrollBar.vertical: ScrollBar {
+            policy: drivesList.contentHeight > drivesList.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+        }
+
+        delegate: Rectangle {
+            id: driveRow
+
+            required property int index
+            required property string driveName
+            required property color driveColor
+            required property string localPath
+            required property bool customFolder
+            required property bool customSelection
+
+            width: drivesList.width
+            height: rowContent.implicitHeight + 2 * IKSyncConfiguration.summaryRowPadding
+            radius: IKSyncConfiguration.summaryRowRadius
+            color: IKColors.syncConfigurationCardSurface
+
+            Row {
+                id: rowContent
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: IKSyncConfiguration.summaryRowPadding
+                anchors.rightMargin: IKSyncConfiguration.summaryRowPadding
+                spacing: IKSyncConfiguration.summaryRowSpacing
+
+                DriveIconView {
+                    width: IKSyncConfiguration.driveIconSize
+                    height: width
+                    iconColor: driveRow.driveColor
+                }
+
+                Column {
+                    width: Math.max(0, parent.width - configureButton.width - IKSyncConfiguration.driveIconSize
+                                    - 2 * parent.spacing)
+                    spacing: IKSyncConfiguration.summaryRowTextSpacing
+
+                    Text {
+                        id: driveNameText
+
+                        width: parent.width
+                        text: driveRow.driveName
+                        color: IKColors.textPrimary
+                        font.pixelSize: IKFonts.bodySize
+                        font.weight: IKFonts.emphasized
+                        elide: Text.ElideRight
+
+                        HoverHandler {
+                            id: driveNameHover
+                        }
+
+                        IKToolTip {
+                            visible: driveNameHover.hovered && driveNameText.truncated
+                            text: driveRow.driveName
+                            maximumTextWidth: IKSyncConfiguration.tooltipMaximumWidth
+                        }
+                    }
+
+                    Text {
+                        id: locationText
+
+                        width: parent.width
+                        text: qsTrId("onboardingAdvancedSettingsDriveSelectionLocationMac")
+                              .arg("<b>" + (driveRow.customFolder ? driveRow.localPath
+                                                                 : qsTrId("labelByDefault")) + "</b>")
+                        textFormat: Text.StyledText
+                        color: IKColors.textSecondary
+                        font.pixelSize: IKFonts.subheadlineSize
+                        elide: Text.ElideRight
+
+                        HoverHandler {
+                            id: locationHover
+                        }
+
+                        IKToolTip {
+                            visible: locationHover.hovered && (locationText.truncated || driveRow.customFolder)
+                            text: driveRow.localPath
+                            maximumTextWidth: IKSyncConfiguration.tooltipMaximumWidth
+                        }
+                    }
+
+                    Text {
+                        width: parent.width
+                        text: qsTrId("onboardingAdvancedSettingsDriveSelectionExclusionMac")
+                              .arg("<b>" + (driveRow.customSelection ? qsTrId("onboardingExclusionSummarySome")
+                                                                     : qsTrId("labelAllkDrive")) + "</b>")
+                        textFormat: Text.StyledText
+                        color: IKColors.textSecondary
+                        font.pixelSize: IKFonts.subheadlineSize
+                        elide: Text.ElideRight
+                    }
+                }
+
+                IKLinkButton {
+                    id: configureButton
+
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTrId("buttonConfigure")
+                    actionEnabled: !root.controller.busy
+                    onClicked: root.controller.configureDrive(driveRow.index)
+                }
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
@@ -27,6 +27,12 @@ Column {
 
     required property var controller
 
+    // A folder name is free text and goes through `Text.StyledText` below, where `&`, `<` and `>` would be read as
+    // markup.
+    function escapedMarkup(value: string): string {
+        return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    }
+
     width: parent ? parent.width : implicitWidth
     spacing: IKSyncConfiguration.sectionSpacing
 
@@ -120,8 +126,8 @@ Column {
 
                         width: parent.width
                         text: qsTrId("onboardingAdvancedSettingsDriveSelectionLocationMac")
-                              .arg("<b>" + (driveRow.customFolder ? driveRow.localPath
-                                                                 : qsTrId("labelByDefault")) + "</b>")
+                              .arg("<b>" + (driveRow.customFolder ? root.escapedMarkup(driveRow.localPath)
+                                                                  : qsTrId("labelByDefault")) + "</b>")
                         textFormat: Text.StyledText
                         color: IKColors.textSecondary
                         font.pixelSize: IKFonts.subheadlineSize
@@ -155,6 +161,8 @@ Column {
 
                     anchors.verticalCenter: parent.verticalCenter
                     text: qsTrId("buttonConfigure")
+                    // Every row repeats the same label, so the drive is what tells them apart.
+                    Accessible.description: driveRow.driveName
                     actionEnabled: !root.controller.busy
                     onClicked: root.controller.configureDrive(driveRow.index)
                 }

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -114,6 +114,7 @@ QtObject {
     readonly property color actionPrimary: accentPrimary
     readonly property color actionOnPrimary: darkMode ? _p.neutralBlue800 : _p.neutralBlue100
     readonly property color actionDisabled: _p.gray400
+    readonly property color actionTonalSurface: darkMode ? _p.blue950 : _p.blue100
     readonly property color actionDestructive: _p.red500
     readonly property color actionDestructivePressed: _p.red600
     readonly property color actionOnDestructive: _p.white
@@ -206,6 +207,11 @@ QtObject {
     readonly property color modalScrim: _p.neutralBlack35
     readonly property color modalSecondaryActionHover: surfaceTertiary
     readonly property color modalHardWarningIcon: actionDestructive
+    readonly property color syncConfigurationCardSurface: surfaceSecondary
+    readonly property color syncConfigurationFieldSurface: modalSurface
+    readonly property color syncConfigurationFieldBorder: surfaceTertiary
+    readonly property color syncConfigurationConfirmationIcon: statusMediumSuccess
+    readonly property color syncConfigurationError: statusStrongWarning
     readonly property color checkboxSurface: "transparent"
     readonly property color checkboxSelectedSurface: actionPrimary
     readonly property color checkboxMark: actionOnPrimary

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -40,6 +40,7 @@ QtObject {
         readonly property color blue400: "#8AA7EF"
         readonly property color blue500: "#6E88E6"
         readonly property color blue600: "#446FDD"
+        readonly property color blue800: "#2A459C"
         readonly property color blue950: "#1F2547"
         readonly property color bluePale: "#DEE7FD"
 
@@ -114,7 +115,10 @@ QtObject {
     readonly property color actionPrimary: accentPrimary
     readonly property color actionOnPrimary: darkMode ? _p.neutralBlue800 : _p.neutralBlue100
     readonly property color actionDisabled: _p.gray400
-    readonly property color actionTonalSurface: darkMode ? _p.blue950 : _p.blue100
+    // Deep surface with a pale label in both themes. A pale surface in light mode barely separated the button from
+    // the card it sits on, and the accent blue on it fell short of the 4.5:1 contrast ratio expected of body text.
+    readonly property color actionTonalSurface: darkMode ? _p.blue950 : _p.blue800
+    readonly property color actionOnTonal: darkMode ? _p.blue400 : _p.blue100
     readonly property color actionDestructive: _p.red500
     readonly property color actionDestructivePressed: _p.red600
     readonly property color actionOnDestructive: _p.white

--- a/src/gui4/linux/ui/tokens/IKColors.qml
+++ b/src/gui4/linux/ui/tokens/IKColors.qml
@@ -40,7 +40,6 @@ QtObject {
         readonly property color blue400: "#8AA7EF"
         readonly property color blue500: "#6E88E6"
         readonly property color blue600: "#446FDD"
-        readonly property color blue800: "#2A459C"
         readonly property color blue950: "#1F2547"
         readonly property color bluePale: "#DEE7FD"
 
@@ -115,10 +114,6 @@ QtObject {
     readonly property color actionPrimary: accentPrimary
     readonly property color actionOnPrimary: darkMode ? _p.neutralBlue800 : _p.neutralBlue100
     readonly property color actionDisabled: _p.gray400
-    // Deep surface with a pale label in both themes. A pale surface in light mode barely separated the button from
-    // the card it sits on, and the accent blue on it fell short of the 4.5:1 contrast ratio expected of body text.
-    readonly property color actionTonalSurface: darkMode ? _p.blue950 : _p.blue800
-    readonly property color actionOnTonal: darkMode ? _p.blue400 : _p.blue100
     readonly property color actionDestructive: _p.red500
     readonly property color actionDestructivePressed: _p.red600
     readonly property color actionOnDestructive: _p.white

--- a/src/gui4/linux/ui/tokens/IKLinkTokens.qml
+++ b/src/gui4/linux/ui/tokens/IKLinkTokens.qml
@@ -1,0 +1,25 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma Singleton
+import QtQuick
+
+QtObject {
+    readonly property real minimumHeight: 20
+    readonly property real focusRingWidth: 2
+}


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Les trois pages des paramètres de synchronisation avancés, plus les deux contrôles partagés dont elles ont besoin. Rien ne les instancie encore : la modale qui héberge les pages, et le bouton qui l'ouvre, arrivent dans la dernière PR de la pile.

## Changements
Nouveaux fichiers :
- `SyncConfigurationSummaryPage.qml` : le récapitulatif multi-drive. Une ligne par kDrive sélectionné avec son icône, sa couleur, son nom, son emplacement (par défaut ou le chemin personnalisé) et son contenu synchronisé (tous les dossiers ou une sélection personnalisée), plus une action Configurer. Les noms et chemins longs s'élident et révèlent la valeur complète dans une infobulle.
- `SyncConfigurationDrivePage.qml` : la configuration par drive : la section dossier local avec Changer de dossier et Revenir au dossier par défaut, et la section dossiers synchronisés qui ouvre l'arbre distant de #2388.
- `SyncConfigurationFolderPage.qml` : héberge l'arbre de dossiers distants avec son texte explicatif.
- `SyncConfigurationErrorBlock.qml` : rapport d'échec en ligne portant un titre et un corps, annoncé comme `Accessible.AlertMessage` pour qu'un échec soit signalé sans voler le focus.
- `IKLinkButton.qml` + `IKLinkTokens.qml` : action textuelle en ligne sans surface propre, pour les lignes et cartes où un bouton plein ou avec bordure entrerait en concurrence avec le fond de la carte.

Modifié : `IKModalButton.qml` gagne un rôle `Tonal` (rempli avec `actionTonalSurface`, pour les actions posées sur une carte plutôt que sur le fond nu de la modale), ainsi que `Accessible.role`/`Accessible.name`. Plus 6 couleurs dans `IKColors.qml` et 6 entrées dans `CMakeLists.txt`.

Points à signaler :
- **Les anneaux de focus n'apparaissent que pour la navigation au clavier.** Les deux pages qui placent un focus initial le font avec `Qt.TabFocusReason` ; sans raison explicite, Qt utilise `OtherFocusReason`, qui ne déclenche pas `visualFocus`, et l'anneau ne serait jamais dessiné. Chaque page prend elle-même son focus au chargement plutôt que de laisser la modale aller le chercher, car `Loader.item` est un `QObject` et toute propriété de page serait un accès non typé.
- **La page de drive redonne le focus à Changer de dossier** quand le sélecteur de dossier natif se ferme, quel que soit le résultat, puisque le sélecteur est une fenêtre séparée et que le focus serait sinon perdu.
- **Le libellé du résumé correspond à macOS et Windows** : `labelByDefault` et `labelAllkDrive`, jamais un nombre de dossiers calculé.


</details>

---

## Summary
The three pages of the advanced synchronization settings, plus the two shared controls they need. Still nothing instantiates them: the modal that hosts the pages, and the button that opens it, come in the last PR of the stack.

## Changes
New files:
- `SyncConfigurationSummaryPage.qml`: the multi-drive recap. One row per selected kDrive with its icon, color, name, location (default or the custom path) and synced content (all folders or custom selection), plus a Configure action. Long names and paths elide and reveal the full value in a tooltip.
- `SyncConfigurationDrivePage.qml`: per-drive configuration: the local folder section with Change folder and Return to default folder, and the synced-folders section that opens the remote tree from #2388.
- `SyncConfigurationFolderPage.qml`: hosts the remote folder tree with its explanatory text.
- `SyncConfigurationErrorBlock.qml`: inline failure report carrying a title and a body, announced as `Accessible.AlertMessage` so a failure is reported without stealing the focus.
- `IKLinkButton.qml` + `IKLinkTokens.qml`: inline textual action with no surface of its own, for rows and cards where a filled or outlined button would compete with the card background.

Modified: `IKModalButton.qml` gains a `Tonal` role (filled with `actionTonalSurface`, for actions sitting on a card rather than on the plain modal background), and `Accessible.role`/`Accessible.name`. Plus 6 colors in `IKColors.qml` and 6 entries in `CMakeLists.txt`.

Points worth stating:
- **Focus rings appear for keyboard navigation only.** Both pages that place an initial focus do it with `Qt.TabFocusReason`; without an explicit reason Qt uses `OtherFocusReason`, which does not raise `visualFocus`, and the ring would never be drawn. Each page claims its own focus on load rather than letting the modal reach into it, because `Loader.item` is a `QObject` and any page property would be an untyped access.
- **The drive page returns the focus to Change folder** when the native folder picker closes, whatever the outcome, since the picker is a separate window and the focus would otherwise be lost.
- **Summary wording matches macOS and Windows**: `labelByDefault` and `labelAllkDrive`, never a computed folder count.

## Notes
Depends on #2388.

# Some Screenshots
_The texts are in French in the screenshots, but everything is translated._

||Light|Dark|
|---|---|---|
|Summary (with Error)|<img width="1125" height="950" alt="summary-error-light" src="https://github.com/user-attachments/assets/1c1585a2-02cf-476e-9e1a-e17a3df53321" />|<img width="1125" height="950" alt="summary-error-dark" src="https://github.com/user-attachments/assets/78d7eaa9-5245-4dfe-b14a-3955b86560db" />|
|Drive Default|<img width="1125" height="950" alt="drive-default-light" src="https://github.com/user-attachments/assets/a80c4cbe-4c96-457f-8a2c-bb813f12d864" />|<img width="1125" height="950" alt="drive-default-dark" src="https://github.com/user-attachments/assets/6907ac50-b720-4106-b49d-48adc4286455" />|
|Drive Custom (with Error)|<img width="1125" height="950" alt="drive-custom-error-light" src="https://github.com/user-attachments/assets/8488c0b8-f0e9-475a-a885-12897b358ca1" />|<img width="1125" height="950" alt="drive-custom-error-dark" src="https://github.com/user-attachments/assets/fa6b8a0f-e013-4ea8-b732-4d2d12fe5435" />|