### PR TITLE
feat(abstract-network-job): Passes the application UUID through the custom context header named ik-client-app-id

### DIFF
--- a/src/libparms/db/parmsdb.h
+++ b/src/libparms/db/parmsdb.h
@@ -153,6 +153,10 @@ class PARMS_EXPORT ParmsDb : public Db {
         bool insertMigrationSelectiveSync(const MigrationSelectiveSync &migrationSelectiveSync);
         bool selectAllMigrationSelectiveSync(std::vector<MigrationSelectiveSync> &migrationSelectiveSyncList);
 
+        /// @brief Returns the application UID stored in the app_state table. Returns an empty string if it cannot be
+        /// retrieved (DB not initialized, DB error, or key not found).
+        static std::string appUID();
+
         bool selectAppState(AppStateKey key, AppStateValue &value, bool &found);
         bool updateAppState(AppStateKey key, const AppStateValue &value, bool &found); // update or insert
 

--- a/src/libparms/db/parmsdbappstate.cpp
+++ b/src/libparms/db/parmsdbappstate.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "parmsdb.h"
+#include "libcommonserver/log/log.h"
 #include "libcommonserver/utility/utility.h"
 #include "libcommon/utility/logiffail.h"
 #include "libcommon/utility/types.h"
@@ -116,7 +117,7 @@ bool ParmsDb::insertDefaultAppState() {
 
     // This AppState was added in version <= 4.x. If an update needs to insert it, the application necessarily comes from a
     // version <= 4.0.0, so the OnboardingV4 banner should be shown. Otherwise, if it is not inserted during an update, there is
-    // no need to display the banner. 
+    // no need to display the banner.
     if (!insertAppState(AppStateKey::ShowV4Onboarding, _versionUpdated ? "1" : "0")) {
         LOG_WARN(_logger, "Error while inserting default value for ShowV4Onboarding");
         return false;
@@ -228,4 +229,23 @@ bool ParmsDb::updateAppState(AppStateKey key, const AppStateValue &value, bool &
     }
     return true;
 };
+
+std::string ParmsDb::appUID() {
+    const auto instance = ParmsDb::instance();
+    if (!instance) {
+        LOG_WARN(Log::instance()->getLogger(), "ParmsDb is not initialized, cannot retrieve " << AppStateKey::AppUid);
+        return {};
+    }
+
+    AppStateValue appStateValue = "";
+    if (bool found = false; !instance->selectAppState(AppStateKey::AppUid, appStateValue, found)) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState");
+        return {};
+    } else if (!found) {
+        LOG_WARN(Log::instance()->getLogger(), AppStateKey::AppUid << " key not found in appstate table");
+        return {};
+    }
+
+    return std::get<std::string>(appStateValue);
+}
 } // namespace KDC

--- a/src/libparms/db/parmsdbappstate.cpp
+++ b/src/libparms/db/parmsdbappstate.cpp
@@ -106,7 +106,7 @@ bool ParmsDb::insertDefaultAppState() {
     }
 
     if (!insertAppState(AppStateKey::AppUid, CommonUtility::generateRandomStringAlphaNum(25), true)) {
-        LOG_WARN(_logger, "Error while inserting default value for LogUploadToken");
+        LOG_WARN(_logger, "Error while inserting default value for AppUid");
         return false;
     }
 
