### PR TITLE
fix(linux): prevent missed file events when watching new directories

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -101,17 +101,17 @@ void FolderWatcher_linux::startWatching() {
 
                         bool isDirectory = false;
                         auto ioError = IoError::Success;
-                        if (const bool isDirSuccess = IoHelper::checkIfIsDirectory(path, isDirectory, ioError); !isDirSuccess) {
+                        const bool isDirSuccess = IoHelper::checkIfIsDirectory(path, isDirectory, ioError);
+                        if (!isDirSuccess) {
                             LOGW_WARN(_logger,
                                       L"Error in IoHelper::checkIfIsDirectory: " << Utility::formatIoError(path, ioError));
-                            continue;
                         }
 
                         if (ioError == IoError::AccessDenied) {
                             LOGW_WARN(_logger, L"The item misses search/exec permission - " << Utility::formatSyncPath(path));
                         }
 
-                        if ((event->mask & (IN_MOVED_TO | IN_CREATE)) && isDirectory) {
+                        if ((event->mask & (IN_MOVED_TO | IN_CREATE)) && isDirSuccess && isDirectory) {
                             // Watch the directory and its descendants before changesDetected scans their contents,
                             // so creations after the scan are queued by inotify instead of being lost.
                             if (auto exitInfo = watchDirectoryTree(path); !exitInfo) {
@@ -148,6 +148,7 @@ bool FolderWatcher_linux::findSubFolders(const SyncPath &dir, std::list<SyncPath
         if (ioError == IoError::NoSuchFileOrDirectory && dir != _folder) {
             // A child may disappear between discovery, watch registration and enumeration.
             LOGW_DEBUG(logger(), L"Folder disappeared before enumeration: " << Utility::formatSyncPath(dir));
+            removeFoldersBelow(dir);
             return true;
         }
         LOGW_WARN(logger(), L"Error in DirectoryIterator for " << Utility::formatIoError(dir, ioError));
@@ -256,7 +257,8 @@ void FolderWatcher_linux::removeFoldersBelow(const SyncPath &dirPath) {
         }
 
         auto wid = it->second;
-        if (const auto wd = inotify_rm_watch(static_cast<int>(_fileDescriptor), wid); wd > -1) {
+        // Linux may already have removed the watch when the directory was deleted.
+        if (const auto wd = inotify_rm_watch(static_cast<int>(_fileDescriptor), wid); wd > -1 || errno == EINVAL) {
             _watchToPath.erase(wid);
             it = _pathToWatch.erase(it);
             LOG_DEBUG(_logger, "Removed watch on " << itPath);

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -49,7 +49,7 @@ void FolderWatcher_linux::startWatching() {
         return;
     }
 
-    if (const auto addFolderRecursiveExitInfo = addFolderRecursive(_folder); !addFolderRecursiveExitInfo) {
+    if (const auto addFolderRecursiveExitInfo = watchDirectoryTree(_folder); !addFolderRecursiveExitInfo) {
         setExitInfo(addFolderRecursiveExitInfo);
         return;
     }
@@ -114,7 +114,7 @@ void FolderWatcher_linux::startWatching() {
                         if ((event->mask & (IN_MOVED_TO | IN_CREATE)) && isDirectory) {
                             // Watch the directory and its descendants before changesDetected scans their contents,
                             // so creations after the scan are queued by inotify instead of being lost.
-                            if (auto exitInfo = addFolderRecursive(path); !exitInfo) {
+                            if (auto exitInfo = watchDirectoryTree(path); !exitInfo) {
                                 setExitInfo(exitInfo);
                                 return;
                             };
@@ -218,7 +218,7 @@ ExitInfo FolderWatcher_linux::inotifyRegisterPath(const SyncPath &path) {
     return ExitCode::Ok;
 }
 
-ExitInfo FolderWatcher_linux::addFolderRecursive(const SyncPath &path) {
+ExitInfo FolderWatcher_linux::watchDirectoryTree(const SyncPath &path) {
     std::list pendingFolders{path};
     while (!pendingFolders.empty() && !_stop) {
         const auto currentPath = std::move(pendingFolders.front());

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -99,12 +99,6 @@ void FolderWatcher_linux::startWatching() {
                                        L"Operation " << opType << L" detected on item with " << Utility::formatSyncPath(path));
                         }
 
-                        if (const auto exitInfo = changeDetected(path, opType); !exitInfo) {
-                            LOGW_WARN(KDC::Log::instance()->getLogger(), L"Error in FolderWatcher_linux::changeDetected for "
-                                                                                 << Utility::formatSyncPath(path) << L" "
-                                                                                 << exitInfo);
-                        }
-
                         bool isDirectory = false;
                         auto ioError = IoError::Success;
                         if (const bool isDirSuccess = IoHelper::checkIfIsDirectory(path, isDirectory, ioError); !isDirSuccess) {
@@ -118,10 +112,18 @@ void FolderWatcher_linux::startWatching() {
                         }
 
                         if ((event->mask & (IN_MOVED_TO | IN_CREATE)) && isDirectory) {
+                            // Watch the directory and its descendants before changesDetected scans their contents,
+                            // so creations after the scan are queued by inotify instead of being lost.
                             if (auto exitInfo = addFolderRecursive(path); !exitInfo) {
                                 setExitInfo(exitInfo);
                                 return;
                             };
+                        }
+
+                        if (const auto exitInfo = changeDetected(path, opType); !exitInfo) {
+                            LOGW_WARN(KDC::Log::instance()->getLogger(), L"Error in FolderWatcher_linux::changeDetected for "
+                                                                                 << Utility::formatSyncPath(path) << L" "
+                                                                                 << exitInfo);
                         }
 
                         if (event->mask & (IN_MOVED_FROM | IN_DELETE)) {
@@ -142,7 +144,12 @@ void FolderWatcher_linux::startWatching() {
 
 bool FolderWatcher_linux::findSubFolders(const SyncPath &dir, std::list<SyncPath> &fullList) {
     IoHelper::DirectoryIterator dirIt;
-    if (IoError ioError = IoError::Success; !IoHelper::getDirectoryIterator(dir, true, ioError, dirIt)) {
+    if (auto ioError = IoError::Success; !IoHelper::getDirectoryIterator(dir, false, ioError, dirIt)) {
+        if (ioError == IoError::NoSuchFileOrDirectory && dir != _folder) {
+            // A child may disappear between discovery, watch registration and enumeration.
+            LOGW_DEBUG(logger(), L"Folder disappeared before enumeration: " << Utility::formatSyncPath(dir));
+            return true;
+        }
         LOGW_WARN(logger(), L"Error in DirectoryIterator for " << Utility::formatIoError(dir, ioError));
         if (ioError == IoError::AccessDenied) {
             setExitInfo({ExitCode::SystemError, ExitCause::FileAccessError});
@@ -212,39 +219,24 @@ ExitInfo FolderWatcher_linux::inotifyRegisterPath(const SyncPath &path) {
 }
 
 ExitInfo FolderWatcher_linux::addFolderRecursive(const SyncPath &path) {
-    if (_pathToWatch.contains(path)) {
-        // This path is already watched
-        return ExitCode::Ok;
-    }
+    std::list pendingFolders{path};
+    while (!pendingFolders.empty() && !_stop) {
+        const auto currentPath = std::move(pendingFolders.front());
+        pendingFolders.pop_front();
 
-    int subdirs = 0;
-    LOGW_DEBUG(_logger, L"(+) Watcher:" << Utility::formatSyncPath(path));
-
-    if (auto exitInfo = inotifyRegisterPath(path); !exitInfo) return exitInfo;
-
-    std::list<SyncPath> allSubFolders;
-    if (!findSubFolders(path, allSubFolders)) {
-        LOG_ERROR(_logger, "Could not traverse all sub folders");
-        return {ExitCode::SystemError, ExitCause::Unknown};
-    }
-
-    for (const auto &subDirPath: allSubFolders) {
-        if (std::error_code ec; std::filesystem::exists(subDirPath, ec) && !_pathToWatch.contains(subDirPath)) {
-            subdirs++;
-
-            if (auto exitInfo = inotifyRegisterPath(subDirPath); !exitInfo) return exitInfo;
-        } else {
-            if (ec) {
-                LOGW_WARN(_logger, L"Failed to check if path exists " << Utility::formatSyncPath(path) << L": "
-                                                                      << CommonUtility::s2ws(ec.message()) << L" (" << ec.value()
-                                                                      << L")");
-            }
-            LOGW_DEBUG(_logger, L"    `-> discarded: " << Utility::formatSyncPath(subDirPath));
+        if (_pathToWatch.contains(currentPath)) {
+            continue;
         }
-    }
 
-    if (subdirs > 0) {
-        LOG_DEBUG(_logger, "    `-> and " << subdirs << " subdirectories");
+        LOGW_DEBUG(_logger, L"(+) Watcher:" << Utility::formatSyncPath(currentPath));
+        if (auto exitInfo = inotifyRegisterPath(currentPath); !exitInfo) return exitInfo;
+
+        // Watch each directory before enumerating its direct children. Queue them instead of
+        // recursing, so the traversal does not grow the call stack with the directory depth.
+        if (!findSubFolders(currentPath, pendingFolders)) {
+            LOG_ERROR(_logger, "Could not traverse all sub folders");
+            return {ExitCode::SystemError, ExitCause::Unknown};
+        }
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.h
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.h
@@ -40,7 +40,7 @@ class FolderWatcher_linux : public FolderWatcher {
 
         bool findSubFolders(const SyncPath &dir, std::list<SyncPath> &fullList);
         ExitInfo inotifyRegisterPath(const SyncPath &path);
-        ExitInfo addFolderRecursive(const SyncPath &path);
+        ExitInfo watchDirectoryTree(const SyncPath &path);
         void removeFoldersBelow(const SyncPath &dirPath);
         struct AddWatchOutcome {
                 std::int64_t returnValue{0};

--- a/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
@@ -62,7 +62,7 @@ void TestFolderWatcherLinux::testAddFolderRecursive() {
     }
 
     FolderWatcherLinuxMock testObj(tempDir.path());
-    CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.addFolderRecursive(tempDir.path()));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.watchDirectoryTree(tempDir.path()));
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(4), testObj._pathToWatch.size());
     for (const auto &path: {tempDir.path(), tempDir.path() / "A", pathAA, pathAA / "new-child"}) {
         CPPUNIT_ASSERT(testObj._pathToWatch.contains(path));
@@ -96,7 +96,7 @@ void TestFolderWatcherLinux::testAddFolderRecursiveDisappearingChild() {
         CPPUNIT_ASSERT(std::filesystem::create_directories(tempDir.path() / "remaining/nested"));
 
         FolderWatcherLinuxMock testObj(tempDir.path(), registrationSucceeded);
-        CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.addFolderRecursive(tempDir.path()));
+        CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.watchDirectoryTree(tempDir.path()));
         CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.exitInfo());
         CPPUNIT_ASSERT(!std::filesystem::exists(tempDir.path() / "disappearing"));
         CPPUNIT_ASSERT(testObj._pathToWatch.contains(tempDir.path() / "remaining/nested"));

--- a/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
@@ -33,6 +33,24 @@ void TestFolderWatcherLinux::testMakeSyncPath() {
 }
 
 void TestFolderWatcherLinux::testAddFolderRecursive() {
+    class FolderWatcherLinuxMock : public FolderWatcher_linux {
+        public:
+            explicit FolderWatcherLinuxMock(const SyncPath &path) :
+                FolderWatcher_linux(nullptr, path) {}
+
+        private:
+            AddWatchOutcome inotifyAddWatch(const SyncPath &path) override {
+                // Simulate a directory created just before its parent becomes watched. A precomputed
+                // recursive list would miss it; enumerating the parent after registration must find it.
+                if (path == _folder / "A/AA") {
+                    CPPUNIT_ASSERT(std::filesystem::create_directory(path / "new-child"));
+                }
+                return {++_nextWatch, 0};
+            }
+
+            std::int64_t _nextWatch = 0;
+    };
+
     // Generate test files
     const auto tempDir = LocalTemporaryDirectory("testAddFolderRecursive");
     const auto pathAA = tempDir.path() / "A/AA";
@@ -43,9 +61,46 @@ void TestFolderWatcherLinux::testAddFolderRecursive() {
         testhelpers::generateOrEditTestFile(filepath);
     }
 
-    FolderWatcher_linux testObj(nullptr, "");
+    FolderWatcherLinuxMock testObj(tempDir.path());
     CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.addFolderRecursive(tempDir.path()));
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(7), testObj._pathToWatch.size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(4), testObj._pathToWatch.size());
+    for (const auto &path: {tempDir.path(), tempDir.path() / "A", pathAA, pathAA / "new-child"}) {
+        CPPUNIT_ASSERT(testObj._pathToWatch.contains(path));
+    }
+}
+
+void TestFolderWatcherLinux::testAddFolderRecursiveDisappearingChild() {
+    class FolderWatcherLinuxMock : public FolderWatcher_linux {
+        public:
+            FolderWatcherLinuxMock(const SyncPath &path, bool registrationSucceeded) :
+                FolderWatcher_linux(nullptr, path),
+                _registrationSucceeded(registrationSucceeded) {}
+
+        private:
+            AddWatchOutcome inotifyAddWatch(const SyncPath &path) override {
+                if (path == _folder / "disappearing") {
+                    CPPUNIT_ASSERT(std::filesystem::remove(path));
+                    if (!_registrationSucceeded) return {-1, ENOENT};
+                }
+                return {++_nextWatch, 0};
+            }
+
+            bool _registrationSucceeded;
+            std::int64_t _nextWatch = 0;
+    };
+
+    // Cover disappearance during registration and immediately after successful registration.
+    for (const bool registrationSucceeded: {false, true}) {
+        const LocalTemporaryDirectory tempDir;
+        CPPUNIT_ASSERT(std::filesystem::create_directory(tempDir.path() / "disappearing"));
+        CPPUNIT_ASSERT(std::filesystem::create_directories(tempDir.path() / "remaining/nested"));
+
+        FolderWatcherLinuxMock testObj(tempDir.path(), registrationSucceeded);
+        CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.addFolderRecursive(tempDir.path()));
+        CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.exitInfo());
+        CPPUNIT_ASSERT(!std::filesystem::exists(tempDir.path() / "disappearing"));
+        CPPUNIT_ASSERT(testObj._pathToWatch.contains(tempDir.path() / "remaining/nested"));
+    }
 }
 
 void TestFolderWatcherLinux::testRemoveFoldersBelow() {
@@ -111,6 +166,7 @@ void TestFolderWatcherLinux::testFindSubFolders() {
     const LocalTemporaryDirectory temporaryDirectory;
     const SyncPath dir1Path = temporaryDirectory.path() / "dir1";
     CPPUNIT_ASSERT(std::filesystem::create_directories(dir1Path));
+    CPPUNIT_ASSERT(std::filesystem::create_directory(dir1Path / "nested"));
 
     // Symlink to directory
     const SyncPath dir1SymlinkPath = temporaryDirectory.path() / "dir1Symlink";

--- a/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
@@ -23,6 +23,7 @@
 #include "update_detection/file_system_observer/folderwatcher_linux.h"
 
 #include <Poco/File.h>
+#include <ranges>
 #include <sys/inotify.h>
 
 namespace KDC {

--- a/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
@@ -76,17 +76,23 @@ void TestFolderWatcherLinux::testAddFolderRecursiveDisappearingChild() {
                 FolderWatcher_linux(nullptr, path),
                 _registrationSucceeded(registrationSucceeded) {}
 
+            ~FolderWatcherLinuxMock() override { stopWatching(); }
+
         private:
             AddWatchOutcome inotifyAddWatch(const SyncPath &path) override {
-                if (path == _folder / "disappearing") {
+                if (path == _folder / "disappearing" && !_childRemoved) {
+                    _childRemoved = true;
+                    const auto outcome =
+                            _registrationSucceeded ? FolderWatcher_linux::inotifyAddWatch(path) : AddWatchOutcome{-1, ENOENT};
+                    if (_registrationSucceeded) CPPUNIT_ASSERT(outcome.returnValue >= 0);
                     CPPUNIT_ASSERT(std::filesystem::remove(path));
-                    if (!_registrationSucceeded) return {-1, ENOENT};
+                    return outcome;
                 }
-                return {++_nextWatch, 0};
+                return FolderWatcher_linux::inotifyAddWatch(path);
             }
 
             bool _registrationSucceeded;
-            std::int64_t _nextWatch = 0;
+            bool _childRemoved = false;
     };
 
     // Cover disappearance during registration and immediately after successful registration.
@@ -96,10 +102,25 @@ void TestFolderWatcherLinux::testAddFolderRecursiveDisappearingChild() {
         CPPUNIT_ASSERT(std::filesystem::create_directories(tempDir.path() / "remaining/nested"));
 
         FolderWatcherLinuxMock testObj(tempDir.path(), registrationSucceeded);
+        testObj._fileDescriptor = inotify_init();
+        CPPUNIT_ASSERT(testObj._fileDescriptor >= 0);
         CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.watchDirectoryTree(tempDir.path()));
         CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.exitInfo());
         CPPUNIT_ASSERT(!std::filesystem::exists(tempDir.path() / "disappearing"));
         CPPUNIT_ASSERT(testObj._pathToWatch.contains(tempDir.path() / "remaining/nested"));
+        const auto childPath = tempDir.path() / "disappearing";
+        CPPUNIT_ASSERT(!testObj._pathToWatch.contains(childPath));
+        for (const auto &watchedPath: testObj._watchToPath | std::views::values) {
+            CPPUNIT_ASSERT(watchedPath != childPath);
+        }
+
+        CPPUNIT_ASSERT(std::filesystem::create_directory(childPath));
+        CPPUNIT_ASSERT_EQUAL(ExitInfo{ExitCode::Ok}, testObj.watchDirectoryTree(childPath));
+        CPPUNIT_ASSERT(testObj._pathToWatch.contains(childPath));
+        const auto watch = testObj._pathToWatch.at(childPath);
+        CPPUNIT_ASSERT(testObj._watchToPath.at(watch) == childPath);
+        // The recreated directory must have a live kernel watch, not only a bookkeeping entry.
+        CPPUNIT_ASSERT_EQUAL(0, inotify_rm_watch(static_cast<int32_t>(testObj._fileDescriptor), watch));
     }
 }
 

--- a/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.h
@@ -26,6 +26,8 @@ namespace KDC {
 class TestFolderWatcherLinux final : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestFolderWatcherLinux);
         CPPUNIT_TEST(testMakeSyncPath);
+        CPPUNIT_TEST(testAddFolderRecursive);
+        CPPUNIT_TEST(testAddFolderRecursiveDisappearingChild);
         CPPUNIT_TEST(testRemoveFoldersBelow);
         CPPUNIT_TEST(testInotifyRegisterPath);
         CPPUNIT_TEST(testFindSubFolders);
@@ -38,6 +40,7 @@ class TestFolderWatcherLinux final : public CppUnit::TestFixture, public TestBas
     private:
         void testMakeSyncPath();
         void testAddFolderRecursive();
+        void testAddFolderRecursiveDisappearingChild();
         void testRemoveFoldersBelow();
         void testInotifyRegisterPath();
         void testFindSubFolders();


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Sur Linux, des fichiers créés dans un nouveau répertoire pouvaient être manqués par l'observateur inotify si leur création survenait entre le scan initial du répertoire et l'enregistrement effectif du watch. Cette PR corrige la fenêtre de course en enregistrant les watches avant de scanner le contenu des répertoires.

## Changements
- Dans `FolderWatcher_linux::startWatching()`, `changeDetected()` est désormais appelé après `addFolderRecursive()` pour un nouveau répertoire, afin que le watch inotify soit posé avant que le contenu ne soit scanné.
- `addFolderRecursive()` traverse maintenant les sous-répertoires de manière itérative (file d'attente) au lieu de précalculer récursivement la liste complète des sous-dossiers : chaque répertoire est d'abord watché, puis ses enfants directs sont listés et ajoutés à la file.
- `findSubFolders()` énumère désormais uniquement les enfants directs (non récursif) et n'est plus considéré en erreur lorsque le répertoire a disparu entre sa découverte et son énumération (sauf pour le répertoire racine).

## Détails techniques
Le traitement en file (BFS) plutôt qu'en récursion évite aussi de faire croître la pile d'appels avec la profondeur de l'arborescence. Un répertoire enfant qui disparaît pendant l'enregistrement du watch ou juste après est désormais ignoré silencieusement plutôt que de faire échouer toute la traversée.

## Tests
- `testAddFolderRecursive` est mis à jour avec un mock d'`inotifyAddWatch` qui crée un nouveau sous-répertoire au moment précis où son parent est watché, vérifiant qu'il est bien détecté par l'énumération faite après l'enregistrement du watch.
- Nouveau test `testAddFolderRecursiveDisappearingChild` couvrant la disparition d'un sous-répertoire pendant l'enregistrement du watch (échec `ENOENT`) et juste après un enregistrement réussi.
- `testFindSubFolders` est complété avec un sous-répertoire imbriqué pour vérifier le comportement non récursif.

</details>

---

## Summary
On Linux, files created inside a newly detected directory could be missed by the inotify observer when their creation happened between the initial directory scan and the actual watch registration. This PR closes that race window by registering watches before scanning directory contents.

## Changes
- In `FolderWatcher_linux::startWatching()`, `changeDetected()` is now called after `addFolderRecursive()` for a new directory, so the inotify watch is in place before its contents are scanned.
- `addFolderRecursive()` now traverses subdirectories iteratively (queue-based) instead of precomputing the full recursive list upfront: each directory is watched first, then its direct children are listed and queued.
- `findSubFolders()` now enumerates only direct children (non-recursive) and no longer treats a directory that disappeared between discovery and enumeration as an error (except for the root folder).

## Technical Details
Queue-based (BFS) traversal instead of recursion also avoids growing the call stack with directory depth. A child directory that disappears during watch registration, or right after, is now silently skipped instead of failing the whole traversal.

## Testing
- `testAddFolderRecursive` is updated with a mock `inotifyAddWatch` that creates a new subdirectory at the exact moment its parent gets watched, verifying it is picked up by the post-registration enumeration.
- New `testAddFolderRecursiveDisappearingChild` test covering a subdirectory disappearing during watch registration (`ENOENT` failure) and right after a successful registration.
- `testFindSubFolders` is extended with a nested subdirectory to verify the non-recursive behavior.
