### PR TITLE
feat(sync-config): wire advanced settings dialog into onboarding

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -14,6 +14,8 @@
 ### Local Norms (Linux v4)
 
 - In versioned documentation, use repo-relative paths, not hardcoded absolute paths.
+- Treat Qt 6.11.1 as the authoritative Qt version for Linux v4; verify the configured dependency before attributing behavior
+  to an older Qt release.
 - Do not add links to `.md` files that are not versioned in git.
 - Use Swiss German orthography for German Linux v4 translations: write `ss` instead of `ß`.
 - Never launch a build unless explicitly asked by the user.
@@ -158,7 +160,7 @@
 
 ## Scope
 
-- Linux-only v4 frontend based on Qt 6.8 (QML + C++).
+- Linux-only v4 frontend based on Qt 6.11.1 (QML + C++).
 - This package handles UI bootstrap and server communication only.
 - Sync business logic stays in `src/libsyncengine/` and server-side jobs.
 

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -52,6 +52,10 @@
   old type names, then validate at least the `kdrive_qml` target.
 - For tray fallback testing, `KDRIVE_FORCE_NO_TRAY=1` is Debug-only and forces the startup tray probe to stay disabled.
 - Avoid magic layout values in QML; put reusable or semantic dimensions and ratios in `ui/tokens/` with explicit names.
+- Give an in-app modal its hosting window's `effectiveShadowMargin` and `surfaceRadius` as `scrimInset`/`scrimRadius`.
+  The overlay spans the complete native window, so an un-inset scrim also dims the transparent custom-shadow margin.
+- Do not place a `Secondary` `IKModalButton` on a card surface: its outline is too close to that surface in both
+  themes. Use the `Tonal` role there, and keep `Secondary` for a plain modal or page background.
 - Size Home Quick Access from the widest translated shortcut label or the drive name capped to the Windows-aligned
   display width. Keep shortcut labels fully visible, while the drive name wraps to two lines before eliding. Let the
   Home status panel consume the remaining horizontal space.
@@ -353,7 +357,8 @@
       primitives accept display values and emit interactions; they do not read `AppCache`, own selection, or call
       services directly. `IKModal` and `IKModalButton` provide the styled in-app modal surface and semantic action roles;
       feature dialogs supply their own wording, state, and actions. Use `IKConfirmationDialog` for standard cancel/confirm
-      prompts so consumers only provide copy, busy state, and the confirmed/dismissed workflows. `IKCheckBox` is the shared tri-state indicator: it
+      prompts so consumers only provide copy, busy state, and the confirmed/dismissed workflows. `IKLinkButton` is the
+      inline textual action for rows and cards that must not carry a button surface of their own. `IKCheckBox` is the shared tri-state indicator: it
       renders the state it is given and only reports clicks, so a model owning the selection stays authoritative.
     - `ui/chrome/`: shared window chrome: frameless shell, header bar, controls, resize handles, and shadow wrapper.
       Top-level app-owned QML windows should use `IKShadowedWindow`; its `headerBackgroundData` and `headerData` slots

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -183,6 +183,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKTintedIcon.qml
         ui/components/IKErrorBanner.qml
         ui/features/syncconfiguration/RemoteFolderTree.qml
+        ui/features/syncconfiguration/SyncConfigurationDialog.qml
         ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
         ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
         ui/features/syncconfiguration/SyncConfigurationFolderPage.qml

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
@@ -91,8 +91,8 @@ void OnboardingSyncConfigurationController::open() {
     _busy = false;
     _errorTitle.clear();
     _errorText.clear();
-    _page = Summary;
     _currentRow = -1;
+    setPage(Summary);
     emit visibleChanged();
     showInitialPage();
 }
