### PR TITLE
fix(onboarding): return to drive selection when sync creation fails

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -288,8 +288,9 @@
   summary. It exposes display values only; stable backend identifiers remain in the controller drafts.
 - `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It
   derives collision-free local folders, creates selected-drive syncs sequentially with the validated remote blacklist,
-  preserves only failed and not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a
-  failed `SYNC_ADD`.
+  stops at the first failure, reconciles the parent-first cache snapshot after a failed `SYNC_ADD`, and automatically
+  returns to drive selection after displaying the failure for three seconds. The failed execution queue is discarded;
+  the next run is rebuilt from the remaining selections after pruning drives that now own a classic synchronization.
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -80,6 +80,8 @@ class AppCache : public QObject {
         [[nodiscard]] std::optional<DriveContext> driveContext(DriveDbId driveDbId) const;
         [[nodiscard]] std::vector<DriveContext> driveContexts() const;
         // Available-drive contexts reconcile addable drives with configured drives for display/disable decisions.
+        // A drive is configured for onboarding only when it owns a classic synchronization.
+        [[nodiscard]] bool isAvailableDriveConfigured(const AvailableDriveKey &key) const;
         [[nodiscard]] std::vector<AvailableDriveContext> availableDriveContexts(UserDbId userDbId) const;
         [[nodiscard]] std::vector<AvailableDriveContext> availableDriveContexts() const;
 

--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -348,6 +348,21 @@ std::vector<DriveContext> AppCache::driveContexts() const {
     return contexts;
 }
 
+bool AppCache::isAvailableDriveConfigured(const AvailableDriveKey &key) const {
+    const auto accountInfo = accountForAvailableDrive(key.userDbId, key.accountId);
+    if (!accountInfo) {
+        return false;
+    }
+
+    const auto configuredDrive = configuredDriveForAvailableDrive(accountInfo->dbId(), key.driveId);
+    if (!configuredDrive) {
+        return false;
+    }
+
+    const auto syncInfos = syncsForDrive(configuredDrive->dbId());
+    return std::ranges::any_of(syncInfos, [](const BaseSync &syncInfo) { return syncInfo.targetNodeId().empty(); });
+}
+
 std::vector<AvailableDriveContext> AppCache::availableDriveContexts(const UserDbId userDbId) const {
     if (const auto userInfo = user(userDbId); !userInfo) {
         return {};
@@ -361,7 +376,11 @@ std::vector<AvailableDriveContext> AppCache::availableDriveContexts(const UserDb
         context.accountInfo = accountForAvailableDrive(userDbId, availableDrive.accountId());
         if (context.accountInfo) {
             context.configuredDrive = configuredDriveForAvailableDrive(context.accountInfo->dbId(), availableDrive.driveId());
-            context.alreadyConfigured = context.configuredDrive.has_value();
+            context.alreadyConfigured = isAvailableDriveConfigured(AvailableDriveKey{
+                    .userDbId = userDbId,
+                    .accountId = availableDrive.accountId(),
+                    .driveId = availableDrive.driveId(),
+            });
         }
         contexts.push_back(context);
     }

--- a/src/gui4/linux/app/cache/onboardingstate.cpp
+++ b/src/gui4/linux/app/cache/onboardingstate.cpp
@@ -35,6 +35,7 @@ OnboardingState::OnboardingState(AppCache &cache, QObject *const parent) :
         }
     });
     (void) connect(&_cache, &AppCache::allAvailableDrivesChanged, this, &OnboardingState::pruneSelectedAvailableDrives);
+    (void) connect(&_cache, &AppCache::syncsChanged, this, &OnboardingState::pruneSelectedAvailableDrives);
 }
 
 qint64 OnboardingState::selectedUserDbId() const {
@@ -195,12 +196,14 @@ void OnboardingState::pruneSelectedAvailableDrives() {
     bool selectionChanged = false;
     bool pendingConfigsChanged = false;
     for (auto it = _selectedAvailableDriveKeys.begin(); it != _selectedAvailableDriveKeys.end();) {
-        if (_cache.availableDrive(*it)) {
+        const bool available = _cache.availableDrive(*it).has_value();
+        const bool configured = available && _cache.isAvailableDriveConfigured(*it);
+        if (available && !configured) {
             ++it;
             continue;
         }
-        qCDebug(lcOnboardingState) << "Selected drive pruned (no longer available) | userDbId:" << it->userDbId
-                                   << "/ driveId:" << it->driveId;
+        qCDebug(lcOnboardingState) << "Selected drive pruned | userDbId:" << it->userDbId << "/ driveId:" << it->driveId
+                                   << "/ available:" << available << "/ configured:" << configured;
         pendingConfigsChanged = _pendingSyncConfigs.erase(*it) > 0 || pendingConfigsChanged;
         it = _selectedAvailableDriveKeys.erase(it);
         selectionChanged = true;

--- a/src/gui4/linux/app/onboarding/availabledrivesmodel.cpp
+++ b/src/gui4/linux/app/onboarding/availabledrivesmodel.cpp
@@ -76,6 +76,7 @@ AvailableDrivesModel::AvailableDrivesModel(const AppCache &cache, OnboardingStat
     (void) connect(&_cache, &AppCache::allAvailableDrivesChanged, this, &AvailableDrivesModel::rebuild);
     (void) connect(&_cache, &AppCache::accountsChanged, this, &AvailableDrivesModel::rebuild);
     (void) connect(&_cache, &AppCache::drivesChanged, this, &AvailableDrivesModel::rebuild);
+    (void) connect(&_cache, &AppCache::syncsChanged, this, &AvailableDrivesModel::rebuild);
     (void) connect(&_onboardingState, &OnboardingState::selectedUserDbIdChanged, this, &AvailableDrivesModel::rebuild);
     (void) connect(&_onboardingState, &OnboardingState::selectedAvailableDrivesChanged, this, [this] {
         if (!_contexts.empty()) {

--- a/src/gui4/linux/app/onboarding/availabledrivesmodel.cpp
+++ b/src/gui4/linux/app/onboarding/availabledrivesmodel.cpp
@@ -74,6 +74,8 @@ AvailableDrivesModel::AvailableDrivesModel(const AppCache &cache, OnboardingStat
         }
     });
     (void) connect(&_cache, &AppCache::allAvailableDrivesChanged, this, &AvailableDrivesModel::rebuild);
+    (void) connect(&_cache, &AppCache::accountsChanged, this, &AvailableDrivesModel::rebuild);
+    (void) connect(&_cache, &AppCache::drivesChanged, this, &AvailableDrivesModel::rebuild);
     (void) connect(&_onboardingState, &OnboardingState::selectedUserDbIdChanged, this, &AvailableDrivesModel::rebuild);
     (void) connect(&_onboardingState, &OnboardingState::selectedAvailableDrivesChanged, this, [this] {
         if (!_contexts.empty()) {

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -23,12 +23,19 @@
 #include <QCoreApplication>
 #include <QDesktopServices>
 #include <QMetaEnum>
+#include <QTimer>
+
+#include <chrono>
 
 Q_LOGGING_CATEGORY(lcOnboardingFlowController, "gui.v4.onboardingflow", QtInfoMsg)
 
 namespace KDC {
 
 namespace {
+// Long enough to read the failure, short enough not to strand the user on a screen they cannot act on. Shorter than
+// the Windows teaching tip, which overlays the selection rather than holding the whole view.
+constexpr std::chrono::seconds errorDisplayDuration{3};
+
 [[nodiscard]] qint32 stepToIndex(const OnboardingFlowController::Step step) {
     return static_cast<uint8_t>(step);
 }
@@ -140,15 +147,17 @@ void OnboardingFlowController::requestDriveSelectionContinue() {
     emit driveSelectionContinueRequested();
 }
 
-void OnboardingFlowController::retrySynchronization() {
+void OnboardingFlowController::returnToDriveSelection() {
+    // The step may have moved on while the error was displayed, through a cancellation or a window closing.
     if (_currentStep != Synchronization || !_synchronizationFailed) {
         return;
     }
 
-    qCInfo(lcOnboardingFlowController) << "Onboarding synchronization retry requested";
+    qCInfo(lcOnboardingFlowController) << "Onboarding returning to drive selection after a failed synchronization";
     _synchronizationFailed = false;
     emit synchronizationFailedChanged();
-    emit synchronizationRetryRequested();
+    emit driveSelectionReturnRequested();
+    setCurrentStep(DriveSelection);
 }
 
 void OnboardingFlowController::cancel() {
@@ -200,6 +209,9 @@ void OnboardingFlowController::failSynchronization() {
     qCWarning(lcOnboardingFlowController) << "Onboarding synchronization creation failed";
     _synchronizationFailed = true;
     emit synchronizationFailedChanged();
+    // The error stays up long enough to be read, then the selection takes over. Offering a retry here would only
+    // replay a request the server has already rejected, with a configuration only the selection can change.
+    QTimer::singleShot(errorDisplayDuration, this, &OnboardingFlowController::returnToDriveSelection);
 }
 
 void OnboardingFlowController::completeSynchronization() {

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
@@ -85,7 +85,6 @@ class OnboardingFlowController final : public QObject {
         Q_INVOKABLE void requestFreeDriveOrder() const;
         Q_INVOKABLE void requestAdvancedSettings();
         Q_INVOKABLE void requestDriveSelectionContinue();
-        Q_INVOKABLE void retrySynchronization();
         Q_INVOKABLE void completeOnboarding();
         Q_INVOKABLE void cancel();
         Q_INVOKABLE void setCurrentStep(Step step);
@@ -106,7 +105,7 @@ class OnboardingFlowController final : public QObject {
         void cancelRequested();
         void advancedSettingsRequested();
         void driveSelectionContinueRequested();
-        void synchronizationRetryRequested();
+        void driveSelectionReturnRequested();
         void synchronizationFailedChanged();
         void readyActionEnabledChanged();
         void completed();
@@ -115,6 +114,7 @@ class OnboardingFlowController final : public QObject {
         static constexpr qint32 stepCountValue{4};
 
         void setLoginState(LoginState loginState);
+        void returnToDriveSelection();
 
         Step _currentStep{Login};
         LoginState _loginState{LoginIdle};

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -49,8 +49,8 @@ OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingF
     _serviceEventBus(serviceEventBus) {
     (void) connect(&_flowController, &OnboardingFlowController::driveSelectionContinueRequested, this,
                    &OnboardingSyncCreationCoordinator::startSynchronization);
-    (void) connect(&_flowController, &OnboardingFlowController::synchronizationRetryRequested, this,
-                   &OnboardingSyncCreationCoordinator::createNextSynchronization);
+    (void) connect(&_flowController, &OnboardingFlowController::driveSelectionReturnRequested, this,
+                   &OnboardingSyncCreationCoordinator::discardPendingSynchronizations);
     (void) connect(&_cachePopulator, &CachePopulator::reconciliationCompleted, this,
                    &OnboardingSyncCreationCoordinator::handleCacheReconciliationCompleted);
     (void) connect(&_cachePopulator, &CachePopulator::reconciliationFailed, this,
@@ -148,6 +148,17 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
         return;
     }
 
+    // TEST ONLY — do not commit. KDRIVE_FAIL_SYNC_AT=2 makes the 2nd drive of the run fail before SYNC_ADD is sent,
+    // so nothing is created server-side for it and the state stays exactly as after a real rejection.
+    if (const int failAt = qEnvironmentVariableIntValue("KDRIVE_FAIL_SYNC_AT"); failAt > 0) {
+        static int attempt = 0;
+        if (++attempt == failAt) {
+            qCWarning(lcOnboardingSyncCreationCoordinator) << "TEST: forcing a sync creation failure | driveId:" << key.driveId;
+            handleCreationFailure(true);
+            return;
+        }
+    }
+
     SyncAddRequest request;
     request.userDbId = key.userDbId;
     request.accountId = key.accountId;
@@ -180,6 +191,13 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
         }
         self->createNextSynchronization();
     });
+}
+
+void OnboardingSyncCreationCoordinator::discardPendingSynchronizations() {
+    // The queue described a run that failed; the next attempt is rebuilt from the selection by startSynchronization().
+    qCInfo(lcOnboardingSyncCreationCoordinator)
+            << "Dropping the onboarding sync queue | remaining:" << _pendingDriveKeys.size();
+    _pendingDriveKeys.clear();
 }
 
 void OnboardingSyncCreationCoordinator::discardPendingSynchronization(const AvailableDriveKey &key) {

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -87,7 +87,8 @@ void OnboardingSyncCreationCoordinator::createNextSynchronization() {
 
 void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDriveKey &key) {
     const auto availableDrive = _appCache.availableDrive(key);
-    if (!availableDrive.has_value() || !_onboardingState.isAvailableDriveSelected(key)) {
+    if (!availableDrive.has_value() || !_onboardingState.isAvailableDriveSelected(key) ||
+        _appCache.isAvailableDriveConfigured(key)) {
         qCWarning(lcOnboardingSyncCreationCoordinator)
                 << "Skipping onboarding sync: available drive is no longer selectable | userDbId:" << key.userDbId
                 << "/ driveId:" << key.driveId;
@@ -140,7 +141,8 @@ void OnboardingSyncCreationCoordinator::handleGoodPathResult(const AvailableDriv
 }
 
 void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config) {
-    if (!_onboardingState.isAvailableDriveSelected(key) || !_appCache.availableDrive(key).has_value()) {
+    if (!_onboardingState.isAvailableDriveSelected(key) || !_appCache.availableDrive(key).has_value() ||
+        _appCache.isAvailableDriveConfigured(key)) {
         qCWarning(lcOnboardingSyncCreationCoordinator)
                 << "Skipping onboarding sync creation: drive is no longer selectable | userDbId:" << key.userDbId
                 << "/ driveId:" << key.driveId;

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -148,17 +148,6 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
         return;
     }
 
-    // TEST ONLY — do not commit. KDRIVE_FAIL_SYNC_AT=2 makes the 2nd drive of the run fail before SYNC_ADD is sent,
-    // so nothing is created server-side for it and the state stays exactly as after a real rejection.
-    if (const int failAt = qEnvironmentVariableIntValue("KDRIVE_FAIL_SYNC_AT"); failAt > 0) {
-        static int attempt = 0;
-        if (++attempt == failAt) {
-            qCWarning(lcOnboardingSyncCreationCoordinator) << "TEST: forcing a sync creation failure | driveId:" << key.driveId;
-            handleCreationFailure(true);
-            return;
-        }
-    }
-
     SyncAddRequest request;
     request.userDbId = key.userDbId;
     request.accountId = key.accountId;

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -186,8 +186,7 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
 
 void OnboardingSyncCreationCoordinator::discardPendingSynchronizations() {
     // The queue described a run that failed; the next attempt is rebuilt from the selection by startSynchronization().
-    qCInfo(lcOnboardingSyncCreationCoordinator)
-            << "Dropping the onboarding sync queue | remaining:" << _pendingDriveKeys.size();
+    qCInfo(lcOnboardingSyncCreationCoordinator) << "Dropping the onboarding sync queue | remaining:" << _pendingDriveKeys.size();
     _pendingDriveKeys.clear();
 }
 
@@ -209,18 +208,16 @@ void OnboardingSyncCreationCoordinator::handleCreationFailure(const bool cacheRe
      * original selection would risk creating duplicate syncs or choosing new suffixed local folders.
      *
      * Account and drive creation also happen before sync creation and are not one database transaction. A failed SYNC_ADD
-     * can therefore leave a newly persisted parent that was not emitted through ACCOUNT_ADDED or DRIVE_ADDED because the
-     * job reports its signals only after complete success. Before exposing Retry, the coordinator asks CachePopulator to
-     * rebuild the graph parent-first so a successful retry cannot emit DRIVE_ADDED/SYNC_ADDED into a cache that still lacks
-     * their account parent.
+     * can therefore leave a newly persisted parent without a synchronization and without its normal ACCOUNT_ADDED or
+     * DRIVE_ADDED push. The coordinator asks CachePopulator to rebuild the graph parent-first so drive selection can
+     * distinguish an actual classic synchronization from a partially persisted parent.
      *
-     * The coordinator stops at the first failure and keeps the current key plus every not-yet-attempted key in
-     * _pendingDriveKeys. Keys that completed successfully were already removed from both this queue and OnboardingState.
-     * The pending config of the failed key is deliberately preserved so Retry reuses the exact same local path instead of
-     * asking the server for another candidate. Retry resumes from the queue front and Ready is reached only after the queue
-     * is empty.
+     * The coordinator stops at the first failure. Keys that completed successfully were already removed from the queue and
+     * OnboardingState. Failed and not-yet-attempted selections stay in OnboardingState so the user can review them. Returning
+     * to drive selection discards this execution queue; the next Continue rebuilds it from the current selection. Cache
+     * reconciliation prunes any key for which a classic synchronization was persisted despite the failed response.
      *
-     * Transport failures cannot reach this retry path: IpcClient treats every post-connection socket error as fatal. An
+     * Transport failures cannot reach this failure path: IpcClient treats every post-connection socket error as fatal. An
      * error callback here is therefore a server response, not an ambiguous timeout after a successful response was lost.
      */
     qCWarning(lcOnboardingSyncCreationCoordinator) << "Onboarding sync creation paused | remaining:" << _pendingDriveKeys.size();

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -39,7 +39,8 @@ struct GoodPathResult;
  * Coordinates automatic sync creation at the end of Linux v4 onboarding.
  *
  * Selected drives are configured sequentially with a collision-free local path and the kDrive root as remote target.
- * Successful creations are removed from the retry queue, while failed and not-yet-attempted creations remain pending.
+ * Successful creations leave OnboardingState immediately. After a failure, returning to drive selection discards the
+ * execution queue; the next run is rebuilt from the remaining user selection.
  */
 class OnboardingSyncCreationCoordinator final : public QObject {
         Q_OBJECT

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -55,6 +55,7 @@ class OnboardingSyncCreationCoordinator final : public QObject {
         void prepareSynchronization(const AvailableDriveKey &key);
         void handleGoodPathResult(const AvailableDriveKey &key, const ExitInfo &exitInfo, const GoodPathResult &result);
         void createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config);
+        void discardPendingSynchronizations();
         void discardPendingSynchronization(const AvailableDriveKey &key);
         void handleCreationFailure(bool cacheReconciliationRequired = false);
         void handleCacheReconciliationCompleted();

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -2044,6 +2044,15 @@ sikkert på din computer.</translation>
             <source>All set!</source> 
             <translation>Klar!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Vi kunne ikke afslutte konfigurationen af dine kDrive.
+
+Du vender tilbage til kDrive-valget.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -2043,6 +2043,15 @@ safely on your computer.</source>
             <source>All set!</source> 
             <translation>Alles bereit!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Wir konnten die Konfiguration Ihrer kDrives nicht abschliessen.
+
+Sie werden zur kDrive-Auswahl zurückgeleitet.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -2044,6 +2044,15 @@ safely on your computer.</source>
             <source>All set!</source> 
             <translation>Όλα έτοιμα!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Δεν μπορέσαμε να οριστικοποιήσουμε τη διαμόρφωση των kDrive σας.
+
+Θα επιστρέψετε στην επιλογή kDrive.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -2044,6 +2044,15 @@ safely on your computer.</translation>
             <source>All set!</source> 
             <translation>All set!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -2044,6 +2044,15 @@ de forma segura en su ordenador.</translation>
             <source>All set!</source> 
             <translation>¡Todo listo!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>No hemos podido finalizar la configuración de sus kDrives.
+
+Volverá a la selección de kDrive.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -2044,6 +2044,15 @@ turvallisesti tietokoneellesi.</translation>
             <source>All set!</source> 
             <translation>Kaikki valmista!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>kDrivejesi määritystä ei voitu viimeistellä.
+
+Sinut ohjataan takaisin kDrive-valintaan.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -2044,6 +2044,15 @@ en toute sécurité sur votre ordinateur.</translation>
             <source>All set!</source> 
             <translation>Tout est prêt !</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Nous n’avons pas pu finaliser la configuration de vos kDrive.
+
+Vous allez être redirigé vers la sélection des kDrive.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -2044,6 +2044,15 @@ in modo sicuro sul tuo computer.</translation>
             <source>All set!</source> 
             <translation>Tutto pronto!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Non siamo riusciti a finalizzare la configurazione dei tuoi kDrive.
+
+Verrai riportato alla selezione dei kDrive.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -2044,6 +2044,15 @@ trygt på datamaskinen din.</translation>
             <source>All set!</source> 
             <translation>Alt er klart!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Vi kunne ikke fullføre konfigurasjonen av kDrive-ene dine.
+
+Du sendes tilbake til kDrive-valget.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -2044,6 +2044,15 @@ te worden gesynchroniseerd op uw computer.</translation>
             <source>All set!</source> 
             <translation>Alles klaar!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>We konden de configuratie van uw kDrives niet voltooien.
+
+U keert terug naar de kDrive-selectie.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -2048,6 +2048,15 @@ synchronizacji na Twoim komputerze.</translation>
             <source>All set!</source> 
             <translation>Wszystko gotowe!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Nie udało się sfinalizować konfiguracji Twoich kDrive.
+
+Nastąpi powrót do wyboru kDrive.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -2044,6 +2044,15 @@ em segurança no seu computador.</translation>
             <source>All set!</source> 
             <translation>Está tudo pronto!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Não foi possível finalizar a configuração dos seus kDrives.
+
+Voltará à seleção de kDrive.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -2044,6 +2044,15 @@ säkert på din dator.</translation>
             <source>All set!</source> 
             <translation>Allt är klart!</translation> 
         </message> 
+        <message id="onboardingSynchronizationFailedDescription"> 
+            <source>We could not finalize the configuration of your kDrives.
+
+You will be taken back to the kDrive selection.</source> 
+            <extracomment>Shown for a few seconds when creating the synchronizations failed during onboarding, before the user is taken back to the drive selection (Linux only).</extracomment> 
+            <translation>Vi kunde inte slutföra konfigurationen av dina kDrives.
+
+Du skickas tillbaka till kDrive-valet.</translation> 
+        </message> 
         <message id="onboardingSynchronizationInProgressDescription"> 
             <source>We are finalizing the configuration of your kDrives.
 

--- a/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/windows/onboarding/SynchronizationView.qml
@@ -17,7 +17,6 @@
  */
 
 import QtQuick
-import QtQuick.Controls
 import kDrive.UI
 
 Item {
@@ -56,7 +55,7 @@ Item {
             Text {
                 width: parent.width
                 text: root.onboardingFlowController.synchronizationFailed
-                      ? qsTrId("unexpectedErrorTeachingTipContent")
+                      ? qsTrId("onboardingSynchronizationFailedDescription")
                       : qsTrId("onboardingSynchronizationInProgressDescription")
                 color: IKColors.textSecondary
                 font.pixelSize: IKFonts.bodySize
@@ -64,45 +63,6 @@ Item {
                 lineHeight: IKOnboarding.completionBodyLineHeight
                 wrapMode: Text.WordWrap
             }
-        }
-
-        Button {
-            id: retryButton
-
-            visible: root.onboardingFlowController.synchronizationFailed
-            // Retry only exists once the synchronization failed, so it claims the focus when it appears.
-            onVisibleChanged: {
-                if (visible) {
-                    retryButton.forceActiveFocus()
-                }
-            }
-            height: IKOnboarding.completionButtonHeight
-            text: qsTrId("buttonRetry")
-            onClicked: root.onboardingFlowController.retrySynchronization()
-
-            contentItem: Text {
-                text: retryButton.text
-                color: IKColors.actionOnPrimary
-                font.pixelSize: IKFonts.bodySize
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                elide: Text.ElideRight
-            }
-
-            background: Rectangle {
-                implicitWidth: IKOnboarding.completionButtonMinWidth
-                implicitHeight: IKOnboarding.completionButtonHeight
-                radius: IKOnboarding.buttonCornerRadius
-                color: IKColors.actionPrimary
-                border.width: retryButton.visualFocus ? IKOnboarding.buttonFocusBorderWidth : 0
-                border.color: IKColors.actionOnPrimary
-            }
-
-            padding: 0
-            leftPadding: IKSpacing.s16
-            rightPadding: IKSpacing.s16
-            topPadding: 0
-            bottomPadding: 0
         }
     }
 }


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Un échec de création de synchronisation en fin d'onboarding menait à une impasse : l'écran proposait « Réessayer », qui rejouait exactement la même requête avec la même configuration locale, déjà rejetée par le serveur. Cette PR remplace ce bouton par un retour automatique à la sélection des kDrive, là où l'utilisateur peut réellement corriger la configuration, comme le fait le client Windows.

## Changements
- `OnboardingFlowController` : `retrySynchronization()` devient `returnToDriveSelection()`, désormais privée et déclenchée par un `QTimer::singleShot` de 3 secondes armé dans `failSynchronization()`. Le signal `synchronizationRetryRequested` est remplacé par `driveSelectionReturnRequested`.
- `OnboardingSyncCreationCoordinator` : nouveau `discardPendingSynchronizations()`, connecté à `driveSelectionReturnRequested`, qui vide `_pendingDriveKeys` au retour. La file est reconstruite depuis la sélection par `startSynchronization()` au prochain « Continuer ».
- `AvailableDrivesModel` : ajout des abonnements manquants à `AppCache::drivesChanged` et `AppCache::accountsChanged`. Sans eux, un drive tout juste synchronisé revenait actif et cochable sur la page de sélection.
- `SynchronizationView.qml` : le bouton « Réessayer » et son style disparaissent (33 lignes supprimées, 1 ajoutée). L'écran d'erreur reste affiché, avec un texte adapté au nouveau comportement.
- Nouvelle chaîne `onboardingSynchronizationFailedDescription`, créée dans Loco avec le tag `linux`, traduite dans les 13 langues.

## Détails techniques
- Pourquoi le bouton bouclait : `handleCreationFailure()` conserve délibérément le chemin local du drive en échec pour que la reprise soit fidèle, et `IpcClient` traite toute erreur socket post-connexion comme fatale. Un échec à cet endroit est donc toujours une réponse du serveur, jamais un timeout, et rejouer la requête à l'identique produisait invariablement le même refus.
- Écart assumé avec Windows : `FinishingPage.OnNavigatedTo()` y revient immédiatement à la sélection en superposant un teaching tip. Ici l'erreur reste 3 secondes sur son propre écran, car `ServiceEventBus::notifyGenericError()` émet `genericErrorOccurred()`, un signal qu'aucun composant de l'UI Linux ne consomme aujourd'hui. Un retour immédiat ramènerait l'utilisateur sans aucune explication. La durée est plus courte que les 5 secondes du teaching tip Windows, qui lui n'occupe pas toute la vue.
- Le retour est sûr : les drives déjà créés ont été retirés de la sélection par `unselectAvailableDrive()` au succès de leur `SYNC_ADD`, et ceux qui restent conservent leur `PendingSyncConfig`. La page de sélection affiche donc exactement ce qui reste à faire, sans risque de doublon.
- `returnToDriveSelection()` conserve sa condition d'entrée sur l'étape courante et sur `_synchronizationFailed` : entre l'échec et l'expiration du minuteur, l'utilisateur a pu annuler ou fermer la fenêtre.
- Sur `AvailableDrivesModel`, la propriété `alreadyConfigured` (qui pilote le grisage et l'infobulle « déjà synchronisé ») se calcule dans `AppCache::availableDriveContexts()` à partir des drives configurés du cache. Le modèle ne recevait que `selectedAvailableDrivesChanged`, dont le gestionnaire ne rafraîchit que `SelectedRole`.
- Le nouveau texte est le miroir de `onboardingSynchronizationInProgressDescription`, l'autre état du même `Text`. L'ancien `unexpectedErrorTeachingTipContent` (« Please try again in a few moments ») demandait une action devenue impossible.

</details>

---

## Summary
A failed synchronization creation at the end of onboarding led to a dead end: the screen offered a Retry button that replayed the exact same request, with the same local configuration the server had already rejected. This PR replaces that button with an automatic return to the drive selection, where the user can actually fix the configuration, mirroring what the Windows client does.

## Changes
- `OnboardingFlowController`: `retrySynchronization()` becomes `returnToDriveSelection()`, now private and driven by a 3 second `QTimer::singleShot` armed in `failSynchronization()`. The `synchronizationRetryRequested` signal is replaced by `driveSelectionReturnRequested`.
- `OnboardingSyncCreationCoordinator`: new `discardPendingSynchronizations()`, connected to `driveSelectionReturnRequested`, clearing `_pendingDriveKeys` on return. The queue is rebuilt from the selection by `startSynchronization()` on the next Continue.
- `AvailableDrivesModel`: added the missing subscriptions to `AppCache::drivesChanged` and `AppCache::accountsChanged`. Without them, a drive that had just been synchronized came back enabled and checkable on the selection page.
- `SynchronizationView.qml`: the Retry button and its styling are gone (33 lines removed, 1 added). The error screen stays, with a text matching the new behaviour.
- New `onboardingSynchronizationFailedDescription` string, created in Loco with the `linux` tag and translated into all 13 languages.

## Technical Details
- Why the button looped: `handleCreationFailure()` deliberately keeps the failed drive's local path so the retry is faithful, and `IpcClient` treats every post-connection socket error as fatal. A failure here is therefore always a server response, never a timeout, so replaying the identical request invariably produced the same rejection.
- Deliberate divergence from Windows: `FinishingPage.OnNavigatedTo()` returns to the selection immediately and overlays a teaching tip. Here the error holds its own screen for 3 seconds, because `ServiceEventBus::notifyGenericError()` emits `genericErrorOccurred()`, a signal no Linux UI component consumes today. An immediate return would strand the user with no explanation at all. The delay is shorter than the 5 seconds of the Windows teaching tip, which does not take over the whole view.
- The return is safe: drives already created were removed from the selection by `unselectAvailableDrive()` when their `SYNC_ADD` succeeded, and the remaining ones keep their `PendingSyncConfig`. The selection page therefore shows exactly what is left to do, with no risk of duplicates.
- `returnToDriveSelection()` keeps its guard on the current step and on `_synchronizationFailed`: between the failure and the timer firing, the user may have cancelled or closed the window.
- On `AvailableDrivesModel`, the `alreadyConfigured` property (which drives the disabled state and the "already synced" tooltip) is computed in `AppCache::availableDriveContexts()` from the cache's configured drives. The model only received `selectedAvailableDrivesChanged`, whose handler refreshes `SelectedRole` alone.
- The new text mirrors `onboardingSynchronizationInProgressDescription`, the other state of the same `Text`. The previous `unexpectedErrorTeachingTipContent` ("Please try again in a few moments") asked for an action that is no longer possible.