### PR TITLE
feat(ui): confirm quit before exiting without a system tray

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -329,8 +329,8 @@
 - `ui/`: QML shell, product windows, design tokens, reusable components, and bundled UI assets such as tray icons and
   onboarding Lottie animations.
     - `ui/dialogs/`: app-global dialog composition. `GlobalModalHost` stays alive across waiting, onboarding, and main
-      routes; feature queueing remains in the owning C++ controller until several global modal families require shared
-      arbitration.
+      routes and arbitrates presentation across global modal families; feature queueing remains in the owning C++
+      controller.
     - `ui/windows/main/`: main-window shell, remaining temporary tab placeholders, and feature families grouped under
       `activities/`, `home/`, and `sidebar/`. Home presentation is split between its root composition, `shortcuts/`,
       `states/`, and versioned generated `animations/`. The shell is loaded only when `AppRouter` marks the main window
@@ -352,7 +352,8 @@
     - `ui/components/`: reusable presentation primitives without product-window ownership. Main-window sidebar
       primitives accept display values and emit interactions; they do not read `AppCache`, own selection, or call
       services directly. `IKModal` and `IKModalButton` provide the styled in-app modal surface and semantic action roles;
-      feature dialogs supply their own wording, state, and actions. `IKCheckBox` is the shared tri-state indicator: it
+      feature dialogs supply their own wording, state, and actions. Use `IKConfirmationDialog` for standard cancel/confirm
+      prompts so consumers only provide copy, busy state, and the confirmed/dismissed workflows. `IKCheckBox` is the shared tri-state indicator: it
       renders the state it is given and only reports clicks, so a model owning the selection stays authoritative.
     - `ui/chrome/`: shared window chrome: frameless shell, header bar, controls, resize handles, and shadow wrapper.
       Top-level app-owned QML windows should use `IKShadowedWindow`; its `headerBackgroundData` and `headerData` slots

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -171,6 +171,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/components/IKBadge.qml
         ui/components/IKAvatar.qml
         ui/components/IKCheckBox.qml
+        ui/components/IKConfirmationDialog.qml
         ui/components/IKDriveIcon.qml
         ui/components/IKLinkButton.qml
         ui/components/IKLoadingSpinner.qml

--- a/src/gui4/linux/app/systraycontroller.cpp
+++ b/src/gui4/linux/app/systraycontroller.cpp
@@ -23,7 +23,6 @@
 
 #include <QAction>
 #include <QApplication>
-#include <QCoreApplication>
 #include <QIcon>
 #include <QLoggingCategory>
 #include <QWindow>