@@ -107,7 +107,7 @@ void OnboardingSyncConfigurationController::cancelCurrentPage() {
     abortPendingRequest();
     clearError();
     if (_page == FolderSelection) {
-        _page = DriveConfiguration;
+        setPage(DriveConfiguration);
         emit presentationChanged();
         return;
     }
@@ -117,8 +117,8 @@ void OnboardingSyncConfigurationController::cancelCurrentPage() {
         if (_drafts.size() == 1) {
             closeWithoutCommit();
         } else {
-            _page = Summary;
             _currentRow = -1;
+            setPage(Summary);
             emit presentationChanged();
         }
         return;
@@ -131,7 +131,7 @@ void OnboardingSyncConfigurationController::validateCurrentPage() {
     if (!canValidate()) return;
     if (_page == FolderSelection) {
         if (Draft *const draft = currentDraft()) draft->config.blackList = _folderTreeModel.blackList();
-        _page = DriveConfiguration;
+        setPage(DriveConfiguration);
         refreshSummaryModel();
         emit presentationChanged();
         return;
@@ -141,8 +141,8 @@ void OnboardingSyncConfigurationController::validateCurrentPage() {
         if (_drafts.size() == 1) {
             commitAndClose();
         } else {
-            _page = Summary;
             _currentRow = -1;
+            setPage(Summary);
             emit presentationChanged();
         }
         return;
@@ -212,8 +212,8 @@ void OnboardingSyncConfigurationController::selectFolders() {
     if (!draft || _busy) return;
     _folderTreeModel.configure(draft->key.userDbId, draft->key.driveId, QStr2Str(draft->config.targetNodeId),
                                draft->config.blackList);
-    _page = FolderSelection;
     clearError();
+    setPage(FolderSelection);
     emit presentationChanged();
 }
 
@@ -274,8 +274,8 @@ void OnboardingSyncConfigurationController::showInitialPage() {
     if (_drafts.size() == 1) {
         openDrive(0);
     } else {
-        _page = Summary;
         _currentRow = -1;
+        setPage(Summary);
         emit presentationChanged();
     }
 }
@@ -283,9 +283,15 @@ void OnboardingSyncConfigurationController::showInitialPage() {
 void OnboardingSyncConfigurationController::openDrive(const int32_t row) {
     _currentRow = row;
     _driveSnapshot = _drafts[static_cast<std::size_t>(row)].config;
-    _page = DriveConfiguration;
     clearError();
+    setPage(DriveConfiguration);
     emit presentationChanged();
+}
+
+void OnboardingSyncConfigurationController::setPage(const Page page) {
+    if (_page == page) return;
+    _page = page;
+    emit pageChanged();
 }
 
 void OnboardingSyncConfigurationController::refreshSummaryModel() {
@@ -331,7 +337,7 @@ void OnboardingSyncConfigurationController::closeWithoutCommit() {
     _drafts.clear();
     _driveSnapshot.reset();
     _currentRow = -1;
-    _page = Summary;
+    setPage(Summary);
     _errorTitle.clear();
     _errorText.clear();
     emit visibleChanged();
@@ -351,8 +357,8 @@ void OnboardingSyncConfigurationController::commitAndClose() {
             closeWithoutCommit();
             return;
         }
-        _page = Summary;
         _currentRow = -1;
+        setPage(Summary);
         emit presentationChanged();
         return;
     }

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.cpp
@@ -89,8 +89,7 @@ void OnboardingSyncConfigurationController::open() {
     ++_requestGeneration;
     _visible = true;
     _busy = false;
-    _errorTitle.clear();
-    _errorText.clear();
+    _localFolderErrorText.clear();
     _currentRow = -1;
     setPage(Summary);
     emit visibleChanged();
@@ -105,7 +104,7 @@ void OnboardingSyncConfigurationController::configureDrive(const int32_t row) {
 void OnboardingSyncConfigurationController::cancelCurrentPage() {
     // Leaving the page drops the path validation it started: its result would land on a page the user has left.
     abortPendingRequest();
-    clearError();
+    clearLocalFolderError();
     if (_page == FolderSelection) {
         setPage(DriveConfiguration);
         emit presentationChanged();
@@ -127,7 +126,7 @@ void OnboardingSyncConfigurationController::cancelCurrentPage() {
 }
 
 void OnboardingSyncConfigurationController::validateCurrentPage() {
-    clearError();
+    clearLocalFolderError();
     if (!canValidate()) return;
     if (_page == FolderSelection) {
         if (Draft *const draft = currentDraft()) draft->config.blackList = _folderTreeModel.blackList();
@@ -167,28 +166,28 @@ void OnboardingSyncConfigurationController::applyCustomFolder(const QUrl &folder
     const QString path = QDir::cleanPath(folderUrl.toLocalFile());
     if (!draft || path.isEmpty()) return;
     if (conflictsWithAnotherDraft(path, _currentRow)) {
-        setError(qtTrId("teachingTipInvalidFolderTitle"), qtTrId("teachingTipInvalidFolderContent"));
+        setLocalFolderError(qtTrId("teachingTipInvalidFolderContent"));
         return;
     }
 
     setBusy(true);
-    clearError();
+    clearLocalFolderError();
     const uint64_t generation = ++_requestGeneration;
     const QPointer self(this);
-    _commService.requestIsPathValidForNewSync(
-            QStr2Path(path), SyncConfiguration::Classic, [self, generation, path](const ExitInfo &exitInfo, const bool valid) {
-                if (!self || generation != self->_requestGeneration) return;
-                self->setBusy(false);
-                if (!exitInfo || !valid || !self->currentDraft()) {
-                    self->setError(qtTrId("teachingTipInvalidFolderTitle"), qtTrId("teachingTipInvalidFolderContent"));
-                    return;
-                }
-                self->currentDraft()->config.localPath = path;
-                self->currentDraft()->config.usesDefaultLocalPath =
-                        QDir::cleanPath(self->currentDraft()->config.defaultLocalPath) == path;
-                self->refreshSummaryModel();
-                emit self->presentationChanged();
-            });
+    _commService.requestIsPathValidForNewSync(QStr2Path(path), SyncConfiguration::Classic,
+                                              [self, generation, path](const ExitInfo &exitInfo, const bool valid) {
+                                                  if (!self || generation != self->_requestGeneration) return;
+                                                  self->setBusy(false);
+                                                  if (!exitInfo || !valid || !self->currentDraft()) {
+                                                      self->setLocalFolderError(qtTrId("teachingTipInvalidFolderContent"));
+                                                      return;
+                                                  }
+                                                  self->currentDraft()->config.localPath = path;
+                                                  self->currentDraft()->config.usesDefaultLocalPath =
+                                                          QDir::cleanPath(self->currentDraft()->config.defaultLocalPath) == path;
+                                                  self->refreshSummaryModel();
+                                                  emit self->presentationChanged();
+                                              });
 }
 
 void OnboardingSyncConfigurationController::returnToDefaultFolder() {
@@ -197,12 +196,12 @@ void OnboardingSyncConfigurationController::returnToDefaultFolder() {
     if (!draft || draft->config.defaultLocalPath.isEmpty()) return;
     // Another drive may have taken that folder while this one sat on a custom path.
     if (conflictsWithAnotherDraft(draft->config.defaultLocalPath, _currentRow)) {
-        setError(qtTrId("teachingTipInvalidFolderTitle"), qtTrId("teachingTipInvalidFolderContent"));
+        setLocalFolderError(qtTrId("teachingTipInvalidFolderContent"));
         return;
     }
     draft->config.localPath = draft->config.defaultLocalPath;
     draft->config.usesDefaultLocalPath = true;
-    clearError();
+    clearLocalFolderError();
     refreshSummaryModel();
     emit presentationChanged();
 }
@@ -212,7 +211,7 @@ void OnboardingSyncConfigurationController::selectFolders() {
     if (!draft || _busy) return;
     _folderTreeModel.configure(draft->key.userDbId, draft->key.driveId, QStr2Str(draft->config.targetNodeId),
                                draft->config.blackList);
-    clearError();
+    clearLocalFolderError();
     setPage(FolderSelection);
     emit presentationChanged();
 }
@@ -283,7 +282,7 @@ void OnboardingSyncConfigurationController::showInitialPage() {
 void OnboardingSyncConfigurationController::openDrive(const int32_t row) {
     _currentRow = row;
     _driveSnapshot = _drafts[static_cast<std::size_t>(row)].config;
-    clearError();
+    clearLocalFolderError();
     setPage(DriveConfiguration);
     emit presentationChanged();
 }
@@ -318,14 +317,13 @@ void OnboardingSyncConfigurationController::abortPendingRequest() {
     setBusy(false);
 }
 
-void OnboardingSyncConfigurationController::clearError() {
-    setError({}, {});
+void OnboardingSyncConfigurationController::clearLocalFolderError() {
+    setLocalFolderError({});
 }
 
-void OnboardingSyncConfigurationController::setError(const QString &title, const QString &text) {
-    if (_errorTitle == title && _errorText == text) return;
-    _errorTitle = title;
-    _errorText = text;
+void OnboardingSyncConfigurationController::setLocalFolderError(const QString &text) {
+    if (_localFolderErrorText == text) return;
+    _localFolderErrorText = text;
     emit presentationChanged();
 }
 
@@ -338,8 +336,7 @@ void OnboardingSyncConfigurationController::closeWithoutCommit() {
     _driveSnapshot.reset();
     _currentRow = -1;
     setPage(Summary);
-    _errorTitle.clear();
-    _errorText.clear();
+    _localFolderErrorText.clear();
     emit visibleChanged();
     emit presentationChanged();
 }
@@ -351,7 +348,6 @@ void OnboardingSyncConfigurationController::commitAndClose() {
     if (!_onboardingState.replacePendingSyncConfigs(configs)) {
         // The selected drives changed under the modal, so the drafts no longer describe them. Closing here would
         // silently drop everything the user configured.
-        setError({}, qtTrId("onboardingLoginErrorDescription"));
         buildDrafts();
         if (_drafts.empty()) {
             closeWithoutCommit();

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
@@ -40,9 +40,9 @@ class OnboardingState;
 class OnboardingSyncConfigurationController final : public QObject {
         Q_OBJECT
         Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
-        Q_PROPERTY(Page page READ page NOTIFY presentationChanged)
-        Q_PROPERTY(bool driveConfigurationPage READ driveConfigurationPage NOTIFY presentationChanged)
-        Q_PROPERTY(bool folderSelectionPage READ folderSelectionPage NOTIFY presentationChanged)
+        Q_PROPERTY(Page page READ page NOTIFY pageChanged)
+        Q_PROPERTY(bool driveConfigurationPage READ driveConfigurationPage NOTIFY pageChanged)
+        Q_PROPERTY(bool folderSelectionPage READ folderSelectionPage NOTIFY pageChanged)
         Q_PROPERTY(bool busy READ busy NOTIFY presentationChanged)
         Q_PROPERTY(bool canValidate READ canValidate NOTIFY presentationChanged)
         Q_PROPERTY(QString errorTitle READ errorTitle NOTIFY presentationChanged)
@@ -97,6 +97,7 @@ class OnboardingSyncConfigurationController final : public QObject {
 
     signals:
         void visibleChanged();
+        void pageChanged();
         void presentationChanged();
         void customFolderRequested(const QUrl &initialFolder);
         void customFolderDialogClosed();
@@ -115,6 +116,7 @@ class OnboardingSyncConfigurationController final : public QObject {
         void buildDrafts();
         void showInitialPage();
         void openDrive(int32_t row);
+        void setPage(Page page);
         void refreshSummaryModel();
         void setBusy(bool busy);
         void abortPendingRequest();

--- a/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingsyncconfigurationcontroller.h
@@ -45,8 +45,7 @@ class OnboardingSyncConfigurationController final : public QObject {
         Q_PROPERTY(bool folderSelectionPage READ folderSelectionPage NOTIFY pageChanged)
         Q_PROPERTY(bool busy READ busy NOTIFY presentationChanged)
         Q_PROPERTY(bool canValidate READ canValidate NOTIFY presentationChanged)
-        Q_PROPERTY(QString errorTitle READ errorTitle NOTIFY presentationChanged)
-        Q_PROPERTY(QString errorText READ errorText NOTIFY presentationChanged)
+        Q_PROPERTY(QString localFolderErrorText READ localFolderErrorText NOTIFY presentationChanged)
         Q_PROPERTY(QString currentDriveName READ currentDriveName NOTIFY presentationChanged)
         Q_PROPERTY(QColor currentDriveColor READ currentDriveColor NOTIFY presentationChanged)
         Q_PROPERTY(QString currentLocalPath READ currentLocalPath NOTIFY presentationChanged)
@@ -73,8 +72,7 @@ class OnboardingSyncConfigurationController final : public QObject {
         [[nodiscard]] bool folderSelectionPage() const { return _page == FolderSelection; }
         [[nodiscard]] bool busy() const { return _busy; }
         [[nodiscard]] bool canValidate() const;
-        [[nodiscard]] QString errorTitle() const { return _errorTitle; }
-        [[nodiscard]] QString errorText() const { return _errorText; }
+        [[nodiscard]] QString localFolderErrorText() const { return _localFolderErrorText; }
         [[nodiscard]] QString currentDriveName() const;
         [[nodiscard]] QColor currentDriveColor() const;
         /** Local folder of the drive being configured, in its `~`-shortened display form. */
@@ -120,8 +118,8 @@ class OnboardingSyncConfigurationController final : public QObject {
         void refreshSummaryModel();
         void setBusy(bool busy);
         void abortPendingRequest();
-        void clearError();
-        void setError(const QString &title, const QString &text);
+        void clearLocalFolderError();
+        void setLocalFolderError(const QString &text);
         void closeWithoutCommit();
         void commitAndClose();
 
@@ -138,8 +136,7 @@ class OnboardingSyncConfigurationController final : public QObject {
         Page _page{Summary};
         bool _visible{false};
         bool _busy{false};
-        QString _errorTitle;
-        QString _errorText;
+        QString _localFolderErrorText;
         uint64_t _requestGeneration{0};
 };
 

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -110,7 +110,7 @@ bool RemoteFolderTreeModel::hasChildren(const QModelIndex &parentIndex) const {
 
 bool RemoteFolderTreeModel::canFetchMore(const QModelIndex &parentIndex) const {
     const TreeNode *const node = nodeForIndex(parentIndex);
-    return node && !node->accessDenied &&
+    return node && !node->accessDenied && (node != _root.get() || _initialPathsState == InitialPathsState::Ready) &&
            (node->childrenState == LoadState::NotLoaded || node->childrenState == LoadState::Failed);
 }
 
@@ -119,11 +119,11 @@ void RemoteFolderTreeModel::fetchMore(const QModelIndex &parentIndex) {
 }
 
 bool RemoteFolderTreeModel::loading() const {
-    return _pendingInitialPathRequests > 0 || _root->childrenState == LoadState::Loading;
+    return _initialPathsState == InitialPathsState::Resolving || _root->childrenState == LoadState::Loading;
 }
 
 bool RemoteFolderTreeModel::loadFailed() const {
-    return _initialPathsFailed || _root->childrenState == LoadState::Failed;
+    return _initialPathsState == InitialPathsState::Failed || _root->childrenState == LoadState::Failed;
 }
 
 bool RemoteFolderTreeModel::empty() const {
@@ -149,8 +149,9 @@ void RemoteFolderTreeModel::configure(const UserDbId userDbId, const DriveId dri
     // `_activeSizeRequests` is deliberately kept: the requests of the previous generation are still in flight and
     // still occupy the provider, so resetting it here would let this generation start as many again.
     _pendingInitialPathRequests = 0;
-    _initialPathsFailed = false;
     for (const auto &nodeId: initialBlackList) (void) _excludedNodeIds.insert(QString::fromStdString(nodeId));
+    _initialPathsState = _excludedNodeIds.isEmpty() ? InitialPathsState::Ready : InitialPathsState::Resolving;
+    _initialPathRequestFailed = false;
     endResetModel();
     emit selectionChanged();
     resolveInitialExclusionPaths();
@@ -166,8 +167,9 @@ std::vector<NodeId> RemoteFolderTreeModel::blackList() const {
 }
 
 void RemoteFolderTreeModel::retryRoot() {
-    if (_initialPathsFailed) {
-        _initialPathsFailed = false;
+    if (_initialPathsState == InitialPathsState::Failed) {
+        _initialPathsState = InitialPathsState::Resolving;
+        _initialPathRequestFailed = false;
         emit stateChanged();
         resolveInitialExclusionPaths();
         return;
@@ -270,10 +272,10 @@ void RemoteFolderTreeModel::resolveInitialExclusionPaths() {
     const QPointer self(this);
     for (const auto &nodeId: QStringList(_excludedNodeIds.cbegin(), _excludedNodeIds.cend())) {
         _remoteFolderProvider.requestNodeInfo(_userDbId, _driveId, QStr2Str(nodeId),
-                                  [self, generation, nodeId](const ExitInfo &exitInfo, const NodeInfo &info) {
-                                      if (!self || generation != self->_generation) return;
-                                      self->handleInitialExclusionPathResult(nodeId, exitInfo, info);
-                                  });
+                                              [self, generation, nodeId](const ExitInfo &exitInfo, const NodeInfo &info) {
+                                                  if (!self || generation != self->_generation) return;
+                                                  self->handleInitialExclusionPathResult(nodeId, exitInfo, info);
+                                              });
     }
 }
 
@@ -288,21 +290,25 @@ void RemoteFolderTreeModel::handleInitialExclusionPathResult(const QString &node
         (void) _excludedNodeIds.remove(nodeId);
         (void) _excludedPaths.remove(nodeId);
     } else {
-        _initialPathsFailed = true;
+        _initialPathRequestFailed = true;
     }
 
     if (_pendingInitialPathRequests > 0) return;
-    if (_initialPathsFailed) {
+    if (_initialPathRequestFailed) {
+        _initialPathsState = InitialPathsState::Failed;
         _excludedPaths.clear();
         emit stateChanged();
         return;
     }
+    _initialPathsState = InitialPathsState::Ready;
     emit selectionChanged();
     requestChildren(_root.get());
 }
 
 void RemoteFolderTreeModel::requestChildren(TreeNode *const node) {
-    if (!node || node->childrenState == LoadState::Loading || node->accessDenied) return;
+    if (!node || node->accessDenied) return;
+    if (node->childrenState != LoadState::NotLoaded && node->childrenState != LoadState::Failed) return;
+    if (node == _root.get() && _initialPathsState != InitialPathsState::Ready) return;
     node->childrenState = LoadState::Loading;
     if (node == _root.get())
         emit stateChanged();
@@ -312,10 +318,10 @@ void RemoteFolderTreeModel::requestChildren(TreeNode *const node) {
     const uint64_t generation = _generation;
     const QPointer self(this);
     _remoteFolderProvider.requestChildren(_userDbId, _driveId, QStr2Str(node->nodeId),
-                              [self, node, generation](const bool success, const std::vector<NodeInfo> &children) {
-                                  if (!self || generation != self->_generation) return;
-                                  self->handleChildrenResult(node, generation, success, children);
-                              });
+                                          [self, node, generation](const bool success, const std::vector<NodeInfo> &children) {
+                                              if (!self || generation != self->_generation) return;
+                                              self->handleChildrenResult(node, generation, success, children);
+                                          });
 }
 
 void RemoteFolderTreeModel::handleChildrenResult(TreeNode *const node, const uint64_t generation, const bool success,
@@ -375,8 +381,7 @@ void RemoteFolderTreeModel::includeNode(TreeNode *const node) {
     removeExclusionsAtOrBelow(node);
 }
 
-void RemoteFolderTreeModel::includeNodeUnderExcludedAncestor(const TreeNode *const node,
-                                                             const TreeNode *const excludedAncestor) {
+void RemoteFolderTreeModel::includeNodeUnderExcludedAncestor(const TreeNode *const node, const TreeNode *const excludedAncestor) {
     (void) _excludedNodeIds.remove(excludedAncestor->nodeId);
     (void) _excludedPaths.remove(excludedAncestor->nodeId);
     const TreeNode *cursor = node;
@@ -409,8 +414,8 @@ void RemoteFolderTreeModel::notifySelectionDataChanged() {
 
 void RemoteFolderTreeModel::notifySelectionDataChanged(const TreeNode *const parentNode) {
     if (!parentNode || parentNode->children.empty()) return;
-    emit dataChanged(indexForNode(parentNode->children.front().get()),
-                     indexForNode(parentNode->children.back().get()), {CheckStateRole});
+    emit dataChanged(indexForNode(parentNode->children.front().get()), indexForNode(parentNode->children.back().get()),
+                     {CheckStateRole});
     for (const auto &child: parentNode->children) notifySelectionDataChanged(child.get());
 }
 
@@ -431,10 +436,10 @@ void RemoteFolderTreeModel::processSizeQueue() {
         const uint64_t generation = _generation;
         const QPointer self(this);
         _remoteFolderProvider.requestSize(_userDbId, _driveId, QStr2Str(nodeId),
-                              [self, nodeId, generation](const bool success, const int64_t size) {
-                                  if (!self) return;
-                                  self->handleSizeResult(nodeId, generation, success, size);
-                              });
+                                          [self, nodeId, generation](const bool success, const int64_t size) {
+                                              if (!self) return;
+                                              self->handleSizeResult(nodeId, generation, success, size);
+                                          });
     }
 }
 

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -297,7 +297,6 @@ void RemoteFolderTreeModel::handleInitialExclusionPathResult(const QString &node
         emit stateChanged();
         return;
     }
-    emit stateChanged();
     emit selectionChanged();
     requestChildren(_root.get());
 }

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.cpp
@@ -194,9 +194,13 @@ void RemoteFolderTreeModel::toggleSelection(const QModelIndex &modelIndex) {
 }
 
 void RemoteFolderTreeModel::toggleRootSelection() {
-    if (_excludedNodeIds.isEmpty()) return;
-    _excludedNodeIds.clear();
-    _excludedPaths.clear();
+    if (_root->children.empty()) return;
+    if (_excludedNodeIds.isEmpty()) {
+        for (const auto &child: _root->children) excludeNode(child.get());
+    } else {
+        _excludedNodeIds.clear();
+        _excludedPaths.clear();
+    }
     notifySelectionDataChanged();
     emit selectionChanged();
 }

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
@@ -112,6 +112,12 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
             Failed,
         };
 
+        enum class InitialPathsState : uint8_t {
+            Ready,
+            Resolving,
+            Failed,
+        };
+
         enum class SizeState : uint8_t {
             NotRequested,
             Queued,
@@ -165,7 +171,8 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
         uint64_t _generation{0};
         uint8_t _activeSizeRequests{0};
         uint32_t _pendingInitialPathRequests{0};
-        bool _initialPathsFailed{false};
+        InitialPathsState _initialPathsState{InitialPathsState::Ready};
+        bool _initialPathRequestFailed{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
+++ b/src/gui4/linux/app/syncconfiguration/remotefoldertreemodel.h
@@ -90,7 +90,7 @@ class RemoteFolderTreeModel final : public QAbstractItemModel {
          * descendant is excluded, it is never a state the user selects.
          */
         Q_INVOKABLE void toggleSelection(const QModelIndex &modelIndex);
-        /** Restores a complete selection. The drive root itself can never be excluded. */
+        /** Selects or deselects every folder directly below the drive root. The drive root itself can never be excluded. */
         Q_INVOKABLE void toggleRootSelection();
         /**
          * Reports that a row entered or left the viewport.

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -188,6 +188,8 @@ IKShadowedWindow {
 
         OnboardingWindow {
             session: onboardingLoader.session
+            surfaceInset: mainWindow.effectiveShadowMargin
+            surfaceRadius: mainWindow.surfaceRadius
         }
     }
 

--- a/src/gui4/linux/ui/components/IKModal.qml
+++ b/src/gui4/linux/ui/components/IKModal.qml
@@ -37,6 +37,7 @@ Popup {
     property Item initialFocusItem: null
     property real scrimInset: 0
     property real scrimRadius: 0
+    property real preferredWidth: IKModalTokens.width
     property alias bodyData: bodyColumn.data
     property alias footerData: footerLayout.data
 
@@ -45,8 +46,8 @@ Popup {
     parent: Overlay.overlay
     x: parent ? Math.round((parent.width - width) / 2) : 0
     y: parent ? Math.round((parent.height - height) / 2) : 0
-    width: parent ? Math.min(IKModalTokens.width, Math.max(0, parent.width - 2 * IKModalTokens.screenMargin))
-                  : IKModalTokens.width
+    width: parent ? Math.min(root.preferredWidth, Math.max(0, parent.width - 2 * IKModalTokens.screenMargin))
+                  : root.preferredWidth
     implicitHeight: modalContent.implicitHeight + topPadding + bottomPadding
     padding: IKModalTokens.contentPadding
     popupType: Popup.Item

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDialog.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDialog.qml
@@ -1,0 +1,100 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+IKModal {
+    id: root
+
+    required property var controller
+
+    preferredWidth: IKSyncConfiguration.modalWidth
+    // Escape cancels the current page, but never while a request the user cannot see is still running.
+    escapeDismissible: !root.controller.busy
+    visible: root.controller.visible
+    title: {
+        if (root.controller.driveConfigurationPage) {
+            return qsTrId("onBoardingAdvancedSettingsDriveTitle")
+        }
+        if (root.controller.folderSelectionPage) {
+            return qsTrId("onboardingAdvancedSettingsExclusionTitle")
+        }
+        return qsTrId("onboardingAdvancedSettingsDriveSelectionTitle")
+    }
+    onDismissRequested: root.controller.cancelCurrentPage()
+
+    bodyData: [
+        Loader {
+            width: parent ? parent.width : implicitWidth
+            sourceComponent: {
+                if (root.controller.driveConfigurationPage) {
+                    return drivePage
+                }
+                if (root.controller.folderSelectionPage) {
+                    return folderPage
+                }
+                return summaryPage
+            }
+        }
+    ]
+
+    footerData: [
+        IKModalButton {
+            role: IKModalButton.Secondary
+            text: qsTrId("buttonCancel")
+            actionEnabled: !root.controller.busy
+            onClicked: root.controller.cancelCurrentPage()
+        },
+        IKModalButton {
+            id: validateButton
+
+            role: IKModalButton.Primary
+            text: qsTrId("buttonValidate")
+            actionEnabled: root.controller.canValidate
+            busy: root.controller.busy
+            onClicked: root.controller.validateCurrentPage()
+        }
+    ]
+
+    Component {
+        id: summaryPage
+
+        SyncConfigurationSummaryPage {
+            controller: root.controller
+        }
+    }
+
+    Component {
+        id: drivePage
+
+        SyncConfigurationDrivePage {
+            controller: root.controller
+        }
+    }
+
+    Component {
+        id: folderPage
+
+        SyncConfigurationFolderPage {
+            controller: root.controller
+        }
+    }
+}

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDialog.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDialog.qml
@@ -25,11 +25,13 @@ IKModal {
     id: root
 
     required property var controller
+    property real summaryContentY: 0
 
     preferredWidth: IKSyncConfiguration.modalWidth
     // Escape cancels the current page, but never while a request the user cannot see is still running.
     escapeDismissible: !root.controller.busy
     visible: root.controller.visible
+    onClosed: root.summaryContentY = 0
     title: {
         if (root.controller.driveConfigurationPage) {
             return qsTrId("onBoardingAdvancedSettingsDriveTitle")
@@ -79,6 +81,8 @@ IKModal {
 
         SyncConfigurationSummaryPage {
             controller: root.controller
+            initialContentY: root.summaryContentY
+            onContentYUpdated: contentY => root.summaryContentY = contentY
         }
     }
 

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationDrivePage.qml
@@ -227,8 +227,14 @@ Column {
                 }
             }
 
+            SyncConfigurationErrorBlock {
+                width: parent.width
+                errorText: root.controller.localFolderErrorText
+            }
+
             Text {
                 width: parent.width
+                visible: root.controller.localFolderErrorText.length === 0
                 text: qsTrId("onboardingAdvancedSettingsDriveCustomizeLocationTip")
                 color: IKColors.textTertiary
                 font.pixelSize: IKFonts.subheadlineSize
@@ -320,11 +326,5 @@ Column {
                 wrapMode: Text.WordWrap
             }
         }
-    }
-
-    SyncConfigurationErrorBlock {
-        width: parent.width
-        errorTitle: root.controller.errorTitle
-        errorText: root.controller.errorText
     }
 }

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationErrorBlock.qml
@@ -21,36 +21,18 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import kDrive.UI
 
-// Inline failure report for the sync-configuration pages. It states what cannot be done and why, so a rejected folder
-// explains the rule it broke instead of only saying that it was refused.
-Column {
+// Inline failure report for the sync-configuration pages.
+Text {
     id: root
 
-    property string errorTitle: ""
     property string errorText: ""
 
-    visible: errorTitle.length > 0 || errorText.length > 0
-    spacing: IKSyncConfiguration.cardTitleSpacing
+    visible: root.errorText.length > 0
+    text: root.errorText
+    color: IKColors.syncConfigurationError
+    font.pixelSize: IKFonts.subheadlineSize
+    wrapMode: Text.WordWrap
     // Announced as an alert so a failure is reported without moving the focus away from what the user was doing.
     Accessible.role: Accessible.AlertMessage
-    Accessible.name: [root.errorTitle, root.errorText].filter(part => part.length > 0).join(". ")
-
-    Text {
-        width: parent.width
-        visible: text.length > 0
-        text: root.errorTitle
-        color: IKColors.syncConfigurationError
-        font.pixelSize: IKFonts.subheadlineSize
-        font.weight: IKFonts.emphasized
-        wrapMode: Text.WordWrap
-    }
-
-    Text {
-        width: parent.width
-        visible: text.length > 0
-        text: root.errorText
-        color: IKColors.syncConfigurationError
-        font.pixelSize: IKFonts.subheadlineSize
-        wrapMode: Text.WordWrap
-    }
+    Accessible.name: root.errorText
 }

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
@@ -44,12 +44,6 @@ Column {
         wrapMode: Text.WordWrap
     }
 
-    SyncConfigurationErrorBlock {
-        width: parent.width
-        errorTitle: root.controller.errorTitle
-        errorText: root.controller.errorText
-    }
-
     ListView {
         id: drivesList
 

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
@@ -26,6 +26,9 @@ Column {
     id: root
 
     required property var controller
+    required property real initialContentY
+
+    signal contentYUpdated(real contentY)
 
     // A folder name is free text and goes through `Text.StyledText` below, where `&`, `<` and `>` would be read as
     // markup.
@@ -47,12 +50,20 @@ Column {
     ListView {
         id: drivesList
 
+        function restoreContentY(): void {
+            const maximumContentY = Math.max(originY, originY + contentHeight - height)
+            contentY = Math.max(originY, Math.min(root.initialContentY, maximumContentY))
+        }
+
         width: parent.width
         height: Math.min(contentHeight, IKSyncConfiguration.summaryListMaximumHeight)
         model: root.controller.selectedDrivesModel
         spacing: IKSyncConfiguration.summaryListSpacing
         clip: true
         boundsBehavior: Flickable.StopAtBounds
+        onContentHeightChanged: Qt.callLater(function() {
+            drivesList.restoreContentY()
+        })
 
         ScrollBar.vertical: ScrollBar {
             policy: drivesList.contentHeight > drivesList.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
@@ -158,7 +169,10 @@ Column {
                     // Every row repeats the same label, so the drive is what tells them apart.
                     Accessible.description: driveRow.driveName
                     actionEnabled: !root.controller.busy
-                    onClicked: root.controller.configureDrive(driveRow.index)
+                    onClicked: {
+                        root.contentYUpdated(drivesList.contentY)
+                        root.controller.configureDrive(driveRow.index)
+                    }
                 }
             }
         }

--- a/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
+++ b/src/gui4/linux/ui/features/syncconfiguration/SyncConfigurationSummaryPage.qml
@@ -61,9 +61,15 @@ Column {
         spacing: IKSyncConfiguration.summaryListSpacing
         clip: true
         boundsBehavior: Flickable.StopAtBounds
-        onContentHeightChanged: Qt.callLater(function() {
-            drivesList.restoreContentY()
-        })
+        acceptedButtons: Qt.NoButton
+        onContentHeightChanged: restoreContentYTimer.restart()
+
+        Timer {
+            id: restoreContentYTimer
+
+            interval: 0
+            onTriggered: drivesList.restoreContentY()
+        }
 
         ScrollBar.vertical: ScrollBar {
             policy: drivesList.contentHeight > drivesList.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff

--- a/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DriveSelectionView.qml
@@ -158,55 +158,38 @@ Item {
             Row {
                 spacing: IKSpacing.s8
 
-                Item {
-                    implicitWidth: advancedButton.implicitWidth
-                    implicitHeight: IKOnboarding.driveSelectionButtonHeight
+                Button {
+                    id: advancedButton
 
-                    Button {
-                        id: advancedButton
+                    enabled: root.selectionController.canOpenAdvancedSettings
+                    hoverEnabled: true
+                    height: IKOnboarding.driveSelectionButtonHeight
+                    text: qsTrId("buttonAdvancedParameters")
+                    onClicked: root.selectionController.requestAdvancedSettings()
 
-                        anchors.fill: parent
-                        enabled: false
-                        text: qsTrId("buttonAdvancedParameters")
-                        onClicked: root.selectionController.requestAdvancedSettings()
-
-                        contentItem: Text {
-                            text: advancedButton.text
-                            color: IKColors.actionDisabled
-                            font.pixelSize: IKFonts.bodySize
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
-                            elide: Text.ElideRight
-                        }
-
-                        background: Rectangle {
-                            implicitWidth: IKOnboarding.driveSelectionSecondaryButtonMinWidth
-                            implicitHeight: IKOnboarding.driveSelectionButtonHeight
-                            radius: IKOnboarding.buttonCornerRadius
-                            color: "transparent"
-                        }
-
-                        padding: 0
-                        leftPadding: IKSpacing.s16
-                        rightPadding: IKSpacing.s16
-                        topPadding: 0
-                        bottomPadding: 0
+                    contentItem: Text {
+                        text: advancedButton.text
+                        color: advancedButton.enabled ? IKColors.actionPrimary : IKColors.actionDisabled
+                        font.pixelSize: IKFonts.bodySize
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideRight
                     }
 
-                    HoverHandler {
-                        id: advancedButtonHoverHandler
+                    background: Rectangle {
+                        implicitWidth: IKOnboarding.driveSelectionSecondaryButtonMinWidth
+                        implicitHeight: IKOnboarding.driveSelectionButtonHeight
+                        radius: IKOnboarding.buttonCornerRadius
+                        color: advancedButton.hovered && advancedButton.enabled ? IKColors.surfaceSecondary : "transparent"
+                        border.width: advancedButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
+                        border.color: IKColors.accentPrimary
                     }
 
-                    IKToolTip {
-                        visible: advancedButtonHoverHandler.hovered
-                        delay: IKOnboarding.driveSelectionTooltipDelay
-                        text: qsTr("Not available yet.")
-                        padding: IKOnboarding.driveSelectionTooltipPadding
-                        maximumTextWidth: IKOnboarding.driveSelectionTooltipMaxWidth
-                        foregroundColor: IKColors.onboardingTooltipText
-                        surfaceColor: IKColors.onboardingTooltipSurface
-                        textLineHeight: IKOnboarding.driveSelectionDriveNameLineHeight
-                    }
+                    padding: 0
+                    leftPadding: IKSpacing.s16
+                    rightPadding: IKSpacing.s16
+                    topPadding: 0
+                    bottomPadding: 0
                 }
 
                 Button {

--- a/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
@@ -32,7 +32,7 @@ ListView {
     spacing: IKSpacing.s8
     clip: true
     boundsBehavior: Flickable.StopAtBounds
-    acceptedButtons: Qt.NoButton // remove the
+    acceptedButtons: Qt.NoButton // without this, a click after a scroll is taken to stop the scroll and is not forwarded to the button
 
     model: root.drivesModel
 

--- a/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/DrivesListView.qml
@@ -32,6 +32,7 @@ ListView {
     spacing: IKSpacing.s8
     clip: true
     boundsBehavior: Flickable.StopAtBounds
+    acceptedButtons: Qt.NoButton // remove the
 
     model: root.drivesModel
 

--- a/src/gui4/linux/ui/windows/onboarding/OnboardingWindow.qml
+++ b/src/gui4/linux/ui/windows/onboarding/OnboardingWindow.qml
@@ -19,15 +19,21 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Dialogs
 import kDrive.UI
 
 Item {
     id: root
 
     required property var session
+    // Modal scrim geometry of the hosting window: the overlay also covers the transparent custom-shadow margin, which
+    // must not be dimmed because it is not part of the visible application surface.
+    required property real surfaceInset
+    required property real surfaceRadius
     readonly property var onboardingFlowController: session.flowController
     readonly property var driveSelectionController: session.driveSelectionController
     readonly property var drivesModel: session.availableDrivesModel
+    readonly property var syncConfigurationController: session.syncConfigurationController
     readonly property var onboardingStepComponents: [
         loginComponent,
         driveSelectionComponent,
@@ -38,6 +44,32 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: IKColors.onboardingSurfacePrimary
+    }
+
+    SyncConfigurationDialog {
+        controller: root.syncConfigurationController
+        scrimInset: root.surfaceInset
+        scrimRadius: root.surfaceRadius
+    }
+
+    FolderDialog {
+        id: localFolderDialog
+
+        title: qsTrId("buttonSelectFolder")
+        onAccepted: {
+            root.syncConfigurationController.applyCustomFolder(selectedFolder)
+            root.syncConfigurationController.notifyCustomFolderDialogClosed()
+        }
+        onRejected: root.syncConfigurationController.notifyCustomFolderDialogClosed()
+    }
+
+    Connections {
+        target: root.syncConfigurationController
+
+        function onCustomFolderRequested(initialFolder) {
+            localFolderDialog.currentFolder = initialFolder
+            localFolderDialog.open()
+        }
     }
 
     Row {


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
C'est la dernière PR de la pile, celle qui rend enfin la fonctionnalité accessible. Tout ce qui précède ajoutait des composants qu'aucun autre code n'instanciait ; celle-ci les assemble tout.

## Changements
- **`SyncConfigurationDialog.qml`** (nouveau) : une seule coque `IKModal` dont la page interne change plutôt que d'empiler des modales. Un `Loader` bascule entre le résumé, la configuration par drive et la sélection de dossiers, si bien que l'arbre conserve ses données chargées et sa sélection d'une page à l'autre. Son pied de page porte Annuler et Valider, tous deux pilotés par le contrôleur de #2387. Échap correspond au Annuler de la page courante, mais seulement quand aucune requête bloquante n'est en cours.
- **`OnboardingWindow.qml`** : instancie la boîte de dialogue comme état d'onboarding contextuel plutôt que comme modale globale au processus, et héberge le `FolderDialog` natif utilisé pour choisir un dossier local personnalisé. Elle notifie le contrôleur à la fermeture de ce sélecteur, quel que soit le résultat, pour que le focus revienne au bouton Changer de dossier.
- **`DriveSelectionView.qml`** : le bouton Paramètres avancés est activé à partir de `canOpenAdvancedSettings`, l'infobulle temporaire « Not available yet » est retirée, et le bouton reçoit l'anneau de focus clavier que les autres boutons de l'onboarding ont reçu dans #2382. Il en avait été volontairement écarté à l'époque car un contrôle désactivé ne peut jamais prendre le focus.
- **`Main.qml` et `IKModal.qml`** : la modale reçoit l'`effectiveShadowMargin` et le `surfaceRadius` de la fenêtre qui l'héberge comme `scrimInset`/`scrimRadius`, car le voile recouvre toute la fenêtre native et un voile non inséré assombrirait aussi la marge d'ombre personnalisée transparente. `IKModal` gagne un `preferredWidth` pour qu'une boîte de dialogue de fonctionnalité puisse être plus large que la valeur par défaut sans forker le composant.
- Plus une entrée `CMakeLists.txt` et trois règles `AGENTS.md` consignant la géométrie du voile, la convention `Tonal` sur une carte, et le rôle d'`IKLinkButton`.

## Détails techniques
- **C'est la première PR où un utilisateur peut atteindre la fonctionnalité.** Tout ce qui précède #2390 était inerte. Relire celle-ci, c'est relire le point d'entrée, pas l'implémentation.
- Les requêtes `SYNC_ADD` proprement dites restent différées jusqu'à la fin de l'onboarding : valider la boîte de dialogue ne fait que committer les brouillons dans `OnboardingState`, elle ne crée aucune synchronisation.
- C'est parce que le bouton des paramètres avancés devient enfin focusable que son anneau de focus arrive ici plutôt que dans #2382.

</details>

---

## Summary
This is the last PR of the stack, and the one that finally makes the feature reachable. Everything before it added components nothing instantiated; this one wires them together and opens the door.

## Changes
- **`SyncConfigurationDialog.qml`** (new): one `IKModal` shell whose internal page changes rather than stacking modals. A `Loader` swaps between the summary, the per-drive configuration and the folder selection, so the tree keeps its loaded data and its selection across page changes. Its footer carries Cancel and Validate, both driven by the controller from #2387. Escape maps to the current page's Cancel, but only when no blocking request is running.
- **`OnboardingWindow.qml`**: instantiates the dialog as contextual onboarding state rather than a process-global modal, and hosts the native `FolderDialog` used to pick a custom local folder. It notifies the controller when that picker closes, whatever the outcome, so focus returns to the Change folder button.
- **`DriveSelectionView.qml`**: the Advanced settings button is enabled from `canOpenAdvancedSettings`, the temporary "Not available yet" tooltip is removed, and the button gets the keyboard focus ring the other onboarding buttons received in #2382. It was deliberately left out there because a disabled control can never take focus.
- **`Main.qml` and `IKModal.qml`**: the modal receives the hosting window's `effectiveShadowMargin` and `surfaceRadius` as `scrimInset`/`scrimRadius`, because the overlay spans the whole native window and an un-inset scrim would also dim the transparent custom-shadow margin. `IKModal` gains a `preferredWidth` so a feature dialog can be wider than the default without forking the component.
- Plus one `CMakeLists.txt` entry and three `AGENTS.md` rules recording the scrim geometry, the `Tonal`-on-card convention, and `IKLinkButton`'s role.

## Technical Details
- **This is the first PR where a user can reach the feature.** Everything up to #2390 was inert. Reviewing this one means reviewing the entry point, not the implementation.
- Actual `SYNC_ADD` requests are still deferred to the end of onboarding: validating the dialog only commits drafts into `OnboardingState`, it creates no synchronization.
- The advanced settings button now becoming focusable is why its focus ring ships here rather than in #2382.

## Notes
Depends on #2390.

||Light|Dark|
|---|---|---|
|Dialog Error|<img width="1175" height="825" alt="dialog-error-light" src="https://github.com/user-attachments/assets/ad131516-2c2d-4d20-9659-42c571ee1d3b" />|<img width="1175" height="825" alt="dialog-error-dark" src="https://github.com/user-attachments/assets/4d02d626-5795-4c91-b9e6-72fbd76e9ac6" />|
|Dialog Tree|<img width="1175" height="825" alt="dialog-tree-light" src="https://github.com/user-attachments/assets/7017350f-8531-41ed-8ffc-9b49bcae3900" />|<img width="1175" height="825" alt="dialog-tree-dark" src="https://github.com/user-attachments/assets/5291e9b2-2d74-4f37-962d-71f25f6b363f" />|