### PR TITLE
fix: file picker issue on windows 10

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -26,7 +26,7 @@ using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.ComponentModel;
 using System.Threading;
-using Windows.Storage.Pickers;
+using Microsoft.Windows.Storage.Pickers;
 
 namespace Infomaniak.kDrive.Pages.AdvancedSyncSetupContentDialog
 {
@@ -143,12 +143,16 @@ namespace Infomaniak.kDrive.Pages.AdvancedSyncSetupContentDialog
             control.IsEnabled = false;
 
             // Create a folder picker
-            FolderPicker openPicker = new();
             var window = ((App)Application.Current)?.CurrentWindow;
-            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
-            WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hWnd);
+            if (window is null)
+            {
+                Logger.Log(Logger.Level.Error, "No CurrentWindow available to attach the folder picker to");
+                control.IsEnabled = true;
+                return;
+            }
+            FolderPicker openPicker = new(window.AppWindow.Id);
             openPicker.SuggestedStartLocation = PickerLocationId.ComputerFolder;
-            Windows.Storage.StorageFolder folder = await openPicker.PickSingleFolderAsync();
+            PickFolderResult folder = await openPicker.PickSingleFolderAsync();
 
             if (folder is null)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -24,11 +24,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
+using Microsoft.Windows.Storage.Pickers;
 using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using Windows.Storage.Pickers;
 
 namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 {
@@ -136,13 +136,17 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             control.IsEnabled = false;
 
             // Create a folder picker
-            FolderPicker openPicker = new();
             var window = ((App)Application.Current)?.CurrentWindow;
-            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
-            WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hWnd);
-            openPicker.SuggestedStartLocation = PickerLocationId.ComputerFolder;
-            Windows.Storage.StorageFolder folder = await openPicker.PickSingleFolderAsync();
+            if (window is null)
+            {
+                Logger.Log(Logger.Level.Error, "No CurrentWindow available to attach the folder picker to");
+                control.IsEnabled = true;
+                return;
+            }
 
+            FolderPicker openPicker = new(window.AppWindow.Id);
+            openPicker.SuggestedStartLocation = PickerLocationId.ComputerFolder;
+            PickFolderResult folder = await openPicker.PickSingleFolderAsync();
             if (folder is null)
             {
                 Logger.Log(Logger.Level.Info, "No folder was picked");

--- a/version.json
+++ b/version.json
@@ -18,7 +18,7 @@
       "major": 4,
       "minor": 0,
       "patch": 0,
-      "build": 14,
+      "build": 15,
       "year": 2026
     }
   }


### PR DESCRIPTION
This pull request updates the folder picker implementation in both `AdvancedSyncSetupContentDialog` and `DriveSetupContentDialog` to use the new `Microsoft.Windows.Storage.Pickers.FolderPicker` API, improving window association and error handling. It also increments the build number.

**Folder picker API migration and improvements:**

* Replaced `Windows.Storage.Pickers.FolderPicker` with `Microsoft.Windows.Storage.Pickers.FolderPicker` in both `SyncSetupPage.xaml.cs` files to use the newer Windows App SDK API. [[1]](diffhunk://#diff-c35e68ce8b09117bee51eb8b72e7330a0f7039f98f5de92603fd40504a763583L29-R29) [[2]](diffhunk://#diff-fbb6de6077962da851b79f4394bc838ebc2f921aff95bc2922be8f1d0a95bf3cR27-L31)
* Updated folder picker initialization to use the current window’s `AppWindow.Id` for proper window association, and added error handling when the window is not available. [[1]](diffhunk://#diff-c35e68ce8b09117bee51eb8b72e7330a0f7039f98f5de92603fd40504a763583L146-R155) [[2]](diffhunk://#diff-fbb6de6077962da851b79f4394bc838ebc2f921aff95bc2922be8f1d0a95bf3cL139-R149)
* Changed the result type from `StorageFolder` to `PickFolderResult` to match the new API. [[1]](diffhunk://#diff-c35e68ce8b09117bee51eb8b72e7330a0f7039f98f5de92603fd40504a763583L146-R155) [[2]](diffhunk://#diff-fbb6de6077962da851b79f4394bc838ebc2f921aff95bc2922be8f1d0a95bf3cL139-R149)

**Versioning:**

* Incremented the build number from 14 to 15 in `version.json`.