@@ -231,19 +231,23 @@ bool ParmsDb::updateAppState(AppStateKey key, const AppStateValue &value, bool &
 };
 
 std::string ParmsDb::appUID() {
-    assert(Log::isSet() && "Log is not initialized, cannot retrieve AppUid.");
-
     if (!_instance) {
-        LOG_WARN(Log::instance()->getLogger(), "ParmsDb is not initialized, cannot retrieve " << AppStateKey::AppUid);
+        if (Log::isSet()) {
+            LOG_WARN(Log::instance()->getLogger(),
+                     "ParmsDb is not initialized, cannot retrieve AppUid (key " << AppStateKey::AppUid << ").");
+        }
+
         return {};
     }
 
     AppStateValue appStateValue = "";
     if (bool found = false; !_instance->selectAppState(AppStateKey::AppUid, appStateValue, found)) {
-        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState");
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState.");
+
         return {};
     } else if (!found) {
-        LOG_WARN(Log::instance()->getLogger(), AppStateKey::AppUid << " key not found in appstate table");
+        LOG_WARN(Log::instance()->getLogger(), "AppUid (key " << AppStateKey::AppUid << ") not found in appstate table.");
+
         return {};
     }
 

--- a/src/libparms/db/parmsdbappstate.cpp
+++ b/src/libparms/db/parmsdbappstate.cpp
@@ -240,13 +240,14 @@ std::string ParmsDb::appUID() {
         return {};
     }
 
+    auto logger = Log::isSet() ? Log::instance()->getLogger() : _instance->_logger;
     AppStateValue appStateValue = "";
     if (bool found = false; !_instance->selectAppState(AppStateKey::AppUid, appStateValue, found)) {
-        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState.");
+        LOG_WARN(logger, "Error in ParmsDb::selectAppState.");
 
         return {};
     } else if (!found) {
-        LOG_WARN(Log::instance()->getLogger(), "AppUid (key " << AppStateKey::AppUid << ") not found in appstate table.");
+        LOG_WARN(logger, "AppUid (key " << AppStateKey::AppUid << ") not found in appstate table.");
 
         return {};
     }

--- a/src/libparms/db/parmsdbappstate.cpp
+++ b/src/libparms/db/parmsdbappstate.cpp
@@ -231,6 +231,8 @@ bool ParmsDb::updateAppState(AppStateKey key, const AppStateValue &value, bool &
 };
 
 std::string ParmsDb::appUID() {
+    assert(Log::isSet() && "Log is not initialized, cannot retrieve AppUid.");
+
     if (!_instance) {
         LOG_WARN(Log::instance()->getLogger(), "ParmsDb is not initialized, cannot retrieve " << AppStateKey::AppUid);
         return {};

--- a/src/libparms/db/parmsdbappstate.cpp
+++ b/src/libparms/db/parmsdbappstate.cpp
@@ -231,14 +231,13 @@ bool ParmsDb::updateAppState(AppStateKey key, const AppStateValue &value, bool &
 };
 
 std::string ParmsDb::appUID() {
-    const auto instance = ParmsDb::instance();
-    if (!instance) {
+    if (!_instance) {
         LOG_WARN(Log::instance()->getLogger(), "ParmsDb is not initialized, cannot retrieve " << AppStateKey::AppUid);
         return {};
     }
 
     AppStateValue appStateValue = "";
-    if (bool found = false; !instance->selectAppState(AppStateKey::AppUid, appStateValue, found)) {
+    if (bool found = false; !_instance->selectAppState(AppStateKey::AppUid, appStateValue, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState");
         return {};
     } else if (!found) {

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -24,6 +24,7 @@
 #include "libcommonserver/utility/utility.h"
 #include "libcommonserver/utility/jsonparserutility.h"
 #include "libcommonserver/utility/truststorehelper.h"
+#include "libparms/db/parmsdb.h"
 #include "utility/timerutility.h"
 
 #include <log4cplus/loggingmacros.h>
@@ -467,6 +468,7 @@ void AbstractNetworkJob::setHeaders(Poco::Net::HTTPRequest &req) {
     }
     if (scope() != Scope::None) req.add("ik-client-scope", toString(scope()));
     if (!context().empty()) req.add("ik-client-context", context());
+    if (const std::string appUID = ParmsDb::appUID(); !appUID.empty()) req.add("ik-client-app-id", appUID);
 }
 
 ExitInfo AbstractNetworkJob::receiveResponseFromSession(StreamVector &stream) {

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -58,6 +58,7 @@ class AbstractNetworkJob : public SyncJob {
     protected:
         ExitInfo runJob() noexcept override;
         void addRawHeader(const std::string &key, const std::string &value);
+        void setHeaders(Poco::Net::HTTPRequest &req);
 
         using StreamVector = std::vector<std::reference_wrapper<std::istream>>;
         virtual ExitInfo receiveResponseFromSession(StreamVector &stream);
@@ -123,7 +124,6 @@ class AbstractNetworkJob : public SyncJob {
         void clearSession();
         void abortSession();
         ExitInfo sendRequest(const Poco::URI &uri);
-        void setHeaders(Poco::Net::HTTPRequest &req);
         ExitInfo followRedirect();
         ExitInfo processSocketError(const std::string &msg, UniqueId jobId);
         ExitInfo processSocketError(const std::string &msg, UniqueId jobId, const std::exception &e);

--- a/test/libparms/db/testparmsdb.cpp
+++ b/test/libparms/db/testparmsdb.cpp
@@ -637,6 +637,20 @@ void TestParmsDb::testAppStateShowV4Onboarding() {
     CPPUNIT_ASSERT_EQUAL(std::string("0"), std::get<std::string>(preservedValue));
 }
 
+void TestParmsDb::testAppUID() {
+    // The application UID is generated when the DB is initialized and must be retrievable via the helper.
+    bool found = false;
+    AppStateValue value;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectAppState(AppStateKey::AppUid, value, found) && found);
+    const auto &expectedAppUID = std::get<std::string>(value);
+    CPPUNIT_ASSERT(!expectedAppUID.empty());
+    CPPUNIT_ASSERT_EQUAL(expectedAppUID, ParmsDb::appUID());
+
+    // A missing key must yield an empty UID.
+    CPPUNIT_ASSERT(deleteAppState(AppStateKey::AppUid));
+    CPPUNIT_ASSERT(ParmsDb::appUID().empty());
+}
+
 #if defined(KD_MACOS)
 void TestParmsDb::testExclusionApp() {
     ExclusionApp exclusionApp1("app id 1", "description 1");

--- a/test/libparms/db/testparmsdb.cpp
+++ b/test/libparms/db/testparmsdb.cpp
@@ -649,6 +649,10 @@ void TestParmsDb::testAppUID() {
     // A missing key must yield an empty UID.
     CPPUNIT_ASSERT(deleteAppState(AppStateKey::AppUid));
     CPPUNIT_ASSERT(ParmsDb::appUID().empty());
+
+    // An uninitialized database must also yield an empty UID.
+    ParmsDb::reset();
+    CPPUNIT_ASSERT(ParmsDb::appUID().empty());
 }
 
 #if defined(KD_MACOS)

--- a/test/libparms/db/testparmsdb.h
+++ b/test/libparms/db/testparmsdb.h
@@ -44,6 +44,7 @@ class TestParmsDb : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testError);
         CPPUNIT_TEST(testAppState);
         CPPUNIT_TEST(testAppStateShowV4Onboarding);
+        CPPUNIT_TEST(testAppUID);
 #if defined(KD_WINDOWS)
         CPPUNIT_TEST(testUpgradeOfShortPathNames);
 #endif
@@ -62,6 +63,7 @@ class TestParmsDb : public CppUnit::TestFixture, public TestBase {
         void testExclusionTemplate();
         void testAppState();
         void testAppStateShowV4Onboarding();
+        void testAppUID();
         void testUpdateExclusionTemplates();
         void testUpgradeOfExclusionTemplates();
         void testUpgrade();

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -39,6 +39,7 @@ set(testsyncengine_SRCS
         ## Network jobs
         jobs/network/testsnapshotitemhandler.h jobs/network/testsnapshotitemhandler.cpp
         jobs/network/testnetworkjobs.h jobs/network/testnetworkjobs.cpp
+        jobs/network/testabstractnetworkjob.h jobs/network/testabstractnetworkjob.cpp
         jobs/network/kDrive_API/testapitranslator.h jobs/network/kDrive_API/testapitranslator.cpp
         jobs/network/kDrive_API/testloguploadjob.h jobs/network/kDrive_API/testloguploadjob.cpp
         jobs/network/kDrive_API/testsearchjob.h jobs/network/kDrive_API/testsearchjob.cpp

--- a/test/libsyncengine/jobs/network/testabstractnetworkjob.cpp
+++ b/test/libsyncengine/jobs/network/testabstractnetworkjob.cpp
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testabstractnetworkjob.h"
+
+#include "jobs/network/abstractnetworkjob.h"
+#include "libparms/db/parmsdb.h"
+#include "mocks/libcommonserver/db/mockdb.h"
+#include "version.h"
+
+#include <Poco/Net/HTTPRequest.h>
+
+namespace KDC {
+
+namespace {
+
+class TestJob final : public AbstractNetworkJob {
+    public:
+        using AbstractNetworkJob::setHeaders; // Expose the protected method to the test
+
+    protected:
+        ExitInfo handleResponse(std::istream &) override { return ExitCode::Ok; }
+        ExitInfo handleError(const std::string &, const Poco::URI &) override { return ExitCode::Ok; }
+        std::string getSpecificUrl() override { return "/"; }
+        std::string getUrl() override { return "/"; }
+};
+
+} // namespace
+
+void TestAbstractNetworkJob::setUp() {
+    TestBase::start();
+    (void) ParmsDb::instance(_localTempDir.path() / MockDb::makeDbMockFileName(), KDRIVE_VERSION_STRING, true, true);
+}
+
+void TestAbstractNetworkJob::tearDown() {
+    ParmsDb::reset();
+    TestBase::stop();
+}
+
+void TestAbstractNetworkJob::testAppUIDIsSentInClientAppIdHeader() {
+    const auto appUID = ParmsDb::appUID();
+    CPPUNIT_ASSERT(!appUID.empty());
+
+    TestJob job;
+    Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_GET, "/");
+    job.setHeaders(req);
+
+    CPPUNIT_ASSERT_EQUAL(appUID, req.get("ik-client-app-id", ""));
+}
+
+void TestAbstractNetworkJob::testExplicitContextIsPassedThroughRequestContext() {
+    const std::string customContext("custom context");
+
+    TestJob job;
+    job.setContext(customContext);
+    Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_GET, "/");
+    job.setHeaders(req);
+
+    CPPUNIT_ASSERT_EQUAL(customContext, req.get("ik-client-context", ""));
+    CPPUNIT_ASSERT_EQUAL(ParmsDb::appUID(), req.get("ik-client-app-id", ""));
+}
+
+} // namespace KDC

--- a/test/libsyncengine/jobs/network/testabstractnetworkjob.h
+++ b/test/libsyncengine/jobs/network/testabstractnetworkjob.h
@@ -1,0 +1,44 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+#include "test_utility/localtemporarydirectory.h"
+
+using namespace CppUnit;
+
+namespace KDC {
+class TestAbstractNetworkJob : public CppUnit::TestFixture, public TestBase {
+    public:
+        CPPUNIT_TEST_SUITE(TestAbstractNetworkJob);
+        CPPUNIT_TEST(testAppUIDIsSentInClientAppIdHeader);
+        CPPUNIT_TEST(testExplicitContextIsPassedThroughRequestContext);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override;
+        void tearDown() override;
+
+    private:
+        void testAppUIDIsSentInClientAppIdHeader();
+        void testExplicitContextIsPassedThroughRequestContext();
+
+        LocalTemporaryDirectory _localTempDir{"testAbstractNetworkJob"};
+};
+} // namespace KDC

--- a/test/libsyncengine/test.cpp
+++ b/test/libsyncengine/test.cpp
@@ -40,6 +40,7 @@
 #include "integration/testintegration.h"
 #include "propagation/executor/testexecutorworker.h"
 #include "jobs/network/testnetworkjobs.h"
+#include "jobs/network/testabstractnetworkjob.h"
 #include "jobs/network/kDrive_API/testapitranslator.h"
 #include "jobs/network/kDrive_API/testloguploadjob.h"
 #include "jobs/network/kDrive_API/testsearchjob.h"
@@ -63,6 +64,7 @@ namespace KDC {
 CPPUNIT_TEST_SUITE_REGISTRATION(TestOperationProcessor);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestExclusionTemplateCache);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestNetworkJobs);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestAbstractNetworkJob);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestApiTranslator);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLogUploadJob);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSearchJob);


### PR DESCRIPTION
These changes implement a custom header filled with the application UUID that is passed to every HTTP request.
The goal is to discriminate different applications used with the same credentials when analyzing the backend logs. 