@@ -33,7 +32,9 @@
 
 namespace KDC {
 
+namespace {
 Q_LOGGING_CATEGORY(lcSystemTrayController, "gui.v4.systray", QtInfoMsg)
+} // namespace
 
 namespace {
 constexpr uint8_t trayAvailabilityRetryLimit = 60;
@@ -128,7 +129,7 @@ void SystemTrayController::initialize() {
 
     (void) connect(_openAction, &QAction::triggered, this, &SystemTrayController::openMainWindowRequested);
     (void) connect(_settingsAction, &QAction::triggered, this, &SystemTrayController::showSettingsWindow);
-    (void) connect(_quitAction, &QAction::triggered, this, &SystemTrayController::quitRequested);
+    (void) connect(_quitAction, &QAction::triggered, this, &SystemTrayController::requestApplicationQuit);
     (void) connect(&_trayIcon, &QSystemTrayIcon::activated, this, &SystemTrayController::onTrayActivated);
 
     if (_isTrayAvailable) {
@@ -240,8 +241,12 @@ void SystemTrayController::showMainWindow() const {
         return;
     }
 
-    qCInfo(lcSystemTrayController) << "Showing main window from system tray";
-    _mainWindow->show();
+    qCInfo(lcSystemTrayController) << "Showing main window";
+    if (_mainWindow->windowState() == Qt::WindowMinimized) {
+        _mainWindow->showNormal();
+    } else {
+        _mainWindow->show();
+    }
     _mainWindow->raise();
     _mainWindow->requestActivate();
 }
@@ -250,20 +255,32 @@ void SystemTrayController::showSettingsWindow() {
     qCWarning(lcSystemTrayController) << "Settings window action triggered from system tray, but not implemented yet";
 }
 
-void SystemTrayController::hideMainWindow() const {
+void SystemTrayController::hideMainWindow() {
     if (_mainWindow == nullptr) {
         qCWarning(lcSystemTrayController) << "Cannot hide main window: no window registered";
         return;
     }
 
     if (!_isTrayModeActive) {
-        qCWarning(lcSystemTrayController) << "Cannot hide main window in fallback mode, quitting application instead";
-        QCoreApplication::quit();
+        qCWarning(lcSystemTrayController)
+                << "Cannot hide main window in fallback mode, requesting application quit confirmation instead";
+        emit quitConfirmationRequested();
         return;
     }
 
     qCInfo(lcSystemTrayController) << "Hiding main window instead of quitting";
     _mainWindow->hide();
+}
+
+void SystemTrayController::requestApplicationQuit() {
+    if (_quitRequestIssued) {
+        qCDebug(lcSystemTrayController) << "Ignoring duplicate application quit request";
+        return;
+    }
+
+    _quitRequestIssued = true;
+    qCInfo(lcSystemTrayController) << "Application quit requested";
+    emit quitRequested();
 }
 
 void SystemTrayController::startTrayAvailabilityRetry() {

--- a/src/gui4/linux/app/systraycontroller.h
+++ b/src/gui4/linux/app/systraycontroller.h
@@ -66,9 +66,14 @@ class SystemTrayController final : public QObject {
 
         Q_INVOKABLE void showMainWindow() const;
         Q_INVOKABLE static void showSettingsWindow();
-        Q_INVOKABLE void hideMainWindow() const;
+        Q_INVOKABLE void hideMainWindow();
+
+        /** Requests a complete application shutdown at most once. */
+        Q_INVOKABLE void requestApplicationQuit();
 
     signals:
+        /** Requests confirmation before quitting because the main window cannot be hidden without a system tray. */
+        void quitConfirmationRequested();
         void quitRequested();
         void openMainWindowRequested();
         void trayModeActiveChanged(bool active);
@@ -97,6 +102,7 @@ class SystemTrayController final : public QObject {
         bool _isTrayAvailable = false;
         bool _isTrayModeActive = false;
         bool _isInitialized = false;
+        bool _quitRequestIssued = false;
 };
 
 } // namespace KDC

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -267,7 +267,7 @@ void AppClientLinux::updateLoggerMinLevel() const {
 }
 
 void AppClientLinux::requestQuit() {
-    qCInfo(lcAppClientLinux) << "Quit requested from system tray";
+    qCInfo(lcAppClientLinux) << "Processing application quit request";
     if (!_ipcClient.isConnected()) {
         qCWarning(lcAppClientLinux) << "IPC is not connected, quitting application directly";
         quit();

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -2827,4 +2827,20 @@ For at fremskynde overførslen anbefaler vi at sende kun den seneste kDrive-sess
             <translation>Send kun seneste session</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Synkroniseringen af dine filer afbrydes, indtil du åbner appen igen.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Vil du virkelig afslutte kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -2826,4 +2826,20 @@ Um den Upload zu beschleunigen, empfehlen wir, nur die letzte kDrive-Sitzung zu 
             <translation>Nur letzte Sitzung senden</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Die Synchronisierung deiner Dateien wird bis zum nächsten Öffnen der Anwendung unterbrochen.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Möchtest du kDrive wirklich beenden?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -2827,4 +2827,20 @@ To speed up the upload, we recommend sending only the last kDrive session.</sour
             <translation>Αποστολή μόνο της τελευταίας περιόδου σύνδεσης</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Ο συγχρονισμός των αρχείων σας θα διακοπεί μέχρι να ανοίξετε ξανά την εφαρμογή.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Θέλετε πραγματικά να κλείσετε το kDrive;</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -2827,4 +2827,20 @@ To speed up the upload, we recommend sending only the last kDrive session.</tran
             <translation>Send last session only</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Your files will stop syncing until the next time you open the application.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Do you really want to quit kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -2827,4 +2827,20 @@ Para acelerar el envío, recomendamos enviar solo la última sesión de kDrive.<
             <translation>Enviar solo la última sesión</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>La sincronización de tus archivos se interrumpirá hasta que vuelvas a abrir la aplicación.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>¿Seguro que quieres salir de kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -2827,4 +2827,20 @@ Lähetyksen nopeuttamiseksi suosittelemme lähettämään vain viimeisen kDrive-
             <translation>Lähetä vain viimeisin istunto</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Tiedostojesi synkronointi keskeytyy, kunnes avaat sovelluksen uudelleen.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Haluatko varmasti lopettaa kDriven?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -2827,4 +2827,20 @@ Pour accélérer l’envoi, nous vous recommandons de n’envoyer que la derniè
             <translation>Envoyer uniquement la dernière session</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>La synchronisation de vos fichiers sera interrompue jusqu’à la prochaine ouverture.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Voulez-vous vraiment quitter kDrive ?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -2827,4 +2827,20 @@ Per velocizzare il caricamento, ti consigliamo di inviare solo l’ultima sessio
             <translation>Invia solo l’ultima sessione</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>La sincronizzazione dei tuoi file verrà interrotta fino alla prossima apertura dell’applicazione.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Vuoi davvero uscire da kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -2827,4 +2827,20 @@ For å fremskynde opplastingen anbefaler vi å sende bare den siste kDrive-sesjo
             <translation>Send bare siste sesjon</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Synkroniseringen av filene dine avbrytes frem til neste gang du åpner programmet.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Er du sikker på at du vil avslutte kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -2827,4 +2827,20 @@ Om het uploaden te versnellen, raden we aan alleen de laatste kDrive-sessie te v
             <translation>Alleen de laatste sessie verzenden</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>De synchronisatie van je bestanden wordt onderbroken totdat je de toepassing opnieuw opent.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Weet je zeker dat je kDrive wilt afsluiten?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -2831,4 +2831,20 @@ Aby przyspieszyć przesyłanie, zalecamy wysłanie tylko ostatniej sesji kDrive.
             <translation>Wyślij tylko ostatnią sesję</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Synchronizacja plików zostanie przerwana do czasu ponownego uruchomienia aplikacji.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Czy na pewno chcesz zamknąć kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -2827,4 +2827,20 @@ Para acelerar o envio, recomendamos enviar apenas a última sessão do kDrive.</
             <translation>Enviar apenas a última sessão</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>A sincronização dos seus ficheiros será interrompida até voltar a abrir a aplicação.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Tem a certeza de que pretende sair do kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -2827,4 +2827,20 @@ För att påskynda uppladdningen rekommenderar vi att du bara skickar den senast
             <translation>Skicka bara senaste sessionen</translation> 
         </message> 
     </context> 
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogDescription">
+            <source>Your files will stop syncing until the next time you open the application.</source>
+            <extracomment>Explain that quitting kDrive interrupts file synchronization until the application is opened again.</extracomment>
+            <translation>Synkroniseringen av dina filer avbryts tills du öppnar appen igen.</translation>
+        </message>
+    </context>
+    <context>
+        <name></name>
+        <message id="quitConfirmationDialogTitle">
+            <source>Do you really want to quit kDrive?</source>
+            <extracomment>Ask whether the user wants to quit kDrive completely. Keep the product name spelled kDrive.</extracomment>
+            <translation>Vill du verkligen avsluta kDrive?</translation>
+        </message>
+    </context>
 </TS>

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -108,22 +108,23 @@ IKShadowedWindow {
     }
 
     onClosing: close => {
+        close.accepted = false;
+
         if (mainWindow.manyDeletesPresentationAllowed
                 && mainWindow.manyDeletesController.visible
-                && mainWindow.manyDeletesController.severity === ManyDeletesController.Hard) {
-            close.accepted = false
-            return
+                && mainWindow.manyDeletesController.severity === mainWindow.manyDeletesController.Hard) {
+            mainWindow.systemTrayController.showMainWindow();
+            return;
         }
 
         if (mainWindow.systemTrayController.trayModeActive) {
-            close.accepted = false;
             if (mainWindow.onboardingActive) {
                 mainWindow.onboardingSessionManager.cancelActiveSession();
+            } else {
+                mainWindow.systemTrayController.hideMainWindow();
             }
-            mainWindow.systemTrayController.hideMainWindow();
         } else {
-            close.accepted = true;
-            Qt.quit();
+            globalModalHost.requestQuitConfirmation();
         }
     }
 
@@ -172,8 +173,11 @@ IKShadowedWindow {
     }
 
     GlobalModalHost {
+        id: globalModalHost
+
         anchors.fill: parent
         manyDeletesController: mainWindow.manyDeletesController
+        systemTrayController: mainWindow.systemTrayController
         presentationAllowed: mainWindow.manyDeletesPresentationAllowed
         surfaceInset: mainWindow.effectiveShadowMargin
         surfaceRadius: mainWindow.surfaceRadius

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -110,9 +110,7 @@ IKShadowedWindow {
     onClosing: close => {
         close.accepted = false;
 
-        if (mainWindow.manyDeletesPresentationAllowed
-                && mainWindow.manyDeletesController.visible
-                && mainWindow.manyDeletesController.severity === mainWindow.manyDeletesController.Hard) {
+        if (globalModalHost.hardDeletePending) {
             mainWindow.systemTrayController.showMainWindow();
             return;
         }

--- a/src/gui4/linux/ui/components/IKConfirmationDialog.qml
+++ b/src/gui4/linux/ui/components/IKConfirmationDialog.qml
@@ -1,0 +1,86 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import kDrive.UI
+
+IKModal {
+    id: root
+
+    required property string cancelText
+    required property string confirmText
+    required property string description
+    property bool busy: false
+    property int confirmRole: IKModalButton.Primary
+    readonly property real requiredActionsWidth: cancelButton.implicitWidth + confirmButton.implicitWidth
+                                                 + IKModalTokens.actionSpacing
+
+    signal confirmed
+    signal dismissed
+
+    function dismiss() {
+        if (root.busy) {
+            return;
+        }
+
+        root.close();
+        root.dismissed();
+    }
+
+    actionsStacked: requiredActionsWidth > availableWidth
+    escapeDismissible: !busy
+    initialFocusItem: cancelButton
+
+    bodyData: Text {
+        color: IKColors.textSecondary
+        font.pixelSize: IKFonts.bodySize
+        lineHeight: IKFonts.title2Size
+        lineHeightMode: Text.FixedHeight
+        text: root.description
+        width: parent.width
+        wrapMode: Text.WordWrap
+    }
+    footerData: [
+        IKModalButton {
+            id: cancelButton
+
+            Layout.fillWidth: root.actionsStacked
+            actionEnabled: !root.busy
+            role: IKModalButton.Secondary
+            text: root.cancelText
+
+            onClicked: root.dismiss()
+        },
+        IKModalButton {
+            id: confirmButton
+
+            Layout.fillWidth: root.actionsStacked
+            actionEnabled: !root.busy
+            busy: root.busy
+            role: root.confirmRole
+            text: root.confirmText
+
+            onClicked: root.confirmed()
+        }
+    ]
+
+    onDismissRequested: dismiss()
+}

--- a/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
+++ b/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
@@ -20,8 +20,8 @@ import QtQuick
 import QtQuick.Controls
 import kDrive.UI
 
-// Always-alive composition point for app-global dialogs. Feature-specific queueing remains in each controller; a
-// cross-feature arbiter can be introduced here later if simultaneous global modal families become a real requirement.
+// Always-alive composition point for app-global dialogs. Feature-specific queueing remains in each controller; this
+// host only arbitrates across global modal families: a hard mass deletion warning outranks the quit confirmation.
 Item {
     id: root
 
@@ -32,22 +32,27 @@ Item {
     required property var systemTrayController
     required property var targetWindow
     required property rect windowMoveArea
+    // Read from the controller so the priority does not depend on which dialog happens to be visible.
+    readonly property bool hardDeletePending: root.presentationAllowed && root.manyDeletesController.visible
+                                              && root.manyDeletesController.severity === ManyDeletesController.Hard
     readonly property bool modalVisible: manyDeletesDialog.visible || quitConfirmationDialog.visible
     property bool quitPending: false
 
     function requestQuitConfirmation() {
         root.systemTrayController.showMainWindow();
 
-        if (quitConfirmationDialog.visible || root.quitPending) {
-            return;
-        }
-
-        if (manyDeletesDialog.visible
-                && root.manyDeletesController.severity === root.manyDeletesController.Hard) {
+        if (quitConfirmationDialog.visible || root.quitPending || root.hardDeletePending) {
             return;
         }
 
         quitConfirmationDialog.open();
+    }
+
+    // A hard warning raised after the quit prompt opened cancels it: the warning must be resolved first.
+    onHardDeletePendingChanged: {
+        if (root.hardDeletePending && !root.quitPending) {
+            quitConfirmationDialog.close();
+        }
     }
 
     ManyDeletesDialog {

--- a/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
+++ b/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
@@ -29,23 +29,66 @@ Item {
     required property bool presentationAllowed
     required property real surfaceInset
     required property real surfaceRadius
+    required property var systemTrayController
     required property var targetWindow
     required property rect windowMoveArea
+    readonly property bool modalVisible: manyDeletesDialog.visible || quitConfirmationDialog.visible
+    property bool quitPending: false
+
+    function requestQuitConfirmation() {
+        root.systemTrayController.showMainWindow();
+
+        if (quitConfirmationDialog.visible || root.quitPending) {
+            return;
+        }
+
+        if (manyDeletesDialog.visible
+                && root.manyDeletesController.severity === root.manyDeletesController.Hard) {
+            return;
+        }
+
+        quitConfirmationDialog.open();
+    }
 
     ManyDeletesDialog {
         id: manyDeletesDialog
 
         controller: root.manyDeletesController
-        presentationAllowed: root.presentationAllowed
+        presentationAllowed: root.presentationAllowed && !quitConfirmationDialog.visible
         scrimInset: root.surfaceInset
         scrimRadius: root.surfaceRadius
+    }
+
+    IKConfirmationDialog {
+        id: quitConfirmationDialog
+
+        busy: root.quitPending
+        cancelText: qsTrId("buttonCancel")
+        confirmText: qsTrId("statusBarQuitApp")
+        description: qsTrId("quitConfirmationDialogDescription")
+        scrimInset: root.surfaceInset
+        scrimRadius: root.surfaceRadius
+        title: qsTrId("quitConfirmationDialogTitle")
+
+        onConfirmed: {
+            root.quitPending = true;
+            root.systemTrayController.requestApplicationQuit();
+        }
+    }
+
+    Connections {
+        target: root.systemTrayController
+
+        function onQuitConfirmationRequested() {
+            root.requestQuitConfirmation();
+        }
     }
 
     Item {
         parent: Overlay.overlay
         anchors.fill: parent
-        z: manyDeletesDialog.z + 1
-        visible: manyDeletesDialog.visible
+        z: Math.max(manyDeletesDialog.z, quitConfirmationDialog.z) + 1
+        visible: root.modalVisible
 
         Item {
             id: modalWindowMoveArea

--- a/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
+++ b/src/gui4/linux/ui/dialogs/GlobalModalHost.qml
@@ -21,7 +21,11 @@ import QtQuick.Controls
 import kDrive.UI
 
 // Always-alive composition point for app-global dialogs. Feature-specific queueing remains in each controller; this
-// host only arbitrates across global modal families: a hard mass deletion warning outranks the quit confirmation.
+// host only arbitrates across global modal families.
+//
+// Priority rule: a hard mass deletion warning outranks the quit confirmation. A hard warning holds a decision the
+// server is waiting for (restore the files or delete them online), so the user must answer it before we offer to
+// leave the app. A soft warning is only informative, so the quit prompt may cover it.
 Item {
     id: root
 
@@ -32,15 +36,19 @@ Item {
     required property var systemTrayController
     required property var targetWindow
     required property rect windowMoveArea
-    // Read from the controller so the priority does not depend on which dialog happens to be visible.
+    // A hard warning is awaiting an answer. Read from the controller, not from the dialog visibility, so the rule
+    // still holds while the dialog is closed or not shown yet.
     readonly property bool hardDeletePending: root.presentationAllowed && root.manyDeletesController.visible
                                               && root.manyDeletesController.severity === ManyDeletesController.Hard
     readonly property bool modalVisible: manyDeletesDialog.visible || quitConfirmationDialog.visible
+    // The user confirmed the quit: the shutdown is running, so arbitration stops and the dialog only shows its busy
+    // state.
     property bool quitPending: false
 
     function requestQuitConfirmation() {
         root.systemTrayController.showMainWindow();
 
+        // Skip when the prompt is already up, the quit is already running, or a hard warning takes precedence.
         if (quitConfirmationDialog.visible || root.quitPending || root.hardDeletePending) {
             return;
         }
@@ -48,7 +56,8 @@ Item {
         quitConfirmationDialog.open();
     }
 
-    // A hard warning raised after the quit prompt opened cancels it: the warning must be resolved first.
+    // A hard warning raised after the quit prompt opened cancels it: the warning must be answered first. Once the
+    // quit is confirmed we let it run instead, the app is already shutting down.
     onHardDeletePendingChanged: {
         if (root.hardDeletePending && !root.quitPending) {
             quitConfirmationDialog.close();


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Ajoute une boîte de dialogue de confirmation avant de quitter kDrive sur Linux lorsque la fenêtre principale ne peut pas simplement être masquée dans la barre d'état système (tray absente ou inactive), afin d'éviter une fermeture instantanée et accidentelle de l'application.

## Changements
- Ajout du composant réutilisable `IKConfirmationDialog` (basé sur `IKModal`) pour les invites standard annuler/confirmer, avec état "busy" et disposition adaptative des boutons d'action selon l'espace disponible.
- `GlobalModalHost` orchestre désormais la boîte de dialogue de confirmation de quit en plus de celle des suppressions massives : arbitrage de priorité entre les deux, calcul partagé du z-order de l'overlay, et écoute du signal `quitConfirmationRequested` du `SystemTrayController`.
- `SystemTrayController` : en mode de repli sans tray active, `hideMainWindow()` émet désormais `quitConfirmationRequested` au lieu d'appeler directement `QCoreApplication::quit()` ; ajout de `requestApplicationQuit()`, qui protège contre les demandes de quit dupliquées via `_quitRequestIssued` ; `showMainWindow()` restaure désormais la fenêtre si elle est minimisée avant de l'activer.
- `Main.qml` : le gestionnaire `onClosing` refuse systématiquement la fermeture native de la fenêtre, puis route vers `hideMainWindow()`, l'annulation de la session d'onboarding en cours, ou `globalModalHost.requestQuitConfirmation()` selon le contexte ; correction de la référence à l'énumération `Hard` de `ManyDeletesController` (accès via l'instance plutôt que via le type).
- Ajout des chaînes de traduction `quitConfirmationDialogTitle` et `quitConfirmationDialogDescription` dans toutes les locales.
- Mise à jour de `AGENTS.md` pour documenter le nouveau rôle d'arbitrage de `GlobalModalHost` entre les familles de modales globales, et l'usage attendu du composant `IKConfirmationDialog`.

## Notes
Comportement volontairement asymétrique : quitter depuis le menu du tray reste immédiat, alors que fermer la fenêtre sans tray disponible demande désormais une confirmation.

### Priorité vis-à-vis des avertissements de suppression massive
Un avertissement de suppression massive **hard** bloque une décision que le serveur attend (restaurer les fichiers ou les supprimer en ligne). Tant que l'utilisateur n'y a pas répondu, on ne lui propose pas de quitter : la demande de confirmation de quit est ignorée, et si l'avertissement survient alors que l'invite de quit est déjà ouverte, celle-ci est fermée. Un avertissement **soft** est purement informatif, l'invite de quit peut donc passer par-dessus.

Concrètement :
- `hardDeletePending` : un avertissement hard attend une réponse. Il est calculé depuis le contrôleur et non depuis la visibilité de la boîte de dialogue, pour que la règle tienne même quand celle-ci est fermée ou pas encore affichée (elle est masquée pendant l'onboarding, et la visibilité n'arrive qu'ensuite).
- `quitPending` : l'utilisateur a confirmé le quit, l'arrêt est en cours. L'arbitrage s'arrête là, la boîte de dialogue affiche seulement son état busy et n'est plus refermée par un avertissement tardif.

</details>

---

## Summary
Adds a confirmation dialog before quitting kDrive on Linux whenever the main window cannot simply be hidden to the system tray (tray unavailable or inactive), preventing an accidental instant application exit.

## Changes
- Added the reusable `IKConfirmationDialog` component (built on `IKModal`) for standard cancel/confirm prompts, with a busy state and adaptive action-button layout based on available width.
- `GlobalModalHost` now orchestrates the quit confirmation dialog alongside the many-deletes dialog: priority arbitration between the two, shared overlay z-order handling, and listening to `SystemTrayController`'s `quitConfirmationRequested` signal.
- `SystemTrayController`: in the tray-unavailable fallback path, `hideMainWindow()` now emits `quitConfirmationRequested` instead of calling `QCoreApplication::quit()` directly; added `requestApplicationQuit()`, which guards against duplicate quit requests via `_quitRequestIssued`; `showMainWindow()` now restores the window from a minimized state before activating it.
- `Main.qml`: the `onClosing` handler now always rejects the native window close, then routes to `hideMainWindow()`, cancelling the active onboarding session, or `globalModalHost.requestQuitConfirmation()` depending on context; fixed a reference to `ManyDeletesController`'s `Hard` enum value (accessed via the instance instead of the type).
- Added the `quitConfirmationDialogTitle` and `quitConfirmationDialogDescription` translation strings across all locales.
- Updated `AGENTS.md` to document `GlobalModalHost`'s expanded arbitration role across global modal families and the intended usage of `IKConfirmationDialog`.

## Notes
The asymmetry is intentional: quitting from the tray menu remains immediate, while closing the window without a tray available now requires confirmation.

### Priority against mass deletion warnings
A **hard** mass deletion warning holds a decision the server is waiting for (restore the files or delete them online). Until the user has answered it, we do not offer to quit: the quit confirmation request is ignored, and if the warning is raised while the quit prompt is already open, that prompt is closed. A **soft** warning is purely informative, so the quit prompt may cover it.

Concretely:
- `hardDeletePending`: a hard warning is awaiting an answer. It is derived from the controller rather than from dialog visibility, so the rule holds even when the dialog is closed or not shown yet (it is hidden during onboarding, and visibility only follows afterwards).
- `quitPending`: the user confirmed the quit and the shutdown is running. Arbitration stops there, the dialog only shows its busy state and is no longer closed by a late warning.

## Screenshots

|Light|Dark|
|---|---|
|<img width="1600" height="1040" alt="quit-confirmation-dialog-light" src="https://github.com/user-attachments/assets/04c8205f-3ace-4de7-b8ae-ac4edc94a495" />|<img width="1600" height="1040" alt="quit-confirmation-dialog-dark" src="https://github.com/user-attachments/assets/ba7627db-d4a8-4f4a-a0e9-89cf5310b65a" />|
